### PR TITLE
Drops UIColor where possible

### DIFF
--- a/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/OrderByFieldsViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/OrderByFieldsViewController.swift
@@ -56,7 +56,7 @@ class OrderByFieldsViewController: UIViewController, UITableViewDataSource, UITa
             messageLabel.textAlignment = .center;
             messageLabel.font = UIFont(name: "HelveticaNeue", size: 20.0)!
             messageLabel.sizeToFit()
-            tableView.backgroundView?.backgroundColor = UIColor.white
+            tableView.backgroundView?.backgroundColor = .white
             tableView.backgroundView = messageLabel;
         }
         return orderByFields.count

--- a/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/StatisticalQueryGroupAndSortViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/StatisticalQueryGroupAndSortViewController.swift
@@ -227,7 +227,7 @@ class StatisticalQueryGroupAndSortViewController: UIViewController, UITableViewD
         // Create the view
         let returnedView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.size.width, height: 44))
         returnedView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
-        returnedView.backgroundColor = .primaryBlue()
+        returnedView.backgroundColor = .primaryBlue
         returnedView.layer.borderColor = UIColor.white.cgColor
         returnedView.layer.borderWidth = 1
 

--- a/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/StatisticalQueryGroupAndSortViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/StatisticalQueryGroupAndSortViewController.swift
@@ -227,20 +227,20 @@ class StatisticalQueryGroupAndSortViewController: UIViewController, UITableViewD
         // Create the view
         let returnedView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.size.width, height: 44))
         returnedView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
-        returnedView.backgroundColor = UIColor.primaryBlue()
+        returnedView.backgroundColor = .primaryBlue()
         returnedView.layer.borderColor = UIColor.white.cgColor
         returnedView.layer.borderWidth = 1
 
         // Add label
         let label = UILabel(frame: CGRect(x: 10, y: 7, width: view.frame.size.width, height: 25))
         label.text = sectionHeaderTitles[section]
-        label.textColor = UIColor.white
+        label.textColor = .white
         returnedView.addSubview(label)
 
         // Add button
         let headerButton = UIButton(type: .contactAdd)
         headerButton.frame = CGRect(x: tableView.frame.size.width - 32, y: 11, width: 22, height: 22)
