### PR TITLE
Zoom the map in so it's harder to drag a point outside the network dataset

### DIFF
--- a/OfflineRoutingSample/objective-c/Classes/RoutingSampleViewController.m
+++ b/OfflineRoutingSample/objective-c/Classes/RoutingSampleViewController.m
@@ -138,6 +138,8 @@
     if(self.routeTaskParams){
         self.routeTaskParams.outSpatialReference = self.mapView.spatialReference;
     }
+    
+    [self.mapView zoomIn:NO];
 }
 
 

--- a/OfflineRoutingSample/swift/OfflineRouting/ViewController.swift
+++ b/OfflineRoutingSample/swift/OfflineRouting/ViewController.swift
@@ -140,6 +140,8 @@ class ViewController: UIViewController, AGSMapViewLayerDelegate, AGSRouteTaskDel
         if self.routeTaskParams != nil {
             self.routeTaskParams.outSpatialReference = self.mapView.spatialReference;
         }
+        
+        mapView.zoomIn(false);
     }
     
     //MARK: - AGSRouteTaskDelegate


### PR DESCRIPTION
Because that causes an error.

Would ideally not even request a route for a point that cannot be routed to, or handle the error more silently.
