### PR TITLE
Modify to make use of Safe Area for iOS 11 and iPhone X

### DIFF
--- a/arcgis-ios-sdk-samples/Analysis/Line of sight (location)/LineOfSightLocation.storyboard
+++ b/arcgis-ios-sdk-samples/Analysis/Line of sight (location)/LineOfSightLocation.storyboard
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="beF-yn-MU6">
-    <device id="retina4_7" orientation="portrait">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="beF-yn-MU6">
+    <device id="retina5_9" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -14,32 +14,24 @@
         <scene sceneID="uVV-jY-ewq">
             <objects>
                 <viewController id="beF-yn-MU6" customClass="LineOfSightLocationViewController" customModule="arcgis_ios_sdk_samples" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="yG8-of-mPN"/>
-                        <viewControllerLayoutGuide type="bottom" id="npD-Cb-LzJ"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="7gX-cs-H6x">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YLS-ms-81h" customClass="AGSSceneView">
-                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yMh-oN-h6N">
-                                <rect key="frame" x="0.0" y="20" width="375" height="34"/>
+                            <view contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="34" translatesAutoresizingMaskIntoConstraints="NO" id="yMh-oN-h6N" userLabel="Instructions Container">
+                                <rect key="frame" x="0.0" y="44" width="375" height="34"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="DOk-3h-gKt">
-                                        <rect key="frame" x="8" y="8" width="359" height="18"/>
+                                        <rect key="frame" x="0.0" y="8" width="375" height="18"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tap on the map to add observer location" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qgh-ab-wUm">
-                                                <rect key="frame" x="0.0" y="0.0" width="359" height="18"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="18"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                 <color key="textColor" red="0.0" green="0.36862745099999999" blue="0.58431372550000005" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tap-and-hold to drag the line of sight target" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jHc-7B-FsF">
-                                                <rect key="frame" x="0.0" y="-28" width="359" height="0.0"/>
+                                                <rect key="frame" x="0.0" y="-52" width="375" height="0.0"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                 <color key="textColor" red="0.0" green="0.36862745099999999" blue="0.58431372550000005" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -50,22 +42,27 @@
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="bottom" secondItem="DOk-3h-gKt" secondAttribute="bottom" constant="8" id="48f-E0-Fb3"/>
-                                    <constraint firstItem="DOk-3h-gKt" firstAttribute="leading" secondItem="yMh-oN-h6N" secondAttribute="leading" constant="8" id="Ieq-af-VS5"/>
-                                    <constraint firstAttribute="trailing" secondItem="DOk-3h-gKt" secondAttribute="trailing" constant="8" id="Ky1-DN-nCN"/>
                                     <constraint firstItem="DOk-3h-gKt" firstAttribute="top" secondItem="yMh-oN-h6N" secondAttribute="top" constant="8" id="ZTX-Hc-u47"/>
                                 </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YLS-ms-81h" customClass="AGSSceneView">
+                                <rect key="frame" x="0.0" y="78" width="375" height="734"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </view>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="yMh-oN-h6N" firstAttribute="top" secondItem="7gX-cs-H6x" secondAttribute="topMargin" id="LC4-cQ-EVN"/>
-                            <constraint firstAttribute="trailing" secondItem="yMh-oN-h6N" secondAttribute="trailing" id="htm-V7-nnv"/>
-                            <constraint firstItem="YLS-ms-81h" firstAttribute="top" secondItem="yG8-of-mPN" secondAttribute="bottom" id="jJ3-gO-uPe"/>
-                            <constraint firstAttribute="trailing" secondItem="YLS-ms-81h" secondAttribute="trailing" id="nvA-FI-1be"/>
+                            <constraint firstAttribute="trailing" secondItem="YLS-ms-81h" secondAttribute="trailing" id="4JD-Hc-i8w"/>
+                            <constraint firstItem="YLS-ms-81h" firstAttribute="bottom" secondItem="7gX-cs-H6x" secondAttribute="bottom" id="6p8-oz-atx"/>
+                            <constraint firstItem="YLS-ms-81h" firstAttribute="leading" secondItem="7gX-cs-H6x" secondAttribute="leading" id="72h-w0-ibb"/>
+                            <constraint firstItem="YLS-ms-81h" firstAttribute="top" secondItem="yMh-oN-h6N" secondAttribute="bottom" id="H0c-YF-ggi"/>
+                            <constraint firstAttribute="trailing" secondItem="yMh-oN-h6N" secondAttribute="trailing" id="LlD-gz-Qxg"/>
+                            <constraint firstItem="bDJ-YQ-Fba" firstAttribute="top" secondItem="yMh-oN-h6N" secondAttribute="top" symbolic="YES" id="Lyf-dh-JpZ"/>
+                            <constraint firstItem="DOk-3h-gKt" firstAttribute="leading" secondItem="bDJ-YQ-Fba" secondAttribute="leading" id="Pot-p2-KQq"/>
+                            <constraint firstItem="DOk-3h-gKt" firstAttribute="trailing" secondItem="bDJ-YQ-Fba" secondAttribute="trailing" id="dsL-sF-9B8"/>
                             <constraint firstItem="yMh-oN-h6N" firstAttribute="leading" secondItem="7gX-cs-H6x" secondAttribute="leading" id="uQr-PE-lfP"/>
-                            <constraint firstItem="YLS-ms-81h" firstAttribute="leading" secondItem="7gX-cs-H6x" secondAttribute="leading" id="un2-9E-dxd"/>
-                            <constraint firstItem="npD-Cb-LzJ" firstAttribute="top" secondItem="YLS-ms-81h" secondAttribute="bottom" id="vU8-Mj-D8l"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="bDJ-YQ-Fba"/>
                     </view>
                     <connections>
                         <outlet property="observerInstructionLabel" destination="qgh-ab-wUm" id="FNy-gu-voB"/>


### PR DESCRIPTION
Hey @gdhakal - could you take a look at this please? It's meant to make the sample compatible with Safe Area and suitable for iPhone X.

Could you let me know if this looks OK for you in Xcode and if it runs OK? I think it might be a bug in Xcode, but playing with constraints makes the instructions label disappear in the storyboard sometimes, though it seems to run properly.