-        headerButton.tintColor = UIColor.white
+        headerButton.tintColor = .white
         headerButton.tag = section
         headerButton.addTarget(self, action:  #selector(headerButtonAction(_:)), for: .touchUpInside)
         returnedView.addSubview(headerButton)

--- a/arcgis-ios-sdk-samples/Analysis/Viewshed (geoprocessing)/ViewshedGeoprocessingViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Viewshed (geoprocessing)/ViewshedGeoprocessingViewController.swift
@@ -40,7 +40,7 @@ class ViewshedGeoprocessingViewController: UIViewController, AGSGeoViewTouchDele
         self.mapView.touchDelegate = self
         
         //renderer for graphics overlays
-        let pointSymbol = AGSSimpleMarkerSymbol(style: .circle, color: UIColor.red, size: 10)
+        let pointSymbol = AGSSimpleMarkerSymbol(style: .circle, color: .red, size: 10)
         let renderer = AGSSimpleRenderer(symbol: pointSymbol)
         self.inputGraphicsOverlay.renderer = renderer
         

--- a/arcgis-ios-sdk-samples/AppDelegate.swift
+++ b/arcgis-ios-sdk-samples/AppDelegate.swift
@@ -83,7 +83,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
         let bool = UserDefaults.standard.bool(forKey: "showTouch")
         if bool {
             DemoTouchManager.showTouches()
-            DemoTouchManager.touchBorderColor = UIColor.lightGray
+            DemoTouchManager.touchBorderColor = .lightGray
             DemoTouchManager.touchFillColor = UIColor(white: 231/255.0, alpha: 1)
         }
         else {
@@ -96,14 +96,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
     
     func modifyAppearance() {
         UINavigationBar.appearance().titleTextAttributes = [NSAttributedStringKey.foregroundColor : UIColor.white]
-        UINavigationBar.appearance().barTintColor = UIColor.primaryBlue()
-        UINavigationBar.appearance().tintColor = UIColor.white
+        UINavigationBar.appearance().barTintColor = .primaryBlue()
+        UINavigationBar.appearance().tintColor = .white
         
-        UIToolbar.appearance().barTintColor = UIColor.backgroundGray()
-        UIToolbar.appearance().tintColor = UIColor.primaryBlue()
+        UIToolbar.appearance().barTintColor = .backgroundGray()
+        UIToolbar.appearance().tintColor = .primaryBlue()
         
-        UISwitch.appearance().onTintColor = UIColor.primaryBlue()
-        UISlider.appearance().tintColor = UIColor.primaryBlue()
+        UISwitch.appearance().onTintColor = .primaryBlue()
+        UISlider.appearance().tintColor = .primaryBlue()
     }
 
     // MARK: - Split view

--- a/arcgis-ios-sdk-samples/AppDelegate.swift
+++ b/arcgis-ios-sdk-samples/AppDelegate.swift
@@ -96,14 +96,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
     
     func modifyAppearance() {
         UINavigationBar.appearance().titleTextAttributes = [NSAttributedStringKey.foregroundColor : UIColor.white]
-        UINavigationBar.appearance().barTintColor = .primaryBlue()
+        UINavigationBar.appearance().barTintColor = .primaryBlue
         UINavigationBar.appearance().tintColor = .white
         
-        UIToolbar.appearance().barTintColor = .backgroundGray()
-        UIToolbar.appearance().tintColor = .primaryBlue()
+        UIToolbar.appearance().barTintColor = .backgroundGray
+        UIToolbar.appearance().tintColor = .primaryBlue
         
-        UISwitch.appearance().onTintColor = .primaryBlue()
-        UISlider.appearance().tintColor = .primaryBlue()
+        UISwitch.appearance().onTintColor = .primaryBlue
+        UISlider.appearance().tintColor = .primaryBlue
     }
 
     // MARK: - Split view
@@ -132,24 +132,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
 }
 
 extension UIColor {
-    class func primaryBlue() -> UIColor {
-        return UIColor(red: 0, green: 0.475, blue: 0.757, alpha: 1)
-    }
-    
-    class func secondaryBlue() -> UIColor {
-        return UIColor(red: 0, green: 0.368, blue: 0.584, alpha: 1)
-    }
-    
-    class func backgroundGray() -> UIColor {
-        return UIColor(red: 0.973, green: 0.973, blue: 0.973, alpha: 1)
-    }
-    
-    class func primaryTextColor() -> UIColor {
-        return UIColor(red: 0.196, green: 0.196, blue: 0.196, alpha: 1)
-    }
-    
-    class func secondaryTextColor() -> UIColor {
-        return UIColor(red: 0.349, green: 0.349, blue: 0.349, alpha: 1)
-    }
+    class var primaryBlue: UIColor { return #colorLiteral(red: 0, green: 0.475, blue: 0.757, alpha: 1) }
+    class var secondaryBlue: UIColor { return #colorLiteral(red: 0, green: 0.368, blue: 0.584, alpha: 1) }
+    class var backgroundGray: UIColor { return #colorLiteral(red: 0.973, green: 0.973, blue: 0.973, alpha: 1) }
+    class var primaryTextColor: UIColor { return #colorLiteral(red: 0.196, green: 0.196, blue: 0.196, alpha: 1) }
+    class var secondaryTextColor: UIColor { return #colorLiteral(red: 0.349, green: 0.349, blue: 0.349, alpha: 1) }
 }
 

--- a/arcgis-ios-sdk-samples/Content Display Logic/Cells/ContentTableCell.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Cells/ContentTableCell.swift
@@ -32,32 +32,32 @@ class ContentTableCell: UITableViewCell {
     override func setHighlighted(_ highlighted: Bool, animated: Bool) {
         
         if highlighted {
-            self.parentView.backgroundColor = .secondaryBlue()
+            self.parentView.backgroundColor = .secondaryBlue
             self.titleLabel.textColor = .white
             self.detailLabel.textColor = .white
             self.infoButton.tintColor = .white
         }
         else {
             self.parentView.backgroundColor = .white
-            self.titleLabel.textColor = .primaryTextColor()
-            self.detailLabel.textColor = .secondaryTextColor()
-            self.infoButton.tintColor = .secondaryBlue()
+            self.titleLabel.textColor = .primaryTextColor
+            self.detailLabel.textColor = .secondaryTextColor
+            self.infoButton.tintColor = .secondaryBlue
         }
     }
     
     override func setSelected(_ selected: Bool, animated: Bool) {
         
         if selected {
-            self.parentView.backgroundColor = .secondaryBlue()
+            self.parentView.backgroundColor = .secondaryBlue
             self.titleLabel.textColor = .white
             self.detailLabel.textColor = .white
             self.infoButton.tintColor = .white
         }
         else {
             self.parentView.backgroundColor = .white
-            self.titleLabel.textColor = .primaryTextColor()
-            self.detailLabel.textColor = .secondaryTextColor()
-            self.infoButton.tintColor = .secondaryBlue()
+            self.titleLabel.textColor = .primaryTextColor
+            self.detailLabel.textColor = .secondaryTextColor
+            self.infoButton.tintColor = .secondaryBlue
         }
     }
 }

--- a/arcgis-ios-sdk-samples/Content Display Logic/Cells/ContentTableCell.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Cells/ContentTableCell.swift
@@ -32,32 +32,32 @@ class ContentTableCell: UITableViewCell {
     override func setHighlighted(_ highlighted: Bool, animated: Bool) {
         
         if highlighted {
-            self.parentView.backgroundColor = UIColor.secondaryBlue()
-            self.titleLabel.textColor = UIColor.white
-            self.detailLabel.textColor = UIColor.white
-            self.infoButton.tintColor = UIColor.white
+            self.parentView.backgroundColor = .secondaryBlue()
+            self.titleLabel.textColor = .white
+            self.detailLabel.textColor = .white
+            self.infoButton.tintColor = .white
         }
         else {
-            self.parentView.backgroundColor = UIColor.white
-            self.titleLabel.textColor = UIColor.primaryTextColor()
-            self.detailLabel.textColor = UIColor.secondaryTextColor()
-            self.infoButton.tintColor = UIColor.secondaryBlue()
+            self.parentView.backgroundColor = .white
+            self.titleLabel.textColor = .primaryTextColor()
+            self.detailLabel.textColor = .secondaryTextColor()
+            self.infoButton.tintColor = .secondaryBlue()
         }
     }
     
     override func setSelected(_ selected: Bool, animated: Bool) {
         
         if selected {
-            self.parentView.backgroundColor = UIColor.secondaryBlue()
-            self.titleLabel.textColor = UIColor.white
-            self.detailLabel.textColor = UIColor.white
-            self.infoButton.tintColor = UIColor.white
+            self.parentView.backgroundColor = .secondaryBlue()
+            self.titleLabel.textColor = .white
+            self.detailLabel.textColor = .white
+            self.infoButton.tintColor = .white
         }
         else {
-            self.parentView.backgroundColor = UIColor.white
-            self.titleLabel.textColor = UIColor.primaryTextColor()
-            self.detailLabel.textColor = UIColor.secondaryTextColor()
-            self.infoButton.tintColor = UIColor.secondaryBlue()
+            self.parentView.backgroundColor = .white
+            self.titleLabel.textColor = .primaryTextColor()
+            self.detailLabel.textColor = .secondaryTextColor()
+            self.infoButton.tintColor = .secondaryBlue()
         }
     }
 }

--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ContentTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ContentTableViewController.swift
@@ -128,7 +128,7 @@ class ContentTableViewController: UITableViewController, CustomSearchHeaderViewD
         cell.infoButton.addTarget(self, action: #selector(ContentTableViewController.expandCell(_:)), for: UIControlEvents.touchUpInside)
         cell.infoButton.tag = (indexPath as NSIndexPath).row
 
-        cell.backgroundColor = UIColor.clear
+        cell.backgroundColor = .clear
         
         return cell
     }

--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ListViewController.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ListViewController.swift
@@ -54,7 +54,7 @@ class ListViewController: UIViewController, UITableViewDataSource, UITableViewDe
         let cell = tableView.dequeueReusableCell(withIdentifier: "ListCell")!
         
         cell.textLabel?.text = self.list[(indexPath as NSIndexPath).row]
-        cell.backgroundColor = UIColor.clear
+        cell.backgroundColor = .clear
         return cell
     }
     

--- a/arcgis-ios-sdk-samples/Content Display Logic/Views/CustomSearchHeaderView.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Views/CustomSearchHeaderView.swift
@@ -54,7 +54,7 @@ class CustomSearchHeaderView: UICollectionReusableView, UITableViewDataSource, U
     
     func setup() {
         //set background color to clear color
-        self.backgroundColor = UIColor.clear
+        self.backgroundColor = .clear
         
         self.nibView = self.loadViewFromNib()
         
@@ -67,14 +67,14 @@ class CustomSearchHeaderView: UICollectionReusableView, UITableViewDataSource, U
             let placeholderAttributes = [NSAttributedStringKey.foregroundColor: UIColor.white, NSAttributedStringKey.font: UIFont.systemFont(ofSize: UIFont.systemFontSize)]
             let attributedPlaceholder = NSAttributedString(string: "Search", attributes: placeholderAttributes)
             searchTextField.attributedPlaceholder = attributedPlaceholder
-            searchTextField.textColor = UIColor.white
+            searchTextField.textColor = .white
             searchTextField.borderStyle = .none
             searchTextField.layer.cornerRadius = 8
-            searchTextField.backgroundColor = UIColor.secondaryBlue()
+            searchTextField.backgroundColor = .secondaryBlue()
             
             let imageV = searchTextField.leftView as! UIImageView
             imageV.image = imageV.image?.withRenderingMode(UIImageRenderingMode.alwaysTemplate)
-            imageV.tintColor = UIColor.white
+            imageV.tintColor = .white
         }
         
         self.addSubview(self.nibView)
@@ -130,7 +130,7 @@ class CustomSearchHeaderView: UICollectionReusableView, UITableViewDataSource, U
         let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath as IndexPath)
         
         cell.textLabel?.text = suggestions[indexPath.row]
-        cell.backgroundColor = UIColor.clear
+        cell.backgroundColor = .clear
         
         return cell
     }

--- a/arcgis-ios-sdk-samples/Content Display Logic/Views/CustomSearchHeaderView.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Views/CustomSearchHeaderView.swift
@@ -70,7 +70,7 @@ class CustomSearchHeaderView: UICollectionReusableView, UITableViewDataSource, U
             searchTextField.textColor = .white
             searchTextField.borderStyle = .none
             searchTextField.layer.cornerRadius = 8
-            searchTextField.backgroundColor = .secondaryBlue()
+            searchTextField.backgroundColor = .secondaryBlue
             
             let imageV = searchTextField.leftView as! UIImageView
             imageV.image = imageV.image?.withRenderingMode(UIImageRenderingMode.alwaysTemplate)

--- a/arcgis-ios-sdk-samples/Content Display Logic/Views/DownloadProgressView.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Views/DownloadProgressView.swift
@@ -51,7 +51,7 @@ class DownloadProgressView: UIView {
     
     private func commonInit() {
         
-        self.backgroundColor = UIColor.clear
+        self.backgroundColor = .clear
         
         self.nibView = self.loadViewFromNib()
         

--- a/arcgis-ios-sdk-samples/Display information/Add graphics with renderer/GORenderersViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Add graphics with renderer/GORenderersViewController.swift
@@ -45,7 +45,7 @@ class GORenderersViewController: UIViewController {
     func addGraphicsOverlay() {
         //point graphic
         let pointGeometry = AGSPoint(x: 40e5, y: 40e5, spatialReference: AGSSpatialReference.webMercator())
-        let pointSymbol = AGSSimpleMarkerSymbol(style: AGSSimpleMarkerSymbolStyle.diamond, color: UIColor.red, size: 10)
+        let pointSymbol = AGSSimpleMarkerSymbol(style: AGSSimpleMarkerSymbolStyle.diamond, color: .red, size: 10)
         let pointGraphic = AGSGraphic(geometry: pointGeometry, symbol: nil, attributes: nil)
         
         //create graphics overlay for point
@@ -65,7 +65,7 @@ class GORenderersViewController: UIViewController {
         let lineGeometry = AGSPolylineBuilder(spatialReference: AGSSpatialReference.webMercator())
         lineGeometry.addPointWith(x: -10e5, y: 40e5)
         lineGeometry.addPointWith(x: 20e5, y: 50e5)
-        let lineSymbol = AGSSimpleLineSymbol(style: AGSSimpleLineSymbolStyle.solid, color: UIColor.blue, width: 5)
+        let lineSymbol = AGSSimpleLineSymbol(style: AGSSimpleLineSymbolStyle.solid, color: .blue, width: 5)
         let lineGraphic = AGSGraphic(geometry: lineGeometry.toGeometry(), symbol: nil, attributes: nil)
         
         // create graphics overlay for polyline
@@ -87,7 +87,7 @@ class GORenderersViewController: UIViewController {
         polygonGeometry.addPointWith(x: 20e5, y: 20e5)
         polygonGeometry.addPointWith(x: 20e5, y: -20e5)
         polygonGeometry.addPointWith(x: -20e5, y: -20e5)
-        let polygonSymbol = AGSSimpleFillSymbol(style: AGSSimpleFillSymbolStyle.solid, color: UIColor.yellow, outline: nil)
+        let polygonSymbol = AGSSimpleFillSymbol(style: AGSSimpleFillSymbolStyle.solid, color: .yellow, outline: nil)
         let polygonGraphic = AGSGraphic(geometry: polygonGeometry.toGeometry(), symbol: nil, attributes: nil)
         
         //create graphics overlay for polygon

--- a/arcgis-ios-sdk-samples/Display information/Add graphics with symbols/GraphicsWithSymbolsViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Add graphics with symbols/GraphicsWithSymbolsViewController.swift
@@ -62,7 +62,7 @@ class GraphicsWithSymbolsViewController: UIViewController {
         
         
         //create a marker symbol
-        let buoyMarker = AGSSimpleMarkerSymbol(style: .circle, color: UIColor.red, size: 10)
+        let buoyMarker = AGSSimpleMarkerSymbol(style: .circle, color: .red, size: 10)
 
         
         //create graphics

--- a/arcgis-ios-sdk-samples/Display information/Display grid/DisplayGridSettingsViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Display grid/DisplayGridSettingsViewController.swift
@@ -213,7 +213,7 @@ class DisplayGridSettingsViewController: UIViewController, HorizontalPickerDeleg
                 textSymbol.size = 14
                 textSymbol.horizontalAlignment = .left
                 textSymbol.verticalAlignment = .bottom
-                textSymbol.haloColor = UIColor.white
+                textSymbol.haloColor = .white
                 textSymbol.haloWidth = CGFloat(gridLevel+1)
                 grid.setTextSymbol(textSymbol, forLevel: gridLevel)
             }

--- a/arcgis-ios-sdk-samples/Display information/Identify graphics/GOIdentifyViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Identify graphics/GOIdentifyViewController.swift
@@ -57,7 +57,7 @@ class GOIdentifyViewController: UIViewController, AGSGeoViewTouchDelegate {
         polygonGeometry.addPointWith(x: 20e5, y: 20e5)
         polygonGeometry.addPointWith(x: 20e5, y: -20e5)
         polygonGeometry.addPointWith(x: -20e5, y: -20e5)
-        let polygonSymbol = AGSSimpleFillSymbol(style: AGSSimpleFillSymbolStyle.solid, color: UIColor.yellow, outline: nil)
+        let polygonSymbol = AGSSimpleFillSymbol(style: AGSSimpleFillSymbolStyle.solid, color: .yellow, outline: nil)
         let polygonGraphic = AGSGraphic(geometry: polygonGeometry.toGeometry(), symbol: nil, attributes: nil)
         
         //initialize the graphics overlay

--- a/arcgis-ios-sdk-samples/Display information/Show legend/MILLegendTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Show legend/MILLegendTableViewController.swift
@@ -94,7 +94,7 @@ class MILLegendTableViewController: UITableViewController {
             }
         })
         
-        cell.backgroundColor = UIColor.clear
+        cell.backgroundColor = .clear
         
         return cell
     }

--- a/arcgis-ios-sdk-samples/Display information/Simple marker symbol/SimpleMarkerSymbolViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Simple marker symbol/SimpleMarkerSymbolViewController.swift
@@ -51,7 +51,7 @@ class SimpleMarkerSymbolViewController: UIViewController {
 
     private func addSimpleMarkerSymbol() {
         //create a simple marker symbol
-        let symbol = AGSSimpleMarkerSymbol(style: .circle, color: UIColor.red, size: 12)
+        let symbol = AGSSimpleMarkerSymbol(style: .circle, color: .red, size: 12)
         
         //create point
         let point = AGSPoint(x: -226773, y: 6550477, spatialReference: AGSSpatialReference.webMercator())

--- a/arcgis-ios-sdk-samples/Display information/Simple renderer/SimpleRendererViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Simple renderer/SimpleRendererViewController.swift
@@ -75,7 +75,7 @@ class SimpleRendererViewController: UIViewController {
     
     private func addSimpleRenderer() {
         //create a simple renderer with red cross symbol
-        let simpleRenderer = AGSSimpleRenderer(symbol: AGSSimpleMarkerSymbol(style: .cross, color: UIColor.red, size: 12))
+        let simpleRenderer = AGSSimpleRenderer(symbol: AGSSimpleMarkerSymbol(style: .cross, color: .red, size: 12))
         
         //assign the renderer to the graphics overlay
         self.graphicsOverlay.renderer = simpleRenderer

--- a/arcgis-ios-sdk-samples/Display information/Unique value renderer/UniqueValueRendererViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Unique value renderer/UniqueValueRendererViewController.swift
@@ -63,10 +63,10 @@ class UniqueValueRendererViewController: UIViewController {
         renderer.fieldNames = ["STATE_ABBR"]
         
         //create symbols to be used in the renderer
-        let defaultSymbol = AGSSimpleFillSymbol(style: .null, color: UIColor.clear, outline: AGSSimpleLineSymbol(style: .solid, color: UIColor.gray, width: 2))
-        let californiaSymbol = AGSSimpleFillSymbol(style: .solid, color: UIColor.red, outline: AGSSimpleLineSymbol(style: .solid, color: UIColor.red, width: 2))
-        let arizonaSymbol = AGSSimpleFillSymbol(style: .solid, color: UIColor.green, outline: AGSSimpleLineSymbol(style: .solid, color: UIColor.green, width: 2))
-        let nevadaSymbol = AGSSimpleFillSymbol(style: .solid, color: UIColor.blue, outline: AGSSimpleLineSymbol(style: .solid, color: UIColor.blue, width: 2))
+        let defaultSymbol = AGSSimpleFillSymbol(style: .null, color: .clear, outline: AGSSimpleLineSymbol(style: .solid, color: .gray, width: 2))
+        let californiaSymbol = AGSSimpleFillSymbol(style: .solid, color: .red, outline: AGSSimpleLineSymbol(style: .solid, color: .red, width: 2))
+        let arizonaSymbol = AGSSimpleFillSymbol(style: .solid, color: .green, outline: AGSSimpleLineSymbol(style: .solid, color: .green, width: 2))
+        let nevadaSymbol = AGSSimpleFillSymbol(style: .solid, color: .blue, outline: AGSSimpleLineSymbol(style: .solid, color: .blue, width: 2))
         
         //set the default symbol
         renderer.defaultSymbol = defaultSymbol

--- a/arcgis-ios-sdk-samples/Edit data/Offline edit and sync/FeatureLayersViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Offline edit and sync/FeatureLayersViewController.swift
@@ -58,7 +58,7 @@ class FeatureLayersViewController: UIViewController, UITableViewDataSource, UITa
             cell.accessoryType = .none
         }
         
-        cell.backgroundColor = UIColor.clear
+        cell.backgroundColor = .clear
         return cell
     }
     

--- a/arcgis-ios-sdk-samples/Features/Change feature layer renderer/OverrideRendererViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Change feature layer renderer/OverrideRendererViewController.swift
@@ -52,7 +52,7 @@ class OverrideRendererViewController: UIViewController {
     
     @IBAction private func overrideRenderer() {
         //create a symbol to be used in the renderer
-        let symbol = AGSSimpleLineSymbol(style: AGSSimpleLineSymbolStyle.solid, color: UIColor.blue, width: 2)
+        let symbol = AGSSimpleLineSymbol(style: AGSSimpleLineSymbolStyle.solid, color: .blue, width: 2)
         //create a new renderer using the symbol just created
         let renderer = AGSSimpleRenderer(symbol: symbol)
         //assign the new renderer to the feature layer

--- a/arcgis-ios-sdk-samples/Features/Feature collection layer/FeatureCollectionLayerVC.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature collection layer/FeatureCollectionLayerVC.swift
@@ -72,7 +72,7 @@ class FeatureCollectionLayerVC: UIViewController {
         let pointsCollectionTable = AGSFeatureCollectionTable(fields: fields, geometryType: .point, spatialReference: AGSSpatialReference.wgs84())
         
         //renderer
-        let symbol = AGSSimpleMarkerSymbol(style: .triangle, color: UIColor.red, size: 18)
+        let symbol = AGSSimpleMarkerSymbol(style: .triangle, color: .red, size: 18)
         pointsCollectionTable.renderer = AGSSimpleRenderer(symbol: symbol)
         
         // Create a new point feature, provide geometry and attribute values
@@ -99,7 +99,7 @@ class FeatureCollectionLayerVC: UIViewController {
         let linesCollectionTable = AGSFeatureCollectionTable(fields: fields, geometryType: .polyline, spatialReference: AGSSpatialReference.wgs84())
         
         //renderer
-        let symbol = AGSSimpleLineSymbol(style: .dash, color: UIColor.green, width: 3)
+        let symbol = AGSSimpleLineSymbol(style: .dash, color: .green, width: 3)
         linesCollectionTable.renderer = AGSSimpleRenderer(symbol: symbol)
         
         // Create a new point feature, provide geometry and attribute values
@@ -129,8 +129,8 @@ class FeatureCollectionLayerVC: UIViewController {
         let polygonsCollectionTable = AGSFeatureCollectionTable(fields: fields, geometryType: .polygon, spatialReference: AGSSpatialReference.wgs84())
         
         //renderer
-        let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: UIColor.blue, width: 2)
-        let fillSymbol = AGSSimpleFillSymbol(style: .diagonalCross, color: UIColor.cyan, outline: lineSymbol)
+        let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: .blue, width: 2)
+        let fillSymbol = AGSSimpleFillSymbol(style: .diagonalCross, color: .cyan, outline: lineSymbol)
         polygonsCollectionTable.renderer = AGSSimpleRenderer(symbol: fillSymbol)
         
         // Create a new point feature, provide geometry and attribute values

--- a/arcgis-ios-sdk-samples/Features/Feature layer query/FLQueryViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer query/FLQueryViewController.swift
@@ -43,7 +43,7 @@ class FLQueryViewController: UIViewController, UISearchBarDelegate {
         self.featureLayer.selectionWidth = 5
         
         //set a new renderer
-        let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: UIColor.black, width: 1)
+        let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: .black, width: 1)
         let fillSymbol = AGSSimpleFillSymbol(style: .solid, color: UIColor.yellow.withAlphaComponent(0.5), outline: lineSymbol)
         self.featureLayer.renderer = AGSSimpleRenderer(symbol: fillSymbol)
         

--- a/arcgis-ios-sdk-samples/Features/Feature layer selection/FLSelectionViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer selection/FLSelectionViewController.swift
@@ -44,7 +44,7 @@ class FLSelectionViewController: UIViewController, AGSGeoViewTouchDelegate {
         self.featureTable = AGSServiceFeatureTable(url: URL(string: FEATURE_SERVICE_URL)!)
         //create feature layer using this feature table
         self.featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
-        self.featureLayer.selectionColor = UIColor.cyan
+        self.featureLayer.selectionColor = .cyan
         self.featureLayer.selectionWidth = 3
         //add feature layer to the map
         self.map.operationalLayers.add(self.featureLayer)

--- a/arcgis-ios-sdk-samples/Features/List related features/ListRelatedFeaturesVC.swift
+++ b/arcgis-ios-sdk-samples/Features/List related features/ListRelatedFeaturesVC.swift
@@ -54,7 +54,7 @@ class ListRelatedFeaturesVC: UIViewController, AGSGeoViewTouchDelegate, UIPopove
         
         //change selection width for feature layer
         self.parksFeatureLayer.selectionWidth = 4
-        self.parksFeatureLayer.selectionColor = UIColor.yellow
+        self.parksFeatureLayer.selectionColor = .yellow
         
         //add parks feature layer to the map
         map.operationalLayers.add(self.parksFeatureLayer)

--- a/arcgis-ios-sdk-samples/Features/List related features/RelatedFeaturesListVC.swift
+++ b/arcgis-ios-sdk-samples/Features/List related features/RelatedFeaturesListVC.swift
@@ -72,7 +72,7 @@ class RelatedFeaturesListVC: UIViewController, UITableViewDataSource, UITableVie
     }
     
     func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
-        view.tintColor = UIColor.white
+        view.tintColor = .white
     }
 
     override func didReceiveMemoryWarning() {

--- a/arcgis-ios-sdk-samples/Geometry/Create geometries/CreateGeometriesViewController.swift
+++ b/arcgis-ios-sdk-samples/Geometry/Create geometries/CreateGeometriesViewController.swift
@@ -37,9 +37,9 @@ class CreateGeometriesViewController: UIViewController {
         self.mapView.graphicsOverlays.add(self.graphicsOverlay)
         
         //create symbols for drawing graphics
-        let markerSymbol = AGSSimpleMarkerSymbol(style: .triangle, color: UIColor.blue, size: 14)
-        let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: UIColor.blue, width: 3)
-        let fillSymbol = AGSSimpleFillSymbol(style: .cross, color: UIColor.blue, outline: nil)
+        let markerSymbol = AGSSimpleMarkerSymbol(style: .triangle, color: .blue, size: 14)
+        let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: .blue, width: 3)
+        let fillSymbol = AGSSimpleFillSymbol(style: .cross, color: .blue, outline: nil)
         
         //add a graphic of point, multipoint, polyline and polygon
         self.graphicsOverlay.graphics.add(AGSGraphic(geometry: self.createPoint(), symbol: markerSymbol, attributes: nil))

--- a/arcgis-ios-sdk-samples/Geometry/Format coordinates/FormatCoordinatesViewController.swift
+++ b/arcgis-ios-sdk-samples/Geometry/Format coordinates/FormatCoordinatesViewController.swift
@@ -71,7 +71,7 @@ class FormatCoordinatesViewController: UIViewController, AGSGeoViewTouchDelegate
         self.graphicsOverlay.graphics.removeAllObjects()
         
         //add graphic at tapped location
-        let symbol = AGSSimpleMarkerSymbol(style: .cross, color: UIColor.yellow, size: 20)
+        let symbol = AGSSimpleMarkerSymbol(style: .cross, color: .yellow, size: 20)
         let graphic = AGSGraphic(geometry: point, symbol: symbol, attributes: nil)
         self.graphicsOverlay.graphics.add(graphic)
     }

--- a/arcgis-ios-sdk-samples/Geometry/Spatial operations/OperationsListViewController.swift
+++ b/arcgis-ios-sdk-samples/Geometry/Spatial operations/OperationsListViewController.swift
@@ -37,7 +37,7 @@ class OperationsListViewController: UIViewController, UITableViewDataSource, UIT
         let cell = tableView.dequeueReusableCell(withIdentifier: "OperationCell")!
         
         cell.textLabel?.text = self.operations[(indexPath as NSIndexPath).row]
-        cell.backgroundColor = UIColor.clear
+        cell.backgroundColor = .clear
         
         return cell
     }

--- a/arcgis-ios-sdk-samples/Geometry/Spatial operations/SpatialOperationsViewController.swift
+++ b/arcgis-ios-sdk-samples/Geometry/Spatial operations/SpatialOperationsViewController.swift
@@ -23,7 +23,7 @@ class SpatialOperationsViewController: UIViewController, OperationsListVCDelegat
     private var polygon1, polygon2: AGSPolygonBuilder!
     private var resultGraphic: AGSGraphic!
     
-    let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: UIColor.black, width: 1)
+    let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: .black, width: 1)
     
     let operations = ["None", "Union", "Difference", "Symmetric Difference", "Intersection"]
     
@@ -66,7 +66,7 @@ class SpatialOperationsViewController: UIViewController, OperationsListVCDelegat
         polygon1.addPointWith(x: -13160, y: 6710100)
         
         //symbol
-        let fillSymbol1 = AGSSimpleFillSymbol(style: .solid, color: UIColor.blue, outline: lineSymbol)
+        let fillSymbol1 = AGSSimpleFillSymbol(style: .solid, color: .blue, outline: lineSymbol)
         
         //graphic
         let polygon1Graphic = AGSGraphic(geometry: polygon1.toGeometry(), symbol: fillSymbol1, attributes: nil)
@@ -93,7 +93,7 @@ class SpatialOperationsViewController: UIViewController, OperationsListVCDelegat
         polygon2.parts.add(innerRing)
         
         //symbol
-        let fillSymbol2 = AGSSimpleFillSymbol(style: .solid, color: UIColor.green, outline: lineSymbol)
+        let fillSymbol2 = AGSSimpleFillSymbol(style: .solid, color: .green, outline: lineSymbol)
         
         //graphic
         let polygon2Graphic = AGSGraphic(geometry: polygon2.toGeometry(), symbol: fillSymbol2, attributes: nil)
@@ -121,7 +121,7 @@ class SpatialOperationsViewController: UIViewController, OperationsListVCDelegat
         }
         
         //using red fill symbol for result with black border
-        let symbol = AGSSimpleFillSymbol(style: .solid, color: UIColor.red, outline: lineSymbol)
+        let symbol = AGSSimpleFillSymbol(style: .solid, color: .red, outline: lineSymbol)
         
         //create result graphic if not present
         if self.resultGraphic == nil {

--- a/arcgis-ios-sdk-samples/Layers/ArcGIS vector tiled layer (custom style)/VectorStylesViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/ArcGIS vector tiled layer (custom style)/VectorStylesViewController.swift
@@ -49,7 +49,7 @@ class VectorStylesViewController: UIViewController, UITableViewDataSource, UITab
         let identifier = "Cell\((indexPath as NSIndexPath).row)"
         let cell = tableView.dequeueReusableCell(withIdentifier: identifier)!
         
-        cell.backgroundColor = UIColor.clear
+        cell.backgroundColor = .clear
         return cell
     }
     

--- a/arcgis-ios-sdk-samples/Layers/Change sublayer visibility/SublayersTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Change sublayer visibility/SublayersTableViewController.swift
@@ -43,7 +43,7 @@ class SublayersTableViewController: UITableViewController {
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "SublayerCell")!
-        cell.backgroundColor = UIColor.clear
+        cell.backgroundColor = .clear
         
         let sublayer = self.sublayers[(indexPath as NSIndexPath).row] as! AGSArcGISMapImageSublayer
         cell.textLabel?.text = sublayer.name

--- a/arcgis-ios-sdk-samples/Layers/Manage sublayers/ManageSublayersViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Manage sublayers/ManageSublayersViewController.swift
@@ -68,7 +68,7 @@ class ManageSublayersViewController: UIViewController, MapImageSublayersVCDelega
         let mapImageSublayer1 = AGSArcGISMapImageSublayer(id: 4, source: tableSublayerSource1)
         
         //assign a renderer to the sublayer
-        let renderer1 = AGSSimpleRenderer(symbol: AGSSimpleLineSymbol(style: .solid, color: UIColor.blue, width: 1))
+        let renderer1 = AGSSimpleRenderer(symbol: AGSSimpleLineSymbol(style: .solid, color: .blue, width: 1))
         mapImageSublayer1.renderer = renderer1
         
         //name for the sublayer
@@ -81,7 +81,7 @@ class ManageSublayersViewController: UIViewController, MapImageSublayersVCDelega
         let mapImageSublayer2 = AGSArcGISMapImageSublayer(id: 5, source: tableSublayerSource2)
         
         //assign a renderer to the sublayer
-        let renderer2 = AGSSimpleRenderer(symbol: AGSSimpleFillSymbol(style: .solid, color: UIColor.cyan, outline: nil))
+        let renderer2 = AGSSimpleRenderer(symbol: AGSSimpleFillSymbol(style: .solid, color: .cyan, outline: nil))
         mapImageSublayer2.renderer = renderer2
         
         //name for the sublayer

--- a/arcgis-ios-sdk-samples/Maps/Change basemap/SwitchBasemapViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Change basemap/SwitchBasemapViewController.swift
@@ -70,7 +70,7 @@ class SwitchBasemapViewController: UIViewController, UITableViewDataSource, UITa
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "basemapsCell")!
-        cell.backgroundColor = UIColor.clear
+        cell.backgroundColor = .clear
         
         cell.textLabel?.text = self.titles[(indexPath as NSIndexPath).row]
         return cell

--- a/arcgis-ios-sdk-samples/Maps/Create and save a map/CreateOptionsViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Create and save a map/CreateOptionsViewController.swift
@@ -102,7 +102,7 @@ class CreateOptionsViewController: UIViewController, UITableViewDataSource, UITa
             }
         }
         
-        cell.backgroundColor = UIColor.clear
+        cell.backgroundColor = .clear
         cell.selectionStyle = UITableViewCellSelectionStyle.none
         return cell
     }

--- a/arcgis-ios-sdk-samples/Maps/Display device location/CustomContextSheet.swift
+++ b/arcgis-ios-sdk-samples/Maps/Display device location/CustomContextSheet.swift
@@ -96,7 +96,6 @@ class CustomContextSheet: UIView {
             //selected label
             self.selectionLabel = self.label(self.titles[self.selectedIndex])
             self.selectionLabel.alpha = 1
-//            self.selectionLabel.backgroundColor = UIColor.redColor()
             self.insertSubview(self.selectionLabel, at: 0)
             
             //constraints
@@ -163,7 +162,7 @@ class CustomContextSheet: UIView {
     func label(_ title:String) -> UILabel {
         let label = UILabel(frame: CGRect.zero)
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.backgroundColor = UIColor.clear
+        label.backgroundColor = .clear
         label.attributedText = self.attributedText(title)
         label.alpha = 0
         label.sizeToFit()

--- a/arcgis-ios-sdk-samples/Maps/Display layer view state/LayerStatusViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Display layer view state/LayerStatusViewController.swift
@@ -131,7 +131,7 @@ class LayerStatusViewController: UIViewController, UITableViewDataSource, UITabl
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "LayerStatusCell")!
-        cell.backgroundColor = UIColor.clear
+        cell.backgroundColor = .clear
         let layer = self.map.operationalLayers[(indexPath as NSIndexPath).row] as! AGSLayer
         
         //if the layer is loaded then show the name

--- a/arcgis-ios-sdk-samples/Maps/Manage bookmarks/BookmarksListViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Manage bookmarks/BookmarksListViewController.swift
@@ -54,7 +54,7 @@ class BookmarksListViewController: UIViewController, UITableViewDataSource, UITa
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "BookmarkCell")!
-        cell.backgroundColor = UIColor.clear
+        cell.backgroundColor = .clear
         //get the respective bookmark
         let bookmark = self.bookmarks[(indexPath as NSIndexPath).row]
         //assign the bookmark's name as the title for the cell

--- a/arcgis-ios-sdk-samples/Maps/Mobile map (search and route)/MobileMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Mobile map (search and route)/MobileMapViewController.swift
@@ -68,7 +68,7 @@ class MobileMapViewController: UIViewController, AGSGeoViewTouchDelegate {
         markerSymbol.leaderOffsetY = markerSymbol.offsetY
         
         if isIndexRequired && index != nil {
-            let textSymbol = AGSTextSymbol(text: "\(index!)", color: UIColor.white, size: 20, horizontalAlignment: AGSHorizontalAlignment.center, verticalAlignment: AGSVerticalAlignment.middle)
+            let textSymbol = AGSTextSymbol(text: "\(index!)", color: .white, size: 20, horizontalAlignment: .center, verticalAlignment: .middle)
             textSymbol.offsetY = markerSymbol.offsetY
             
             let compositeSymbol = AGSCompositeSymbol(symbols: [markerSymbol, textSymbol])
@@ -86,7 +86,7 @@ class MobileMapViewController: UIViewController, AGSGeoViewTouchDelegate {
     
     //method returns the symbol for the route graphic
     func routeSymbol() -> AGSSimpleLineSymbol {
-        let symbol = AGSSimpleLineSymbol(style: .solid, color: UIColor.blue, width: 5)
+        let symbol = AGSSimpleLineSymbol(style: .solid, color: .blue, width: 5)
         return symbol
     }
     

--- a/arcgis-ios-sdk-samples/Maps/Open an existing map/OpenExistingMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Open an existing map/OpenExistingMapViewController.swift
@@ -75,7 +75,7 @@ class OpenExistingMapViewController: UIViewController, UITableViewDataSource, UI
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "ExistingMapCell")!
-        cell.backgroundColor = UIColor.clear
+        cell.backgroundColor = .clear
         
         cell.textLabel?.text = self.titles[(indexPath as NSIndexPath).row]
         cell.imageView?.image = UIImage(named: self.imageNames[(indexPath as NSIndexPath).row])!

--- a/arcgis-ios-sdk-samples/Maps/Take screenshot/MapViewScreenshotViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Take screenshot/MapViewScreenshotViewController.swift
@@ -86,7 +86,7 @@ class MapViewScreenshotViewController: UIViewController {
     private func imitateFlashAndPreviewImage(_ image:UIImage) {
         
         let flashView = UIView(frame: self.mapView.bounds)
-        flashView.backgroundColor = UIColor.white
+        flashView.backgroundColor = .white
         self.mapView.addSubview(flashView)
         
         //animate the white flash view on and off to show the flash effect

--- a/arcgis-ios-sdk-samples/Route & Directions/Find route/FindRouteViewController.swift
+++ b/arcgis-ios-sdk-samples/Route & Directions/Find route/FindRouteViewController.swift
@@ -70,8 +70,8 @@ class FindRouteViewController: UIViewController {
         self.stop1Geometry = AGSPoint(x: -13041171.537945, y: 3860988.271378, spatialReference: AGSSpatialReference(wkid: 3857))
         self.stop2Geometry = AGSPoint(x: -13041693.562570, y: 3856006.859684, spatialReference: AGSSpatialReference(wkid: 3857))
         
-        let startStopGraphic = AGSGraphic(geometry: self.stop1Geometry, symbol: self.stopSymbol(withName: "Origin", textColor: UIColor.blue), attributes: nil)
-        let endStopGraphic = AGSGraphic(geometry: self.stop2Geometry, symbol: self.stopSymbol(withName: "Destination", textColor: UIColor.red), attributes: nil)
+        let startStopGraphic = AGSGraphic(geometry: self.stop1Geometry, symbol: self.stopSymbol(withName: "Origin", textColor: .blue), attributes: nil)
+        let endStopGraphic = AGSGraphic(geometry: self.stop2Geometry, symbol: self.stopSymbol(withName: "Destination", textColor: .red), attributes: nil)
         
         self.stopGraphicsOverlay.graphics.addObjects(from: [startStopGraphic, endStopGraphic])
     }
@@ -83,7 +83,7 @@ class FindRouteViewController: UIViewController {
     
     //method provides a line symbol for the route graphic
     func routeSymbol() -> AGSSimpleLineSymbol {
-        let symbol = AGSSimpleLineSymbol(style: .solid, color: UIColor.yellow, width: 5)
+        let symbol = AGSSimpleLineSymbol(style: .solid, color: .yellow, width: 5)
         return symbol
     }
     

--- a/arcgis-ios-sdk-samples/Route & Directions/Find service area interactive/FindServiceAreaInteractiveVC.swift
+++ b/arcgis-ios-sdk-samples/Route & Directions/Find service area interactive/FindServiceAreaInteractiveVC.swift
@@ -70,7 +70,7 @@ class FindServiceAreaInteractiveVC: UIViewController, AGSGeoViewTouchDelegate, S
         self.facilitiesGraphicsOverlay.renderer = AGSSimpleRenderer(symbol: facilitySymbol)
         
         //barrier symbol
-        let barrierSymbol = AGSSimpleFillSymbol(style: .diagonalCross, color: UIColor.red, outline: nil)
+        let barrierSymbol = AGSSimpleFillSymbol(style: .diagonalCross, color: .red, outline: nil)
         
         //set symbol on barrier graphics overlay using renderer
         self.barriersGraphicsOverlay.renderer = AGSSimpleRenderer(symbol: barrierSymbol)

--- a/arcgis-ios-sdk-samples/Route & Directions/Offline routing/OfflineRoutingViewController.swift
+++ b/arcgis-ios-sdk-samples/Route & Directions/Offline routing/OfflineRoutingViewController.swift
@@ -104,7 +104,7 @@ class OfflineRoutingViewController: UIViewController, AGSGeoViewTouchDelegate {
         let markerSymbol = AGSPictureMarkerSymbol(image: markerImage)
         markerSymbol.offsetY = markerImage.size.height/2
         
-        let textSymbol = AGSTextSymbol(text: "\(index)", color: UIColor.white, size: 20, horizontalAlignment: AGSHorizontalAlignment.center, verticalAlignment: AGSVerticalAlignment.middle)
+        let textSymbol = AGSTextSymbol(text: "\(index)", color: .white, size: 20, horizontalAlignment: .center, verticalAlignment: .middle)
         textSymbol.offsetY = markerSymbol.offsetY
         
         let compositeSymbol = AGSCompositeSymbol(symbols: [markerSymbol, textSymbol])
@@ -261,7 +261,7 @@ class OfflineRoutingViewController: UIViewController, AGSGeoViewTouchDelegate {
     
     //method returns the symbol for the route graphic
     func routeSymbol() -> AGSSimpleLineSymbol {
-        let symbol = AGSSimpleLineSymbol(style: .solid, color: UIColor.yellow, width: 5)
+        let symbol = AGSSimpleLineSymbol(style: .solid, color: .yellow, width: 5)
         return symbol
     }
     

--- a/arcgis-ios-sdk-samples/Route & Directions/Route around barriers/RouteAroundBarriersViewController.swift
+++ b/arcgis-ios-sdk-samples/Route & Directions/Route around barriers/RouteAroundBarriersViewController.swift
@@ -136,12 +136,12 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
     }
     
     func routeSymbol() -> AGSSimpleLineSymbol {
-        let symbol = AGSSimpleLineSymbol(style: .solid, color: UIColor.yellow, width: 5)
+        let symbol = AGSSimpleLineSymbol(style: .solid, color: .yellow, width: 5)
         return symbol
     }
     
     func directionSymbol() -> AGSSimpleLineSymbol {
-        let symbol = AGSSimpleLineSymbol(style: .dashDot, color: UIColor.orange, width: 5)
+        let symbol = AGSSimpleLineSymbol(style: .dashDot, color: .orange, width: 5)
         return symbol
     }
     
@@ -150,7 +150,7 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
         let markerSymbol = AGSPictureMarkerSymbol(image: markerImage)
         markerSymbol.offsetY = markerImage.size.height/2
         
-        let textSymbol = AGSTextSymbol(text: "\(index)", color: UIColor.white, size: 20, horizontalAlignment: AGSHorizontalAlignment.center, verticalAlignment: AGSVerticalAlignment.middle)
+        let textSymbol = AGSTextSymbol(text: "\(index)", color: .white, size: 20, horizontalAlignment: .center, verticalAlignment: .middle)
         textSymbol.offsetY = markerSymbol.offsetY
         
         let compositeSymbol = AGSCompositeSymbol(symbols: [markerSymbol, textSymbol])
@@ -159,7 +159,7 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
     }
     
     func barrierSymbol() -> AGSSimpleFillSymbol {
-        return AGSSimpleFillSymbol(style: .diagonalCross, color: UIColor.red, outline: nil)
+        return AGSSimpleFillSymbol(style: .diagonalCross, color: .red, outline: nil)
     }
     
     //MARK: - AGSGeoViewTouchDelegate

--- a/arcgis-ios-sdk-samples/Scenes/Animate 3D graphic/Animate3DGraphicViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Animate 3D graphic/Animate3DGraphicViewController.swift
@@ -102,7 +102,7 @@ class Animate3DGraphicViewController: UIViewController, MissionSettingsVCDelegat
         self.mapGraphicsOverlay.renderer = renderer2D
         
         //route graphic
-        let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: UIColor.blue, width: 1)
+        let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: .blue, width: 1)
         self.routeGraphic = AGSGraphic(geometry: nil, symbol: lineSymbol, attributes: nil)
         self.mapGraphicsOverlay.graphics.add(routeGraphic)
         
@@ -119,7 +119,7 @@ class Animate3DGraphicViewController: UIViewController, MissionSettingsVCDelegat
     }
     
     private func addPlane2D() {
-        self.triangleSymbol = AGSSimpleMarkerSymbol(style: .triangle, color: UIColor.red, size: 10)
+        self.triangleSymbol = AGSSimpleMarkerSymbol(style: .triangle, color: .red, size: 10)
         self.triangleGraphic = AGSGraphic(geometry: nil, symbol: self.triangleSymbol, attributes: nil)
         self.mapGraphicsOverlay.graphics.add(self.triangleGraphic)
     }

--- a/arcgis-ios-sdk-samples/Scenes/Extrude graphics/ExtrudeGraphicsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Extrude graphics/ExtrudeGraphicsViewController.swift
@@ -51,7 +51,7 @@ class ExtrudeGraphicsViewController: UIViewController {
         //simple renderer with extrusion property
         let renderer = AGSSimpleRenderer()
         let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: .white, width: 1)
-        renderer.symbol = AGSSimpleFillSymbol(style: .solid, color: .primaryBlue(), outline: lineSymbol)
+        renderer.symbol = AGSSimpleFillSymbol(style: .solid, color: .primaryBlue, outline: lineSymbol)
         renderer.sceneProperties?.extrusionMode = .baseHeight
         renderer.sceneProperties?.extrusionExpression = "[height]"
         self.graphicsOverlay.renderer = renderer

--- a/arcgis-ios-sdk-samples/Scenes/Extrude graphics/ExtrudeGraphicsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Extrude graphics/ExtrudeGraphicsViewController.swift
@@ -50,8 +50,8 @@ class ExtrudeGraphicsViewController: UIViewController {
         
         //simple renderer with extrusion property
         let renderer = AGSSimpleRenderer()
-        let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: UIColor.white, width: 1)
-        renderer.symbol = AGSSimpleFillSymbol(style: .solid, color: UIColor.primaryBlue(), outline: lineSymbol)
+        let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: .white, width: 1)
+        renderer.symbol = AGSSimpleFillSymbol(style: .solid, color: .primaryBlue(), outline: lineSymbol)
         renderer.sceneProperties?.extrusionMode = .baseHeight
         renderer.sceneProperties?.extrusionExpression = "[height]"
         self.graphicsOverlay.renderer = renderer

--- a/arcgis-ios-sdk-samples/Scenes/Feature layer extrusion/FeatureLayerExtrusionViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Feature layer extrusion/FeatureLayerExtrusionViewController.swift
@@ -41,8 +41,8 @@ class FeatureLayerExtrusionViewController: UIViewController {
         // feature layer must be rendered dynamically for extrusion to work
         layer.renderingMode = .dynamic
         // setup the symbols used to display the features (US states) from the table
-        let lineSymbol = AGSSimpleLineSymbol(style:.solid, color:UIColor.blue, width:1.0)
-        let fillSymbol = AGSSimpleFillSymbol(style:.solid, color:UIColor.blue, outline:lineSymbol)
+        let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: .blue, width: 1.0)
+        let fillSymbol = AGSSimpleFillSymbol(style: .solid, color:.blue, outline: lineSymbol)
         renderer = AGSSimpleRenderer(symbol: fillSymbol)
         // need to set an extrusion type, BASE HEIGHT extrudes each point from the feature individually
         renderer?.sceneProperties?.extrusionMode = .baseHeight

--- a/arcgis-ios-sdk-samples/Scenes/Scene properties expressions/ScenePropertiesExpressionsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Scene properties expressions/ScenePropertiesExpressionsViewController.swift
@@ -54,7 +54,7 @@ class ScenePropertiesExpressionsViewController: UIViewController {
         graphicsOverlay.renderer = renderer
         
         //create a red cone graphic
-        let coneSymbol = AGSSimpleMarkerSceneSymbol(style: .cone, color: UIColor.red, height: 200, width: 100, depth: 100, anchorPosition: .center)
+        let coneSymbol = AGSSimpleMarkerSceneSymbol(style: .cone, color: .red, height: 200, width: 100, depth: 100, anchorPosition: .center)
         coneSymbol.pitch = -90  //correct symbol's default pitch
         let conePoint = AGSPoint(x: 83.9, y: 28.404, z: 5000, spatialReference: AGSSpatialReference.wgs84())
         let coneAttributes = ["HEADING": 0, "PITCH": 0]

--- a/arcgis-ios-sdk-samples/Scenes/Surface placements/SurfacePlacementsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Surface placements/SurfacePlacementsViewController.swift
@@ -68,11 +68,11 @@ class SurfacePlacementsViewController: UIViewController {
     }
     
     private func pointSymbol() -> AGSSimpleMarkerSceneSymbol {
-        return AGSSimpleMarkerSceneSymbol(style: .sphere, color: UIColor.red, height: 50, width: 50, depth: 50, anchorPosition: .center)
+        return AGSSimpleMarkerSceneSymbol(style: .sphere, color: .red, height: 50, width: 50, depth: 50, anchorPosition: .center)
     }
     
     private func textSymbol(withText text: String) -> AGSTextSymbol {
-        return AGSTextSymbol(text: text, color: UIColor.blue, size: 20, horizontalAlignment: .left, verticalAlignment: .middle)
+        return AGSTextSymbol(text: text, color: .blue, size: 20, horizontalAlignment: .left, verticalAlignment: .middle)
     }
 
     override func didReceiveMemoryWarning() {

--- a/arcgis-ios-sdk-samples/Search/Offline geocode/SanDiegoAddressesViewController.swift
+++ b/arcgis-ios-sdk-samples/Search/Offline geocode/SanDiegoAddressesViewController.swift
@@ -53,7 +53,7 @@ class SanDiegoAddressesViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "AddressCell")!
         cell.textLabel?.text = self.addresses[(indexPath as NSIndexPath).row]
-        cell.backgroundColor = UIColor.clear
+        cell.backgroundColor = .clear
         return cell
     }
     

--- a/arcgis-ios-sdk-samples/Shared resources/Libraries/DemoTouchView/DemoTouchView.swift
+++ b/arcgis-ios-sdk-samples/Shared resources/Libraries/DemoTouchView/DemoTouchView.swift
@@ -384,7 +384,7 @@ private class DemoTouchesView: UIView {
     
     static let sharedInstance: DemoTouchesView = {
         var dtv = DemoTouchesView()
-        dtv.backgroundColor = UIColor.clear
+        dtv.backgroundColor = .clear
         dtv.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         dtv.isUserInteractionEnabled = false
         return dtv

--- a/arcgis-ios-sdk-samples/Shared resources/Libraries/ExpandableTableViewController/ExpandableTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Shared resources/Libraries/ExpandableTableViewController/ExpandableTableViewController.swift
@@ -82,7 +82,7 @@ class ExpandableTableViewController: UITableViewController {
         // Recast view as a UITableViewHeaderFooterView
         let header: UITableViewHeaderFooterView = view as! UITableViewHeaderFooterView
         header.contentView.backgroundColor = .white
-        header.textLabel?.textColor = .primaryTextColor()
+        header.textLabel?.textColor = .primaryTextColor
         header.tag = section
 
         // Remove image view

--- a/arcgis-ios-sdk-samples/Shared resources/Libraries/ExpandableTableViewController/ExpandableTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Shared resources/Libraries/ExpandableTableViewController/ExpandableTableViewController.swift
@@ -48,7 +48,7 @@ class ExpandableTableViewController: UITableViewController {
             messageLabel.textAlignment = .center;
             messageLabel.font = UIFont(name: "HelveticaNeue", size: 20.0)!
             messageLabel.sizeToFit()
-            tableView.backgroundView?.backgroundColor = UIColor.white
+            tableView.backgroundView?.backgroundColor = .white
             tableView.backgroundView = messageLabel;
         }
         return 0
@@ -81,8 +81,8 @@ class ExpandableTableViewController: UITableViewController {
         //
         // Recast view as a UITableViewHeaderFooterView
         let header: UITableViewHeaderFooterView = view as! UITableViewHeaderFooterView
-        header.contentView.backgroundColor = UIColor.white
-        header.textLabel?.textColor = UIColor.primaryTextColor()
+        header.contentView.backgroundColor = .white
+        header.textLabel?.textColor = .primaryTextColor()
         header.tag = section
 
         // Remove image view
@@ -122,7 +122,7 @@ class ExpandableTableViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "TableViewCell", for: indexPath) as UITableViewCell
         let sectionData = sectionItems[indexPath.section]
-        cell.textLabel?.textColor = UIColor.black
+        cell.textLabel?.textColor = .black
         let (text, detail) = sectionData[indexPath.row]
         cell.textLabel?.text = text
         cell.detailTextLabel?.text = detail

--- a/arcgis-ios-sdk-samples/Shared resources/Libraries/HorizontalPicker/HorizontalColorPicker.swift
+++ b/arcgis-ios-sdk-samples/Shared resources/Libraries/HorizontalPicker/HorizontalColorPicker.swift
@@ -45,7 +45,7 @@ class HorizontalColorPicker: UIView, UICollectionViewDataSource, UICollectionVie
     }
     
     private func commonInit() {
-        backgroundColor = UIColor.clear
+        backgroundColor = .clear
         nibView = loadViewFromNib()
         nibView.frame = bounds
         nibView.autoresizingMask = [UIViewAutoresizing.flexibleHeight, .flexibleWidth]

--- a/arcgis-ios-sdk-samples/Shared resources/Libraries/HorizontalPicker/HorizontalPicker.swift
+++ b/arcgis-ios-sdk-samples/Shared resources/Libraries/HorizontalPicker/HorizontalPicker.swift
@@ -75,8 +75,8 @@ class HorizontalPicker: UIView, UICollectionViewDataSource, UICollectionViewDele
                 self.collectionView.isUserInteractionEnabled = false
                 self.nextButton.isEnabled = false
                 self.prevButton.isEnabled = false
-                self.nextButton.imageView?.tintColor = UIColor.gray
-                self.prevButton.imageView?.tintColor = UIColor.gray
+                self.nextButton.imageView?.tintColor = .gray
+                self.prevButton.imageView?.tintColor = .gray
             }
         }
     }
@@ -96,7 +96,7 @@ class HorizontalPicker: UIView, UICollectionViewDataSource, UICollectionViewDele
     }
     
     private func commonInit() {
-        self.backgroundColor = UIColor.clear
+        self.backgroundColor = .clear
         
         self.nibView = self.loadViewFromNib()
         
@@ -136,7 +136,7 @@ class HorizontalPicker: UIView, UICollectionViewDataSource, UICollectionViewDele
         
         let prevFlag = self.selectedIndex > 0
         self.prevButton.isEnabled = prevFlag
-        self.prevButton.imageView?.tintColor = prevFlag ? self.buttonsColor : UIColor.gray
+        self.prevButton.imageView?.tintColor = prevFlag ? self.buttonsColor : .gray
     }
     
     //MARK: - UICollectionViewDataSource

--- a/arcgis-ios-sdk-samples/Shared resources/Libraries/HorizontalPicker/HorizontalPicker.swift
+++ b/arcgis-ios-sdk-samples/Shared resources/Libraries/HorizontalPicker/HorizontalPicker.swift
@@ -55,7 +55,7 @@ class HorizontalPicker: UIView, UICollectionViewDataSource, UICollectionViewDele
             self.updateButtonsState()
         }
     }
-    var buttonsColor = UIColor.secondaryBlue()
+    var buttonsColor = UIColor.secondaryBlue
     
     var isEnabled: Bool {
         didSet {


### PR DESCRIPTION
Takes advantage of type inference by removing explicit references to `UIColor` where possible.