### PR TITLE
Manage Bookmarks: Improves add bookmark

### DIFF
--- a/arcgis-ios-sdk-samples/Maps/Manage bookmarks/BookmarksViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Manage bookmarks/BookmarksViewController.swift
@@ -15,12 +15,11 @@
 import UIKit
 import ArcGIS
 
-class BookmarksViewController: UIViewController, UIAlertViewDelegate, UIAdaptivePresentationControllerDelegate {
+class BookmarksViewController: UIViewController, UIAdaptivePresentationControllerDelegate {
     
     @IBOutlet private weak var mapView:AGSMapView!
     
     private var map:AGSMap!
-    private var alertController:UIAlertController!
     
     private weak var bookmarksListVC:BookmarksListViewController!
     
@@ -83,31 +82,31 @@ class BookmarksViewController: UIViewController, UIAlertViewDelegate, UIAdaptive
     //MARK: - Actions
     
     @IBAction private func addAction() {
-        //show an alert controller with textfield to get the name for the bookmark
-        self.alertController = UIAlertController(title: "Provide the bookmark name", message: nil, preferredStyle: .alert)
-        self.alertController.addTextField { (textField: UITextField) in
-            
-        }
+        // Show an alert controller with textfield to get the name for the bookmark.
+        let alertController = UIAlertController(title: "Provide the bookmark name", message: nil, preferredStyle: .alert)
+        alertController.addTextField()
         
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
-        let doneAction = UIAlertAction(title: "Done", style: .default) { [weak self] (action: UIAlertAction) in
-            guard let weakSelf = self else {
-                return
-            }
-            //if the textfield is not empty then add a bookmark
-            //else dont do anything
-            let textField = weakSelf.alertController.textFields![0]
-            if !textField.text!.isEmpty {
-                weakSelf.addBookmark(withName: textField.text!)
-            }
+        let doneAction = UIAlertAction(title: "Done", style: .default) { [weak self, textField = alertController.textFields?.first] (_) in
+            // If the text field is empty, do nothing.
+            guard let text = textField?.text, !text.isEmpty else { return }
+            // Add the bookmark since the text isn't empty.
+            self?.addBookmark(withName: text)
         }
         
-        //add actions to alert controller
-        self.alertController.addAction(cancelAction)
-        self.alertController.addAction(doneAction)
+        // Add actions to alert controller.
+        alertController.addAction(cancelAction)
+        alertController.addAction(doneAction)
+        alertController.preferredAction = doneAction
         
-        //present alert controller
-        self.present(self.alertController, animated: true, completion: nil)
+        // Present alert controller.
+        if presentedViewController != nil {
+            dismiss(animated: false) {
+                self.present(alertController, animated: true)
+            }
+        } else {
+            present(alertController, animated: true)
+        }
     }
     
     private func addBookmark(withName name:String) {


### PR DESCRIPTION
- Removes conformance to `UIAlertViewDelegate`. This was an unnecessary holdover from `UIAlertController`.
- Removes `alertController` property. The alert controller was being stored but not reused. I don't even know if alert controllers can be reused, so I just removed it.
- Dismisses bookmark list before presenting the add bookmark view controller. This fixes a problem where the add button was enabled, but tapping it did nothing.