### PR TITLE
Removes `handler` parameter from UIAlertAction

### DIFF
--- a/arcgis-ios-sdk-samples/Analysis/Statistical query/StatisticalQueryViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Statistical query/StatisticalQueryViewController.swift
@@ -110,7 +110,7 @@ class StatisticalQueryViewController: UIViewController {
     
     private func showResult(message: String) {
         let alertController = UIAlertController(title: "Statistical Query Results", message: message, preferredStyle: .alert)
-        let okAction = UIAlertAction(title: "OK", style: .cancel, handler: nil)
+        let okAction = UIAlertAction(title: "OK", style: .cancel)
         alertController.addAction(okAction)
         self.present(alertController, animated: true, completion: nil)
     }

--- a/arcgis-ios-sdk-samples/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
@@ -119,7 +119,7 @@ class DeleteFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate, A
         alertController.addAction(alertAction)
         
         //action for cancel
-        let cancelAlertAction = UIAlertAction(title: "No", style: UIAlertActionStyle.cancel, handler: nil)
+        let cancelAlertAction = UIAlertAction(title: "No", style: .cancel)
         alertController.addAction(cancelAlertAction)
         
         //present alert controller

--- a/arcgis-ios-sdk-samples/Edit data/Offline edit and sync/OfflineEditingViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Offline edit and sync/OfflineEditingViewController.swift
@@ -364,14 +364,14 @@ class OfflineEditingViewController: UIViewController, AGSGeoViewTouchDelegate, A
     
     @IBAction func switchToServiceMode(_ sender:AnyObject) {
         if self.generatedGeodatabase.hasLocalEdits() {
-            let yesAction = UIAlertAction(title: "Yes", style: UIAlertActionStyle.default, handler: { [weak self] (action:UIAlertAction) -> Void in
+            let yesAction = UIAlertAction(title: "Yes", style: .default) { [weak self] _ in
                 self?.syncAction({ () -> Void in
                     self?.switchToServiceMode()
                 })
-            })
-            let noAction = UIAlertAction(title: "No", style: UIAlertActionStyle.cancel, handler: { [weak self] (action: UIAlertAction) -> Void in
+            }
+            let noAction = UIAlertAction(title: "No", style: .cancel) { [weak self] _ in
                 self?.switchToServiceMode()
-            })
+            }
             
             let alert = UIAlertController(title: nil, message: "Would you like to sync the changes before switching?", preferredStyle: UIAlertControllerStyle.alert)
             alert.addAction(noAction)

--- a/arcgis-ios-sdk-samples/Maps/Create and save a map/CreateSaveMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Create and save a map/CreateSaveMapViewController.swift
@@ -75,15 +75,15 @@ class CreateSaveMapViewController: UIViewController, CreateOptionsVCDelegate, Sa
     private func showSuccess() {
         let alertController = UIAlertController(title: "Saved successfully", message: nil, preferredStyle: UIAlertControllerStyle.alert)
         
-        let okAction = UIAlertAction(title: "Ok", style: UIAlertActionStyle.cancel, handler: { [weak self] (action:UIAlertAction!) -> Void in
+        let okAction = UIAlertAction(title: "Ok", style: .cancel) { [weak self] _ in
             self?.dismiss(animated: true, completion: nil)
-            })
+        }
         
-        let openAction = UIAlertAction(title: "Open in Safari", style: UIAlertActionStyle.default, handler: { [weak self] (action:UIAlertAction!) -> Void in
+        let openAction = UIAlertAction(title: "Open in Safari", style: .default) { [weak self] _ in
             if let weakSelf = self {
                 UIApplication.shared.open(URL(string: "\(weakSelf.webmapURL)\(weakSelf.mapView.map!.item!.itemID)")!, options: [:])
             }
-        })
+        }
         
         alertController.addAction(okAction)
         alertController.addAction(openAction)

--- a/arcgis-ios-sdk-samples/Maps/Generate offline map/GenerateOfflineMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map/GenerateOfflineMapViewController.swift
@@ -223,7 +223,7 @@ class GenerateOfflineMapViewController: UIViewController, AGSAuthenticationManag
             self?.addMap()
         }
         
-        let noAction = UIAlertAction(title: "No", style: .cancel, handler: nil)
+        let noAction = UIAlertAction(title: "No", style: .cancel)
         
         alertController.addAction(noAction)
         alertController.addAction(yesAction)

--- a/arcgis-ios-sdk-samples/Maps/Identify layers/IdentifyLayersViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Identify layers/IdentifyLayersViewController.swift
@@ -155,7 +155,7 @@ class IdentifyLayersViewController: UIViewController, AGSGeoViewTouchDelegate {
     private func showAlertController(_ title: String, message: String) {
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
         
-        let okAction = UIAlertAction(title: "Ok", style: .cancel, handler: nil)
+        let okAction = UIAlertAction(title: "Ok", style: .cancel)
         alertController.addAction(okAction)
         self.present(alertController, animated: true, completion: nil)
     }

--- a/arcgis-ios-sdk-samples/Maps/Manage bookmarks/BookmarksViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Manage bookmarks/BookmarksViewController.swift
@@ -89,7 +89,7 @@ class BookmarksViewController: UIViewController, UIAlertViewDelegate, UIAdaptive
             
         }
         
-        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
         let doneAction = UIAlertAction(title: "Done", style: .default) { [weak self] (action: UIAlertAction) in
             guard let weakSelf = self else {
                 return


### PR DESCRIPTION
Removes `handler` parameter from UIAlertAction initialization by using either a trailing closure or the default value.

This will make it easier to find usage of other APIs with `handler` in the name.