### PR TITLE
Makes Display Grid settings persist while in the sample.

### DIFF
--- a/arcgis-ios-sdk-samples/Display information/Display grid/DisplayGrid.storyboard
+++ b/arcgis-ios-sdk-samples/Display information/Display grid/DisplayGrid.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ELk-dd-Onf">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ELk-dd-Onf">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -32,9 +32,7 @@
                                     <barButtonItem style="plain" systemItem="flexibleSpace" id="zHB-Ga-8qi"/>
                                     <barButtonItem title="Change Grid" id="Nbd-kp-CVq">
                                         <connections>
-                                            <segue destination="CLz-RC-N1t" kind="popoverPresentation" identifier="DisplayGridSettingsSegue" popoverAnchorBarButtonItem="Nbd-kp-CVq" id="mMf-Sj-moN">
-                                                <popoverArrowDirection key="popoverArrowDirection" up="YES" down="YES" left="YES" right="YES"/>
-                                            </segue>
+                                            <action selector="showSettings:" destination="ELk-dd-Onf" id="cff-D1-ebX"/>
                                         </connections>
                                     </barButtonItem>
                                     <barButtonItem style="plain" systemItem="flexibleSpace" id="c5P-1m-4CN"/>
@@ -64,7 +62,7 @@
         <!--Display Grid Settings View Controller-->
         <scene sceneID="5zE-GI-81H">
             <objects>
-                <viewController id="CLz-RC-N1t" customClass="DisplayGridSettingsViewController" customModule="arcgis_ios_sdk_samples" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="DisplayGridSettingsViewController" id="CLz-RC-N1t" customClass="DisplayGridSettingsViewController" customModule="arcgis_ios_sdk_samples" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="pY2-yh-gJ9">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/arcgis-ios-sdk-samples/Display information/Display grid/DisplayGridViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Display grid/DisplayGridViewController.swift
@@ -46,7 +46,7 @@ class DisplayGridViewController: UIViewController, UIAdaptivePresentationControl
             fatalError()
         }
         
-        viewController.mapView = self.mapView
+        viewController.mapView = mapView
         viewController.modalPresentationStyle = .popover
         
         return viewController

--- a/arcgis-ios-sdk-samples/Display information/Display grid/DisplayGridViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Display grid/DisplayGridViewController.swift
@@ -17,9 +17,7 @@ import UIKit
 import ArcGIS
 
 class DisplayGridViewController: UIViewController, UIAdaptivePresentationControllerDelegate {
-
     @IBOutlet weak var mapView: AGSMapView!
-    private var gridSettingsViewController:DisplayGridSettingsViewController!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -41,34 +39,47 @@ class DisplayGridViewController: UIViewController, UIAdaptivePresentationControl
         mapView.grid = AGSLatitudeLongitudeGrid()
     }
     
+    var settingsViewController: DisplayGridSettingsViewController?
+    
+    func makeSettingsViewController() -> DisplayGridSettingsViewController {
+        guard let viewController = storyboard?.instantiateViewController(withIdentifier: "DisplayGridSettingsViewController") as? DisplayGridSettingsViewController else {
+            fatalError()
+        }
+        
+        viewController.mapView = self.mapView
+        viewController.modalPresentationStyle = .popover
+        
+        return viewController
+    }
+    
+    @IBAction func showSettings(_ sender: Any) {
+        let settingsViewController: DisplayGridSettingsViewController
+        if let viewController = self.settingsViewController {
+            settingsViewController = viewController
+        } else {
+            settingsViewController = makeSettingsViewController()
+            self.settingsViewController = settingsViewController
+        }
+        settingsViewController.preferredContentSize = {
+            let height: CGFloat
+            if traitCollection.horizontalSizeClass == .regular && traitCollection.verticalSizeClass == .regular {
+                height = 350
+            } else {
+                height = 250
+            }
+            return CGSize(width: 375, height: height)
+        }()
+        settingsViewController.presentationController?.delegate = self
+        if let popoverPC = settingsViewController.popoverPresentationController {
+            popoverPC.barButtonItem = sender as? UIBarButtonItem
+            popoverPC.passthroughViews = [mapView]
+        }
+        present(settingsViewController, animated: true)
+    }
+    
     //MARK: - UIAdaptivePresentationControllerDelegate
     
     func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
-        //
-        // For popover or non modal presentation
-        return UIModalPresentationStyle.none
-    }
-    
-    //MARK: - Navigation
-    
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if segue.identifier == "DisplayGridSettingsSegue" {
-            //
-            // Set grid settings view controller
-            gridSettingsViewController = segue.destination as! DisplayGridSettingsViewController
-            gridSettingsViewController.mapView = self.mapView
-
-            // Pop over settings
-            gridSettingsViewController.presentationController?.delegate = self
-            gridSettingsViewController.popoverPresentationController?.passthroughViews = [self.mapView]
-            
-            // Preferred content size
-            if traitCollection.horizontalSizeClass == .regular && traitCollection.verticalSizeClass == .regular {
-                gridSettingsViewController.preferredContentSize = CGSize(width: 375, height: 350)
-            }
-            else {
-                gridSettingsViewController.preferredContentSize = CGSize(width: 375, height: 250)
-            }
-        }
+        return .none
     }
 }


### PR DESCRIPTION
Previously the settings would be reset everytime the dialogue was opened, not showing accurate values for each setting.