### PR TITLE
Removes OS_ACTIVITY_MODE environment variable

### DIFF
--- a/arcgis-ios-sdk-samples.xcodeproj/xcshareddata/xcschemes/arcgis-ios-sdk-samples.xcscheme
+++ b/arcgis-ios-sdk-samples.xcodeproj/xcshareddata/xcschemes/arcgis-ios-sdk-samples.xcscheme
@@ -61,13 +61,6 @@
             ReferencedContainer = "container:arcgis-ios-sdk-samples.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "OS_ACTIVITY_MODE"
-            value = "disable"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>


### PR DESCRIPTION
This was used to prevent being inundated with log messages, but that issue has been fixed. Removing as it now hides useful log messages.