### PR TITLE
Fixing: The app crashes by just clicking the plus sign on

### DIFF
--- a/DownloadTileCacheSample/DownloadTileCacheSample/ViewController.m
+++ b/DownloadTileCacheSample/DownloadTileCacheSample/ViewController.m
@@ -62,7 +62,7 @@
         //Initialize UIStepper based on number of scale levels in the tiled layer
         self.levelStepper.value = 0;
         self.levelStepper.minimumValue = 0;
-        self.levelStepper.maximumValue = self.tiledLayer.tileInfo.lods.count;
+        self.levelStepper.maximumValue = self.tiledLayer.tileInfo.lods.count - 1;
         
         //Register observer for mapScale property so we can reset the stepper and other UI when map is zoomed in/out
         [self.mapView addObserver:self forKeyPath:@"mapScale" options:NSKeyValueObservingOptionNew context:NULL];


### PR DESCRIPTION
The app crashes by just clicking the plus sign on if the initial extent hasn't be changed.
You can reproduce the issue with the following instruction:
 
1.       Run the application.
2.       Don't change the extent
3.       Click scale “+” to 9, click “+” one more time.