### PR TITLE
Updates the Feature Layer Extrusion sample

### DIFF
--- a/arcgis-ios-sdk-samples/Extensions/Foundation/URL.swift
+++ b/arcgis-ios-sdk-samples/Extensions/Foundation/URL.swift
@@ -26,6 +26,10 @@ extension URL {
     
     // Map Services
     
+    /// The url of a map service containing sample census data of the United States.
+    static let censusMapService = URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer")!
+    /// The url of the States layer of the Census Map Service.
+    static let censusMapServiceStatesLayer = censusMapService.appendingPathComponent("3")
     /// The url of a map service containing sample data of the United States.
     static let unitedStatesMapService = URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer")!
     

--- a/arcgis-ios-sdk-samples/Scenes/Feature layer extrusion/FeatureLayerExtrusionViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Feature layer extrusion/FeatureLayerExtrusionViewController.swift
@@ -54,6 +54,9 @@ class FeatureLayerExtrusionViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        // Adds the source code button item to the right of navigation bar.
+        (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["FeatureLayerExtrusionViewController"]
+        
         sceneView.scene = scene
         
         // Set the scene view's viewpoint.

--- a/arcgis-ios-sdk-samples/Scenes/Feature layer extrusion/FeatureLayerExtrusionViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Feature layer extrusion/FeatureLayerExtrusionViewController.swift
@@ -15,62 +15,77 @@
 import UIKit
 import ArcGIS
 
+/// A view controller that manages the interface of the Feature Layer Extrusion
+/// sample.
 class FeatureLayerExtrusionViewController: UIViewController {
-
+    /// The scene displayed in the scene view.
+    let scene: AGSScene
+    /// The renderer of the feature layer.
+    let renderer: AGSRenderer
+    
+    required init?(coder: NSCoder) {
+        scene = AGSScene(basemapType: .topographic)
+        
+        // Create service feature table from US census feature service.
+        let table = AGSServiceFeatureTable(url: .censusMapServiceStatesLayer)
+        // Create feature layer from service feature table.
+        let layer = AGSFeatureLayer(featureTable: table)
+        // Feature layer must be rendered dynamically for extrusion to work.
+        layer.renderingMode = .dynamic
+        // Setup the symbols used to display the features (US states) from the table.
+        let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: .blue, width: 1.0)
+        let fillSymbol = AGSSimpleFillSymbol(style: .solid, color: .blue, outline: lineSymbol)
+        renderer = AGSSimpleRenderer(symbol: fillSymbol)
+        if let sceneProperties = renderer.sceneProperties {
+            sceneProperties.extrusionMode = .absoluteHeight
+            sceneProperties.extrusionExpression = Statistic.totalPopulation.extrusionExpression
+        }
+        
+        // Set the renderer on the layer and add the layer to the scene.
+        layer.renderer = renderer
+        scene.operationalLayers.add(layer)
+        
+        super.init(coder: coder)
+    }
+    
+    /// The scene view managed by the view controller.
     @IBOutlet weak var sceneView: AGSSceneView!
     
-    // initialize scene with the topographic basemap
-    let scene = AGSScene(basemapType: .topographic)
-    
-    // US census data feature service
-    let statesService = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3"
-    var renderer : AGSRenderer?
-
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        //add the source code button item to the right of navigation bar
-        (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["FeatureLayerExtrusionViewController"]
-
-        self.sceneView.scene = scene
         
-        // create service feature table from US census feature service
-        let table = AGSServiceFeatureTable(url: URL(string: statesService)!)
-        // create feature layer from service feature table
-        let layer = AGSFeatureLayer(featureTable: table)
-        // feature layer must be rendered dynamically for extrusion to work
-        layer.renderingMode = .dynamic
-        // setup the symbols used to display the features (US states) from the table
-        let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: .blue, width: 1.0)
-        let fillSymbol = AGSSimpleFillSymbol(style: .solid, color:.blue, outline: lineSymbol)
-        renderer = AGSSimpleRenderer(symbol: fillSymbol)
-        // need to set an extrusion type, BASE HEIGHT extrudes each point from the feature individually
-        renderer?.sceneProperties?.extrusionMode = .baseHeight
+        sceneView.scene = scene
         
-        // set the extrusion to total population
-        renderer?.sceneProperties?.extrusionExpression = "[POP2007]/ 10"
+        // Set the scene view's viewpoint.
+        let distance = 12_940_924.0
+        let point = AGSPoint(x: -99.659448, y: 20.513652, z: distance, spatialReference: .wgs84())
+        let camera = AGSCamera(lookAt: point, distance: 0, heading: 0, pitch: 15, roll: 0)
+        let viewpoint = AGSViewpoint(center: point, scale: distance, camera: camera)
+        sceneView.setViewpoint(viewpoint)
+    }
+    
+    enum Statistic: Int {
+        case totalPopulation
+        case populationDensity
         
-        // set the renderer on the layer and add the layer to the scene
-        layer.renderer = renderer
-        self.scene.operationalLayers.add(layer)
-        
-        // set the initial view
-        let initialLocation = AGSPoint(x: -98.585522, y: 60, spatialReference: sceneView.spatialReference)
-        let orbitCamera = AGSOrbitLocationCameraController(targetLocation: initialLocation, distance: 20000000)
-        orbitCamera.cameraPitchOffset = 55.0
-        orbitCamera.cameraHeadingOffset = 0.0
-        sceneView.cameraController = orbitCamera
+        /// The extrusion expression for the statistic.
+        var extrusionExpression: String {
+            switch self {
+            case .totalPopulation:
+                return "[POP2007]/ 10"
+            case .populationDensity:
+                // The offset makes the extrusion look better over Alaska.
+                let offset = 100_000
+                return "([POP07_SQMI] * 5000) + \(offset)"
+            }
+        }
     }
 
     @IBAction func extrusionAction(_ sender: UISegmentedControl) {
-        // button action for extruding by total population or by population density
-        switch sender.selectedSegmentIndex {
-        case 0:
-            renderer?.sceneProperties?.extrusionExpression = "[POP2007]/ 10"
-        case 1:
-            renderer?.sceneProperties?.extrusionExpression = "[POP07_SQMI] * 5000"
-        default:
-            renderer?.sceneProperties?.extrusionExpression = ""
+        if let statistic = Statistic(rawValue: sender.selectedSegmentIndex) {
+            renderer.sceneProperties?.extrusionExpression = statistic.extrusionExpression
+        } else {
+            assertionFailure("Selected segment does not correspond to a statistic")
         }
     }
     


### PR DESCRIPTION
This brings it in line with the macOS [implementation](https://github.com/Esri/arcgis-runtime-samples-macos/tree/v.next/arcgis-runtime-samples-macos/Scenes/Feature%20layer%20extrusion). Includes changes to the extrusion mode and population density expression.