### PR TITLE
Respect safe area for embedded instruction label

### DIFF
--- a/arcgis-ios-sdk-samples/Analysis/Viewshed (GeoElement)/ViewshedGeoElement.storyboard
+++ b/arcgis-ios-sdk-samples/Analysis/Viewshed (GeoElement)/ViewshedGeoElement.storyboard
@@ -15,18 +15,18 @@
             <objects>
                 <viewController id="asZ-BO-edQ" customClass="ViewshedGeoElementViewController" customModule="arcgis_ios_sdk_samples" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="OmS-KM-jTp">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Z0U-33-i0S" customClass="AGSSceneView">
-                                <rect key="frame" x="0.0" y="77" width="375" height="590"/>
+                                <rect key="frame" x="0.0" y="80.666666666666686" width="375" height="731.33333333333326"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </view>
-                            <view opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cM1-Ws-yO3">
-                                <rect key="frame" x="0.0" y="20" width="375" height="57"/>
+                            <view opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cM1-Ws-yO3" userLabel="Instruction View">
+                                <rect key="frame" x="0.0" y="44" width="375" height="36.666666666666657"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tap on the map to move the tank and update the viewshed" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PF5-we-Wcu">
-                                        <rect key="frame" x="8" y="8" width="359" height="41"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tap on the map to move the tank and update the viewshed" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PF5-we-Wcu" userLabel="Instruction Label">
+                                        <rect key="frame" x="8" y="8.0000000000000018" width="359" height="20.666666666666671"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -36,8 +36,6 @@
                                 <constraints>
                                     <constraint firstItem="PF5-we-Wcu" firstAttribute="top" secondItem="cM1-Ws-yO3" secondAttribute="top" constant="8" id="1Qa-Ms-iDL"/>
                                     <constraint firstAttribute="bottom" secondItem="PF5-we-Wcu" secondAttribute="bottom" constant="8" id="TJj-bI-d0C"/>
-                                    <constraint firstAttribute="trailing" secondItem="PF5-we-Wcu" secondAttribute="trailing" constant="8" id="Vk4-LO-K27"/>
-                                    <constraint firstItem="PF5-we-Wcu" firstAttribute="leading" secondItem="cM1-Ws-yO3" secondAttribute="leading" constant="8" id="pac-ca-TmU"/>
                                 </constraints>
                             </view>
                         </subviews>
@@ -47,8 +45,10 @@
                             <constraint firstAttribute="trailing" secondItem="Z0U-33-i0S" secondAttribute="trailing" id="Ese-qa-9Fx"/>
                             <constraint firstItem="cM1-Ws-yO3" firstAttribute="top" secondItem="zHk-5t-F8j" secondAttribute="top" id="dlD-Rm-K4a"/>
                             <constraint firstItem="cM1-Ws-yO3" firstAttribute="leading" secondItem="OmS-KM-jTp" secondAttribute="leading" id="gPr-j9-HFr"/>
+                            <constraint firstItem="PF5-we-Wcu" firstAttribute="leading" secondItem="zHk-5t-F8j" secondAttribute="leading" constant="8" id="hVG-a1-DJq"/>
                             <constraint firstItem="Z0U-33-i0S" firstAttribute="leading" secondItem="OmS-KM-jTp" secondAttribute="leading" id="sGF-jw-jKg"/>
                             <constraint firstAttribute="bottom" secondItem="Z0U-33-i0S" secondAttribute="bottom" id="smM-X7-5Ow"/>
+                            <constraint firstItem="zHk-5t-F8j" firstAttribute="trailing" secondItem="PF5-we-Wcu" secondAttribute="trailing" constant="8" id="tnr-q8-s06"/>
                             <constraint firstItem="Z0U-33-i0S" firstAttribute="top" secondItem="cM1-Ws-yO3" secondAttribute="bottom" id="xLC-MU-DwI"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="zHk-5t-F8j"/>


### PR DESCRIPTION
Really sorry, @mhdostal. I've since learnt a bit more about working with the Safe Area and I think this change is useful.

Now the Instruction View still extends the full width of the main view, but the contained label's leading and trailing edges are now constrained by the safe area. In practice it doesn't affect the label with the default text contents and font sizes, but it's a better practice.

This time I'll re-review immediately, I promise!