### PR TITLE
fixes

### DIFF
--- a/arcgis-ios-sdk-samples/Edit data/Edit Features (connected)/EditFeaturesOnlineViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit Features (connected)/EditFeaturesOnlineViewController.swift
@@ -124,7 +124,7 @@ class EditFeaturesOnlineViewController: UIViewController, AGSMapViewTouchDelegat
         
         
         //zoom to the existing feature's geometry
-        self.mapView.setViewpointGeometry(geometryBuilder.toGeometry(), padding: 10, completion: nil)
+        self.mapView.setViewpointGeometry(geometryBuilder.extent, padding: 10, completion: nil)
         
         //hide the back button
         self.navigationItem.hidesBackButton = true
@@ -171,6 +171,8 @@ class EditFeaturesOnlineViewController: UIViewController, AGSMapViewTouchDelegat
             self.featureLayer.featureTable?.deleteFeature(self.newFeature, completion: { [weak self] (error: NSError?) -> Void in
                 self?.newFeature = nil
             })
+            //dismiss popups view controller
+            self.dismissViewControllerAnimated(true, completion: nil)
         }
     }
     


### PR DESCRIPTION
dismissing popups view controller on cancel while creating new featue; zooming to the extent of the geometry instead of the geometry itself inside `readyToEditGeometryWithBuilder`