### PR TITLE
Suggestion for wiring up the Animated Zoom button via Storyboard

### DIFF
--- a/arcgis-ios-sdk-samples/Features/Feature layer rendering mode (map)/FeatureLayerRenderingModeMap.storyboard
+++ b/arcgis-ios-sdk-samples/Features/Feature layer rendering mode (map)/FeatureLayerRenderingModeMap.storyboard
@@ -31,6 +31,9 @@
                                 <state key="normal" title="Animated Zoom">
                                     <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
+                                <connections>
+                                    <action selector="animateZoom:" destination="7OF-WW-ois" eventType="touchUpInside" id="lpu-EU-12z"/>
+                                </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Static" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aQ5-jH-GCE">
                                 <rect key="frame" x="20" y="431" width="44" height="21"/>
@@ -67,7 +70,6 @@
                     <connections>
                         <outlet property="dynamicMapView" destination="MHI-Dx-Wlm" id="OlE-5d-Onv"/>
                         <outlet property="staticMapView" destination="vR4-Yr-oi4" id="lRO-Xl-Csc"/>
-                        <outlet property="zoomButton" destination="EGP-7C-mcY" id="VAn-Ef-LG1"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="JMI-gX-ZKf" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/arcgis-ios-sdk-samples/Features/Feature layer rendering mode (map)/FeatureLayerRenderingModeMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer rendering mode (map)/FeatureLayerRenderingModeMapViewController.swift
@@ -20,8 +20,6 @@ class FeatureLayerRenderingModeMapViewController: UIViewController {
     @IBOutlet weak var dynamicMapView: AGSMapView!
     @IBOutlet weak var staticMapView: AGSMapView!
     
-    @IBOutlet weak var zoomButton: UIButton!
-    
     var _zoomed = false
     var zoomedInViewpoint : AGSViewpoint!
     var zoomedOutViewpoint : AGSViewpoint!
@@ -67,12 +65,9 @@ class FeatureLayerRenderingModeMapViewController: UIViewController {
         //set the initial viewpoint
         self.dynamicMapView.setViewpoint(zoomedOutViewpoint)
         self.staticMapView.setViewpoint(zoomedOutViewpoint)
-        
-        //handle clicks
-        self.zoomButton.addTarget(self, action: #selector(FeatureLayerRenderingModeMapViewController.buttonClicked(_:)), for: .touchUpInside)
     }
-    
-    func buttonClicked(_ sender: AnyObject?) {
+
+    @IBAction func animateZoom(_ sender: Any) {
         if _zoomed {
             self.dynamicMapView.setViewpoint(zoomedOutViewpoint, duration: 5, completion: nil)
             self.staticMapView.setViewpoint(zoomedOutViewpoint, duration: 5, completion: nil)


### PR DESCRIPTION
In this sample I've got rid of the zoomButton outlet and just wired the touchUpInside action through the Storyboard. This is a little better aligned with most of the other samples.