### PR TITLE
changed map variables to optional instead of explicitly unwrapped

### DIFF
--- a/arcgis-ios-sdk-samples/Maps/Display drawing status/MapViewDrawStatusViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Display drawing status/MapViewDrawStatusViewController.swift
@@ -20,7 +20,7 @@ class MapViewDrawStatusViewController: UIViewController {
     @IBOutlet private weak var mapView:AGSMapView!
     @IBOutlet private weak var activityIndicatorView:UIView!
     
-    private var map:AGSMap!
+    private var map:AGSMap?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -32,12 +32,12 @@ class MapViewDrawStatusViewController: UIViewController {
         self.map = AGSMap(basemap: AGSBasemap.topographic())
         
         //initial viewpoint
-        self.map.initialViewpoint = AGSViewpoint(targetExtent: AGSEnvelope(xMin: -13639984, yMin: 4537387, xMax: -13606734, yMax: 4558866, spatialReference: AGSSpatialReference.webMercator()))
+        self.map?.initialViewpoint = AGSViewpoint(targetExtent: AGSEnvelope(xMin: -13639984, yMin: 4537387, xMax: -13606734, yMax: 4558866, spatialReference: AGSSpatialReference.webMercator()))
         
         //add a feature layer
         let featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0")!)
         let featureLayer = AGSFeatureLayer(featureTable: featureTable)
-        self.map.operationalLayers.add(featureLayer)
+        self.map?.operationalLayers.add(featureLayer)
         
         //assign the map to mapView
         self.mapView.map = self.map
@@ -63,6 +63,6 @@ class MapViewDrawStatusViewController: UIViewController {
     }
     
     deinit {
-        self.mapView.removeObserver(self, forKeyPath: "drawStatus")
+        self.mapView?.removeObserver(self, forKeyPath: "drawStatus")
     }
 }

--- a/arcgis-ios-sdk-samples/Maps/Map loaded/MapLoadedViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Map loaded/MapLoadedViewController.swift
@@ -44,12 +44,12 @@ class MapLoadedViewController: UIViewController {
         DispatchQueue.main.async { [weak self] in
             
             //get the string for load status
-            if let weakSelf = self, let loadStatus = weakSelf.map?.loadStatus {
+            if let strongSelf = self, let loadStatus = strongSelf.map?.loadStatus {
                 
-                let loadStatusString = weakSelf.loadStatusString(loadStatus)
+                let loadStatusString = strongSelf.loadStatusString(loadStatus)
                 
                 //set it on the banner label
-                weakSelf.bannerLabel.text = "Load status : \(loadStatusString)"
+                strongSelf.bannerLabel.text = "Load status : \(loadStatusString)"
             }
         }
     }

--- a/arcgis-ios-sdk-samples/Maps/Map loaded/MapLoadedViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Map loaded/MapLoadedViewController.swift
@@ -20,7 +20,7 @@ class MapLoadedViewController: UIViewController {
     @IBOutlet var mapView:AGSMapView!
     @IBOutlet var bannerLabel:UILabel!
     
-    private var map:AGSMap!
+    private var map:AGSMap?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -35,7 +35,7 @@ class MapLoadedViewController: UIViewController {
         self.mapView.map = self.map
         
         //register as an observer for loadStatus property on map
-        self.map.addObserver(self, forKeyPath: "loadStatus", options: .new, context: nil)
+        self.map?.addObserver(self, forKeyPath: "loadStatus", options: .new, context: nil)
     }
     
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
@@ -43,9 +43,10 @@ class MapLoadedViewController: UIViewController {
         //update the banner label on main thread
         DispatchQueue.main.async { [weak self] in
             
-            if let weakSelf = self {
-                //get the string for load status
-                let loadStatusString = weakSelf.loadStatusString(weakSelf.map.loadStatus)
+            //get the string for load status
+            if let weakSelf = self, let loadStatus = weakSelf.map?.loadStatus {
+                
+                let loadStatusString = weakSelf.loadStatusString(loadStatus)
                 
                 //set it on the banner label
                 weakSelf.bannerLabel.text = "Load status : \(loadStatusString)"
@@ -74,6 +75,6 @@ class MapLoadedViewController: UIViewController {
     }
 
     deinit {
-        self.map.removeObserver(self, forKeyPath: "loadStatus")
+        self.map?.removeObserver(self, forKeyPath: "loadStatus")
     }
 }


### PR DESCRIPTION
Caused a crash when calling removeObserver on map and opening the Map loaded sample multiple times