### PR TITLE
Constrain top of label to top of Safe Area, not the superView top margin

### DIFF
--- a/arcgis-ios-sdk-samples/Analysis/Viewshed (GeoElement)/ViewshedGeoElement.storyboard
+++ b/arcgis-ios-sdk-samples/Analysis/Viewshed (GeoElement)/ViewshedGeoElement.storyboard
@@ -6,7 +6,6 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -23,7 +22,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tap on the map to move the tank and update the viewshed" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1aQ-aB-Yda">
-                                        <rect key="frame" x="0.0" y="52" width="375" height="20.333333333333329"/>
+                                        <rect key="frame" x="0.0" y="44" width="375" height="20.333333333333329"/>
                                         <color key="backgroundColor" white="0.75" alpha="0.5" colorSpace="custom" customColorSpace="calibratedWhite"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
@@ -34,13 +33,13 @@
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="1aQ-aB-Yda" secondAttribute="trailing" id="LJw-90-On6"/>
                                     <constraint firstItem="1aQ-aB-Yda" firstAttribute="leading" secondItem="Z0U-33-i0S" secondAttribute="leading" id="fxy-lp-pN1"/>
-                                    <constraint firstItem="1aQ-aB-Yda" firstAttribute="top" secondItem="Z0U-33-i0S" secondAttribute="topMargin" id="lQ6-kl-Wcr"/>
                                 </constraints>
                             </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="Z0U-33-i0S" secondAttribute="trailing" id="Ese-qa-9Fx"/>
+                            <constraint firstItem="1aQ-aB-Yda" firstAttribute="top" secondItem="zHk-5t-F8j" secondAttribute="top" id="GZx-th-OYh"/>
                             <constraint firstItem="Z0U-33-i0S" firstAttribute="top" secondItem="OmS-KM-jTp" secondAttribute="top" id="ofT-e7-fu0"/>
                             <constraint firstItem="Z0U-33-i0S" firstAttribute="leading" secondItem="OmS-KM-jTp" secondAttribute="leading" id="sGF-jw-jKg"/>
                             <constraint firstAttribute="bottom" secondItem="Z0U-33-i0S" secondAttribute="bottom" id="smM-X7-5Ow"/>


### PR DESCRIPTION
Move the instruction label to immediately below the navigation bar, as opposed to leaving a small gap. Required removing the original top constraint (top of label to top of superview top margin) and adding one for the top of label to top of safe area.