### PR TITLE
Update Brest Service URL to reference the layer explicitly

### DIFF
--- a/arcgis-ios-sdk-samples/Extensions/Foundation/URL.swift
+++ b/arcgis-ios-sdk-samples/Extensions/Foundation/URL.swift
@@ -27,5 +27,5 @@ extension URL {
     // Scene Services
     
     /// The url of the scene service for buildings in Brest, France.
-    static let brestBuildingsService = URL(string: "https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer")!
+    static let brestBuildingsService = URL(string: "https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0")!
 }


### PR DESCRIPTION
I missed this during review. Should reference the layer explicitly to match the design.