### PR TITLE
Removes an extra space

### DIFF
--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/SourceCodeViewController.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/SourceCodeViewController.swift
@@ -69,7 +69,7 @@ class SourceCodeViewController: UIViewController, UIWebViewDelegate, UIAdaptiveP
             "<link rel=\"stylesheet\" href=\"\(cssPath)\">" +
             "<script src=\"\(jsPath)\"></script>" +
             "<script>hljs.initHighlightingOnLoad();</script> </head> <body>" +
-            "<pre><code class=\"Swift\"> \(content) </code></pre>" +
+            "<pre><code class=\"Swift\">\(content)</code></pre>" +
             "</body> </html>"
 //        println(stringForHTML)
         // style=\"white-space:initial;\"


### PR DESCRIPTION
Removes a space that was inserted before the source code, causing the first line to always be offset.

Before: 
![simulator screen shot - iphone x - 2018-05-30 at 08 42 15](https://user-images.githubusercontent.com/2257493/40732792-f4429ff2-63e8-11e8-90b6-cddab2c9eeb7.png)

After: 
![simulator screen shot - iphone x - 2018-05-30 at 09 01 20](https://user-images.githubusercontent.com/2257493/40732809-06bae3ba-63e9-11e8-8ace-5789227f0c9f.png)
