### PR TITLE
Adds a missing call to super's viewDidAppear

### DIFF
--- a/arcgis-ios-sdk-samples/Display information/Display grid/DisplayGridSettingsViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Display grid/DisplayGridSettingsViewController.swift
@@ -60,6 +60,7 @@ class DisplayGridSettingsViewController: UIViewController, HorizontalPickerDeleg
     
     
     override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         //
         // Setup UI Controls
         setupUI()


### PR DESCRIPTION
From the documentations:

> If you override this method, you must call super at some point in your implementation.