### PR TITLE
Changes class-bound protocols to inherit from AnyObject

### DIFF
--- a/arcgis-ios-sdk-samples/Analysis/Analyze hotspots/HotspotSettingsViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Analyze hotspots/HotspotSettingsViewController.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 
-protocol HotspotSettingsVCDelegate: class {
+protocol HotspotSettingsVCDelegate: AnyObject {
     
     func hotspotSettingsViewController(_ hotspotSettingsViewController: HotspotSettingsViewController, didSelectDates fromDate: String, toDate: String)
 }

--- a/arcgis-ios-sdk-samples/Analysis/Analyze hotspots/HotspotSettingsViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Analyze hotspots/HotspotSettingsViewController.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 
-protocol HotspotSettingsVCDelegate: AnyObject {
+protocol HotspotSettingsVCDelegate: class {
     
     func hotspotSettingsViewController(_ hotspotSettingsViewController: HotspotSettingsViewController, didSelectDates fromDate: String, toDate: String)
 }

--- a/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/AddStatisticDefinitionsViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/AddStatisticDefinitionsViewController.swift
@@ -16,7 +16,7 @@
 import UIKit
 import ArcGIS
 
-protocol AddStatisticDefinitionsViewControllerDelegate: AnyObject {
+protocol AddStatisticDefinitionsViewControllerDelegate: class {
     func addStatisticDefinitions(_ statisticDefinitions: [AGSStatisticDefinition])
 }
 

--- a/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/AddStatisticDefinitionsViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/AddStatisticDefinitionsViewController.swift
@@ -16,7 +16,7 @@
 import UIKit
 import ArcGIS
 
-protocol AddStatisticDefinitionsViewControllerDelegate: class {
+protocol AddStatisticDefinitionsViewControllerDelegate: AnyObject {
     func addStatisticDefinitions(_ statisticDefinitions: [AGSStatisticDefinition])
 }
 

--- a/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/GroupByFieldsViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/GroupByFieldsViewController.swift
@@ -16,7 +16,7 @@
 import UIKit
 import ArcGIS
 
-protocol GroupByFieldsViewControllerDelegate: class {
+protocol GroupByFieldsViewControllerDelegate: AnyObject {
     func setGrouping(with fieldNames: [String])
 }
 

--- a/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/GroupByFieldsViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/GroupByFieldsViewController.swift
@@ -16,7 +16,7 @@
 import UIKit
 import ArcGIS
 
-protocol GroupByFieldsViewControllerDelegate: AnyObject {
+protocol GroupByFieldsViewControllerDelegate: class {
     func setGrouping(with fieldNames: [String])
 }
 

--- a/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/OrderByFieldsViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/OrderByFieldsViewController.swift
@@ -16,7 +16,7 @@
 import UIKit
 import ArcGIS
 
-protocol OrderByFieldsViewControllerDelegate: class {
+protocol OrderByFieldsViewControllerDelegate: AnyObject {
     func setOrdering(with orderByFields: [AGSOrderBy])
 }
 

--- a/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/OrderByFieldsViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/OrderByFieldsViewController.swift
@@ -16,7 +16,7 @@
 import UIKit
 import ArcGIS
 
-protocol OrderByFieldsViewControllerDelegate: AnyObject {
+protocol OrderByFieldsViewControllerDelegate: class {
     func setOrdering(with orderByFields: [AGSOrderBy])
 }
 

--- a/arcgis-ios-sdk-samples/Analysis/Viewshed (location)/ViewshedSettingsVC.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Viewshed (location)/ViewshedSettingsVC.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 
-protocol ViewshedSettingsVCDelegate:class {
+protocol ViewshedSettingsVCDelegate: AnyObject {
     
     func viewshedSettingsVC(_ viewshedSettingsVC:ViewshedSettingsVC, didUpdateAnalysisOverlayVisibility analysisOverlayVisibility:Bool)
     func viewshedSettingsVC(_ viewshedSettingsVC:ViewshedSettingsVC, didUpdateFrustumOutlineVisibility frustumOutlineVisibility:Bool)

--- a/arcgis-ios-sdk-samples/Analysis/Viewshed (location)/ViewshedSettingsVC.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Viewshed (location)/ViewshedSettingsVC.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 
-protocol ViewshedSettingsVCDelegate: AnyObject {
+protocol ViewshedSettingsVCDelegate:class {
     
     func viewshedSettingsVC(_ viewshedSettingsVC:ViewshedSettingsVC, didUpdateAnalysisOverlayVisibility analysisOverlayVisibility:Bool)
     func viewshedSettingsVC(_ viewshedSettingsVC:ViewshedSettingsVC, didUpdateFrustumOutlineVisibility frustumOutlineVisibility:Bool)

--- a/arcgis-ios-sdk-samples/Cloud & Portal/Search for webmap by keyword/WebMapsCollectionViewController.swift
+++ b/arcgis-ios-sdk-samples/Cloud & Portal/Search for webmap by keyword/WebMapsCollectionViewController.swift
@@ -17,7 +17,7 @@
 import UIKit
 import ArcGIS
 
-protocol WebMapsCollectionViewControllerDelegate:class {
+protocol WebMapsCollectionViewControllerDelegate: AnyObject {
     
     func webMapsCollectionVC(_ webMapsCollectionVC:WebMapsCollectionViewController, didSelectWebMap webMap:AGSPortalItem)
 }

--- a/arcgis-ios-sdk-samples/Cloud & Portal/Search for webmap by keyword/WebMapsCollectionViewController.swift
+++ b/arcgis-ios-sdk-samples/Cloud & Portal/Search for webmap by keyword/WebMapsCollectionViewController.swift
@@ -17,7 +17,7 @@
 import UIKit
 import ArcGIS
 
-protocol WebMapsCollectionViewControllerDelegate: AnyObject {
+protocol WebMapsCollectionViewControllerDelegate:class {
     
     func webMapsCollectionVC(_ webMapsCollectionVC:WebMapsCollectionViewController, didSelectWebMap webMap:AGSPortalItem)
 }

--- a/arcgis-ios-sdk-samples/Content Display Logic/Views/CustomSearchHeaderView.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Views/CustomSearchHeaderView.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 
-protocol CustomSearchHeaderViewDelegate: AnyObject {
+protocol CustomSearchHeaderViewDelegate:class {
     func customSearchHeaderViewWillShowSuggestions(_ customSearchHeaderView:CustomSearchHeaderView)
     func customSearchHeaderViewWillHideSuggestions(_ customSearchHeaderView:CustomSearchHeaderView)
     func customSearchHeaderView(_ customSearchHeaderView:CustomSearchHeaderView, didFindSamples sampleNames:[String]?)

--- a/arcgis-ios-sdk-samples/Content Display Logic/Views/CustomSearchHeaderView.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Views/CustomSearchHeaderView.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 
-protocol CustomSearchHeaderViewDelegate:class {
+protocol CustomSearchHeaderViewDelegate: AnyObject {
     func customSearchHeaderViewWillShowSuggestions(_ customSearchHeaderView:CustomSearchHeaderView)
     func customSearchHeaderViewWillHideSuggestions(_ customSearchHeaderView:CustomSearchHeaderView)
     func customSearchHeaderView(_ customSearchHeaderView:CustomSearchHeaderView, didFindSamples sampleNames:[String]?)

--- a/arcgis-ios-sdk-samples/Content Display Logic/Views/DownloadProgressView.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Views/DownloadProgressView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-@objc protocol DownloadProgressViewDelegate:class {
+@objc protocol DownloadProgressViewDelegate: AnyObject {
     
     @objc optional func downloadProgressViewDidCancel(downloadProgressView:DownloadProgressView)
 }

--- a/arcgis-ios-sdk-samples/Content Display Logic/Views/DownloadProgressView.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Views/DownloadProgressView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-@objc protocol DownloadProgressViewDelegate: AnyObject {
+@objc protocol DownloadProgressViewDelegate:class {
     
     @objc optional func downloadProgressViewDidCancel(downloadProgressView:DownloadProgressView)
 }

--- a/arcgis-ios-sdk-samples/Edit data/Edit features (connected)/FeatureTemplatePickerViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit features (connected)/FeatureTemplatePickerViewController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import ArcGIS
 
-protocol FeatureTemplatePickerDelegate:class {
+protocol FeatureTemplatePickerDelegate: AnyObject {
     func featureTemplatePickerViewControllerWantsToDismiss(_ controller:FeatureTemplatePickerViewController)
     func featureTemplatePickerViewController(_ controller:FeatureTemplatePickerViewController, didSelectFeatureTemplate template:AGSFeatureTemplate, forFeatureLayer featureLayer:AGSFeatureLayer)
 }

--- a/arcgis-ios-sdk-samples/Edit data/Edit features (connected)/FeatureTemplatePickerViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit features (connected)/FeatureTemplatePickerViewController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import ArcGIS
 
-protocol FeatureTemplatePickerDelegate: AnyObject {
+protocol FeatureTemplatePickerDelegate:class {
     func featureTemplatePickerViewControllerWantsToDismiss(_ controller:FeatureTemplatePickerViewController)
     func featureTemplatePickerViewController(_ controller:FeatureTemplatePickerViewController, didSelectFeatureTemplate template:AGSFeatureTemplate, forFeatureLayer featureLayer:AGSFeatureLayer)
 }

--- a/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/EAOptionsViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/EAOptionsViewController.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 
-protocol EAOptionsVCDelegate:class {
+protocol EAOptionsVCDelegate: AnyObject {
     func optionsViewController(_ optionsViewController:EAOptionsViewController, didSelectOptionAtIndex index:Int)
 }
 

--- a/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/EAOptionsViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/EAOptionsViewController.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 
-protocol EAOptionsVCDelegate: AnyObject {
+protocol EAOptionsVCDelegate:class {
     func optionsViewController(_ optionsViewController:EAOptionsViewController, didSelectOptionAtIndex index:Int)
 }
 

--- a/arcgis-ios-sdk-samples/Geometry/Spatial operations/OperationsListViewController.swift
+++ b/arcgis-ios-sdk-samples/Geometry/Spatial operations/OperationsListViewController.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 
-protocol OperationsListVCDelegate: class {
+protocol OperationsListVCDelegate: AnyObject {
     
     func operationsListViewController(_ operationsListViewController: OperationsListViewController, didSelectOperation index: Int)
 }

--- a/arcgis-ios-sdk-samples/Geometry/Spatial operations/OperationsListViewController.swift
+++ b/arcgis-ios-sdk-samples/Geometry/Spatial operations/OperationsListViewController.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 
-protocol OperationsListVCDelegate: AnyObject {
+protocol OperationsListVCDelegate: class {
     
     func operationsListViewController(_ operationsListViewController: OperationsListViewController, didSelectOperation index: Int)
 }

--- a/arcgis-ios-sdk-samples/Layers/ArcGIS tiled layer (tile cache)/TilePackagesListViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/ArcGIS tiled layer (tile cache)/TilePackagesListViewController.swift
@@ -15,7 +15,7 @@
 
 import UIKit
 
-protocol TilePackagesListVCDelegate:class {
+protocol TilePackagesListVCDelegate: AnyObject {
     func tilePackagesListViewController(_ tilePackagesListViewController:TilePackagesListViewController, didSelectTPKWithPath path:String)
 }
 

--- a/arcgis-ios-sdk-samples/Layers/ArcGIS tiled layer (tile cache)/TilePackagesListViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/ArcGIS tiled layer (tile cache)/TilePackagesListViewController.swift
@@ -15,7 +15,7 @@
 
 import UIKit
 
-protocol TilePackagesListVCDelegate: AnyObject {
+protocol TilePackagesListVCDelegate:class {
     func tilePackagesListViewController(_ tilePackagesListViewController:TilePackagesListViewController, didSelectTPKWithPath path:String)
 }
 

--- a/arcgis-ios-sdk-samples/Layers/ArcGIS vector tiled layer (custom style)/VectorStylesViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/ArcGIS vector tiled layer (custom style)/VectorStylesViewController.swift
@@ -16,7 +16,7 @@
 
 import UIKit
 
-protocol VectorStylesVCDelegate: class {
+protocol VectorStylesVCDelegate: AnyObject {
     
     func vectorStylesViewController(_ vectorStylesViewController: VectorStylesViewController, didSelectItemWithID itemID:String)
 }

--- a/arcgis-ios-sdk-samples/Layers/ArcGIS vector tiled layer (custom style)/VectorStylesViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/ArcGIS vector tiled layer (custom style)/VectorStylesViewController.swift
@@ -16,7 +16,7 @@
 
 import UIKit
 
-protocol VectorStylesVCDelegate: AnyObject {
+protocol VectorStylesVCDelegate: class {
     
     func vectorStylesViewController(_ vectorStylesViewController: VectorStylesViewController, didSelectItemWithID itemID:String)
 }

--- a/arcgis-ios-sdk-samples/Layers/Blend renderer/BlendRendererSettingsVC.swift
+++ b/arcgis-ios-sdk-samples/Layers/Blend renderer/BlendRendererSettingsVC.swift
@@ -16,7 +16,7 @@
 import UIKit
 import ArcGIS
 
-protocol BlendRendererSettingsVCDelegate: class {
+protocol BlendRendererSettingsVCDelegate: AnyObject {
     
     func blendRendererSettingsVC(_ blendRendererSettingsVC: BlendRendererSettingsVC, selectedAltitude altitude: Double, azimuth: Double, slopeType: AGSSlopeType, colorRampType: AGSPresetColorRampType)
 }

--- a/arcgis-ios-sdk-samples/Layers/Blend renderer/BlendRendererSettingsVC.swift
+++ b/arcgis-ios-sdk-samples/Layers/Blend renderer/BlendRendererSettingsVC.swift
@@ -16,7 +16,7 @@
 import UIKit
 import ArcGIS
 
-protocol BlendRendererSettingsVCDelegate: AnyObject {
+protocol BlendRendererSettingsVCDelegate: class {
     
     func blendRendererSettingsVC(_ blendRendererSettingsVC: BlendRendererSettingsVC, selectedAltitude altitude: Double, azimuth: Double, slopeType: AGSSlopeType, colorRampType: AGSPresetColorRampType)
 }

--- a/arcgis-ios-sdk-samples/Layers/Hillshade renderer/HillshadeSettingsVC.swift
+++ b/arcgis-ios-sdk-samples/Layers/Hillshade renderer/HillshadeSettingsVC.swift
@@ -15,7 +15,7 @@
 import UIKit
 import ArcGIS
 
-protocol HillshadeSettingsDelegate: AnyObject {
+protocol HillshadeSettingsDelegate: class {
     
     func hillshadeSettingsVC(_ hillshadeSettingsVC: HillshadeSettingsVC, selectedAltitude altitude: Double, azimuth: Double, slopeType: AGSSlopeType)
 }

--- a/arcgis-ios-sdk-samples/Layers/Hillshade renderer/HillshadeSettingsVC.swift
+++ b/arcgis-ios-sdk-samples/Layers/Hillshade renderer/HillshadeSettingsVC.swift
@@ -15,7 +15,7 @@
 import UIKit
 import ArcGIS
 
-protocol HillshadeSettingsDelegate: class {
+protocol HillshadeSettingsDelegate: AnyObject {
     
     func hillshadeSettingsVC(_ hillshadeSettingsVC: HillshadeSettingsVC, selectedAltitude altitude: Double, azimuth: Double, slopeType: AGSSlopeType)
 }

--- a/arcgis-ios-sdk-samples/Layers/Manage sublayers/MapImageSublayersVC.swift
+++ b/arcgis-ios-sdk-samples/Layers/Manage sublayers/MapImageSublayersVC.swift
@@ -16,7 +16,7 @@
 import UIKit
 import ArcGIS
 
-protocol MapImageSublayersVCDelegate: AnyObject {
+protocol MapImageSublayersVCDelegate:class {
     
     func mapImageSublayersVC(mapImageSublayersVC: MapImageSublayersVC, didCloseWith removedMapImageSublayers:[AGSArcGISMapImageSublayer])
 }

--- a/arcgis-ios-sdk-samples/Layers/Manage sublayers/MapImageSublayersVC.swift
+++ b/arcgis-ios-sdk-samples/Layers/Manage sublayers/MapImageSublayersVC.swift
@@ -16,7 +16,7 @@
 import UIKit
 import ArcGIS
 
-protocol MapImageSublayersVCDelegate:class {
+protocol MapImageSublayersVCDelegate: AnyObject {
     
     func mapImageSublayersVC(mapImageSublayersVC: MapImageSublayersVC, didCloseWith removedMapImageSublayers:[AGSArcGISMapImageSublayer])
 }

--- a/arcgis-ios-sdk-samples/Layers/RGB renderer/RGBRendererSettingsVC.swift
+++ b/arcgis-ios-sdk-samples/Layers/RGB renderer/RGBRendererSettingsVC.swift
@@ -16,7 +16,7 @@
 import UIKit
 import ArcGIS
 
-protocol RGBRendererSettingsVCDelegate:class {
+protocol RGBRendererSettingsVCDelegate: AnyObject {
     
     func rgbRendererSettingsVC(_ rgbRendererSettingsVC: RGBRendererSettingsVC, didSelectStretchParameters parameters: AGSStretchParameters)
 }

--- a/arcgis-ios-sdk-samples/Layers/RGB renderer/RGBRendererSettingsVC.swift
+++ b/arcgis-ios-sdk-samples/Layers/RGB renderer/RGBRendererSettingsVC.swift
@@ -16,7 +16,7 @@
 import UIKit
 import ArcGIS
 
-protocol RGBRendererSettingsVCDelegate: AnyObject {
+protocol RGBRendererSettingsVCDelegate:class {
     
     func rgbRendererSettingsVC(_ rgbRendererSettingsVC: RGBRendererSettingsVC, didSelectStretchParameters parameters: AGSStretchParameters)
 }

--- a/arcgis-ios-sdk-samples/Layers/RGB renderer/RGBRendererTypeCell.swift
+++ b/arcgis-ios-sdk-samples/Layers/RGB renderer/RGBRendererTypeCell.swift
@@ -15,7 +15,7 @@
 
 import UIKit
 
-protocol RGBRendererTypeCellDelegate: class {
+protocol RGBRendererTypeCellDelegate: AnyObject {
     
     func rgbRendererTypeCell(_ rgbRendererTypeCell: RGBRendererTypeCell, didUpdateType type: StretchType)
 }

--- a/arcgis-ios-sdk-samples/Layers/RGB renderer/RGBRendererTypeCell.swift
+++ b/arcgis-ios-sdk-samples/Layers/RGB renderer/RGBRendererTypeCell.swift
@@ -15,7 +15,7 @@
 
 import UIKit
 
-protocol RGBRendererTypeCellDelegate: AnyObject {
+protocol RGBRendererTypeCellDelegate: class {
     
     func rgbRendererTypeCell(_ rgbRendererTypeCell: RGBRendererTypeCell, didUpdateType type: StretchType)
 }

--- a/arcgis-ios-sdk-samples/Layers/Stretch renderer/StretchRendererSettingsVC.swift
+++ b/arcgis-ios-sdk-samples/Layers/Stretch renderer/StretchRendererSettingsVC.swift
@@ -37,7 +37,7 @@ enum StretchType: String {
     }
 }
 
-protocol StretchRendererSettingsVCDelegate:class {
+protocol StretchRendererSettingsVCDelegate: AnyObject {
     
     func stretchRendererSettingsVC(_ stretchRendererSettingsVC: StretchRendererSettingsVC, didSelectStretchParameters parameters: AGSStretchParameters)
 }

--- a/arcgis-ios-sdk-samples/Layers/Stretch renderer/StretchRendererSettingsVC.swift
+++ b/arcgis-ios-sdk-samples/Layers/Stretch renderer/StretchRendererSettingsVC.swift
@@ -37,7 +37,7 @@ enum StretchType: String {
     }
 }
 
-protocol StretchRendererSettingsVCDelegate: AnyObject {
+protocol StretchRendererSettingsVCDelegate:class {
     
     func stretchRendererSettingsVC(_ stretchRendererSettingsVC: StretchRendererSettingsVC, didSelectStretchParameters parameters: AGSStretchParameters)
 }

--- a/arcgis-ios-sdk-samples/Layers/Stretch renderer/StretchRendererTypeCell.swift
+++ b/arcgis-ios-sdk-samples/Layers/Stretch renderer/StretchRendererTypeCell.swift
@@ -15,7 +15,7 @@
 
 import UIKit
 
-protocol StretchRendererTypeCellDelegate: class {
+protocol StretchRendererTypeCellDelegate: AnyObject {
     
     func stretchRendererTypeCell(_ stretchRendererTypeCell: StretchRendererTypeCell, didUpdateType type: StretchType)
 }

--- a/arcgis-ios-sdk-samples/Layers/Stretch renderer/StretchRendererTypeCell.swift
+++ b/arcgis-ios-sdk-samples/Layers/Stretch renderer/StretchRendererTypeCell.swift
@@ -15,7 +15,7 @@
 
 import UIKit
 
-protocol StretchRendererTypeCellDelegate: AnyObject {
+protocol StretchRendererTypeCellDelegate: class {
     
     func stretchRendererTypeCell(_ stretchRendererTypeCell: StretchRendererTypeCell, didUpdateType type: StretchType)
 }

--- a/arcgis-ios-sdk-samples/Maps/Change map view background/GridSettingsViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Change map view background/GridSettingsViewController.swift
@@ -26,7 +26,7 @@ enum AnimationDirection: String {
     case Backward = "Backward"
 }
 
-protocol GridSettingsVCDelegate: class {
+protocol GridSettingsVCDelegate: AnyObject {
     
     func gridSettingsViewController(_ gridSettingsViewController: GridSettingsViewController, didUpdateBackgroundGrid grid: AGSBackgroundGrid)
     

--- a/arcgis-ios-sdk-samples/Maps/Change map view background/GridSettingsViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Change map view background/GridSettingsViewController.swift
@@ -26,7 +26,7 @@ enum AnimationDirection: String {
     case Backward = "Backward"
 }
 
-protocol GridSettingsVCDelegate: AnyObject {
+protocol GridSettingsVCDelegate: class {
     
     func gridSettingsViewController(_ gridSettingsViewController: GridSettingsViewController, didUpdateBackgroundGrid grid: AGSBackgroundGrid)
     

--- a/arcgis-ios-sdk-samples/Maps/Create and save a map/CreateOptionsViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Create and save a map/CreateOptionsViewController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import ArcGIS
 
-protocol CreateOptionsVCDelegate: AnyObject {
+protocol CreateOptionsVCDelegate:class {
     func createOptionsViewController(_ createOptionsViewController:CreateOptionsViewController, didSelectBasemap basemap:AGSBasemap, layers:[AGSLayer]?)
 }
 

--- a/arcgis-ios-sdk-samples/Maps/Create and save a map/CreateOptionsViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Create and save a map/CreateOptionsViewController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import ArcGIS
 
-protocol CreateOptionsVCDelegate:class {
+protocol CreateOptionsVCDelegate: AnyObject {
     func createOptionsViewController(_ createOptionsViewController:CreateOptionsViewController, didSelectBasemap basemap:AGSBasemap, layers:[AGSLayer]?)
 }
 

--- a/arcgis-ios-sdk-samples/Maps/Create and save a map/SaveAsViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Create and save a map/SaveAsViewController.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 
-protocol SaveAsVCDelegate:class {
+protocol SaveAsVCDelegate: AnyObject {
     func saveAsViewController(_ saveAsViewController: SaveAsViewController, didInitiateSaveWithTitle title: String, tags: [String], itemDescription: String)
     func saveAsViewControllerDidCancel(_ saveAsViewController:SaveAsViewController)
 }

--- a/arcgis-ios-sdk-samples/Maps/Create and save a map/SaveAsViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Create and save a map/SaveAsViewController.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 
-protocol SaveAsVCDelegate: AnyObject {
+protocol SaveAsVCDelegate:class {
     func saveAsViewController(_ saveAsViewController: SaveAsViewController, didInitiateSaveWithTitle title: String, tags: [String], itemDescription: String)
     func saveAsViewControllerDidCancel(_ saveAsViewController:SaveAsViewController)
 }

--- a/arcgis-ios-sdk-samples/Maps/Display device location/CustomContextSheet.swift
+++ b/arcgis-ios-sdk-samples/Maps/Display device location/CustomContextSheet.swift
@@ -16,7 +16,7 @@
 
 import UIKit
 
-protocol CustomContextSheetDelegate:class {
+protocol CustomContextSheetDelegate: AnyObject {
     func customContextSheet(_ customContextSheet:CustomContextSheet, didSelectItemAtIndex index:Int)
 }
 

--- a/arcgis-ios-sdk-samples/Maps/Display device location/CustomContextSheet.swift
+++ b/arcgis-ios-sdk-samples/Maps/Display device location/CustomContextSheet.swift
@@ -16,7 +16,7 @@
 
 import UIKit
 
-protocol CustomContextSheetDelegate: AnyObject {
+protocol CustomContextSheetDelegate:class {
     func customContextSheet(_ customContextSheet:CustomContextSheet, didSelectItemAtIndex index:Int)
 }
 

--- a/arcgis-ios-sdk-samples/Maps/Manage operational layers/MMLLayersViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Manage operational layers/MMLLayersViewController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import ArcGIS
 
-protocol MMLLayersViewControllerDelegate: AnyObject {
+protocol MMLLayersViewControllerDelegate: class {
     func layersViewControllerWantsToClose(_ layersViewController: MMLLayersViewController, withDeletedLayers layers: [AGSLayer])
 }
 

--- a/arcgis-ios-sdk-samples/Maps/Manage operational layers/MMLLayersViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Manage operational layers/MMLLayersViewController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import ArcGIS
 
-protocol MMLLayersViewControllerDelegate: class {
+protocol MMLLayersViewControllerDelegate: AnyObject {
     func layersViewControllerWantsToClose(_ layersViewController: MMLLayersViewController, withDeletedLayers layers: [AGSLayer])
 }
 

--- a/arcgis-ios-sdk-samples/Maps/Mobile map (search and route)/MapPackageCell.swift
+++ b/arcgis-ios-sdk-samples/Maps/Mobile map (search and route)/MapPackageCell.swift
@@ -16,7 +16,7 @@
 import UIKit
 import ArcGIS
 
-protocol MapPackageCellDelegate: AnyObject {
+protocol MapPackageCellDelegate:class {
     
     func mapPackageCell(_ mapPackageCell:MapPackageCell, didSelectMap map:AGSMap)
 }

--- a/arcgis-ios-sdk-samples/Maps/Mobile map (search and route)/MapPackageCell.swift
+++ b/arcgis-ios-sdk-samples/Maps/Mobile map (search and route)/MapPackageCell.swift
@@ -16,7 +16,7 @@
 import UIKit
 import ArcGIS
 
-protocol MapPackageCellDelegate:class {
+protocol MapPackageCellDelegate: AnyObject {
     
     func mapPackageCell(_ mapPackageCell:MapPackageCell, didSelectMap map:AGSMap)
 }

--- a/arcgis-ios-sdk-samples/Route & Directions/Find service area interactive/ServiceAreaSettingsVC.swift
+++ b/arcgis-ios-sdk-samples/Route & Directions/Find service area interactive/ServiceAreaSettingsVC.swift
@@ -15,7 +15,7 @@
 
 import UIKit
 
-protocol ServiceAreaSettingsVCDelegate:class {
+protocol ServiceAreaSettingsVCDelegate: AnyObject {
     
     func serviceAreaSettingsVC(_ serviceAreaSettingsVC:ServiceAreaSettingsVC, didUpdateFirstTimeBreak timeBreak:Int)
     

--- a/arcgis-ios-sdk-samples/Route & Directions/Find service area interactive/ServiceAreaSettingsVC.swift
+++ b/arcgis-ios-sdk-samples/Route & Directions/Find service area interactive/ServiceAreaSettingsVC.swift
@@ -15,7 +15,7 @@
 
 import UIKit
 
-protocol ServiceAreaSettingsVCDelegate: AnyObject {
+protocol ServiceAreaSettingsVCDelegate:class {
     
     func serviceAreaSettingsVC(_ serviceAreaSettingsVC:ServiceAreaSettingsVC, didUpdateFirstTimeBreak timeBreak:Int)
     

--- a/arcgis-ios-sdk-samples/Route & Directions/Route around barriers/DirectionsListViewController.swift
+++ b/arcgis-ios-sdk-samples/Route & Directions/Route around barriers/DirectionsListViewController.swift
@@ -16,7 +16,7 @@
 import UIKit
 import ArcGIS
 
-protocol DirectionsListVCDelegate:class {
+protocol DirectionsListVCDelegate: AnyObject {
     func directionsListViewController(_ directionsListViewController:DirectionsListViewController, didSelectDirectionManuever directionManeuver:AGSDirectionManeuver)
     func directionsListViewControllerDidDeleteRoute(_ directionsListViewController:DirectionsListViewController)
 }

--- a/arcgis-ios-sdk-samples/Route & Directions/Route around barriers/DirectionsListViewController.swift
+++ b/arcgis-ios-sdk-samples/Route & Directions/Route around barriers/DirectionsListViewController.swift
@@ -16,7 +16,7 @@
 import UIKit
 import ArcGIS
 
-protocol DirectionsListVCDelegate: AnyObject {
+protocol DirectionsListVCDelegate:class {
     func directionsListViewController(_ directionsListViewController:DirectionsListViewController, didSelectDirectionManuever directionManeuver:AGSDirectionManeuver)
     func directionsListViewControllerDidDeleteRoute(_ directionsListViewController:DirectionsListViewController)
 }

--- a/arcgis-ios-sdk-samples/Scenes/Animate 3D graphic/MissionSettingsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Animate 3D graphic/MissionSettingsViewController.swift
@@ -15,7 +15,7 @@
 
 import UIKit
 
-protocol MissionSettingsVCDelegate:class {
+protocol MissionSettingsVCDelegate: AnyObject {
     
     func missionSettingsViewController(_ missionSettingsViewController:MissionSettingsViewController, didSelectMissionAtIndex index:Int)
     

--- a/arcgis-ios-sdk-samples/Scenes/Animate 3D graphic/MissionSettingsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Animate 3D graphic/MissionSettingsViewController.swift
@@ -15,7 +15,7 @@
 
 import UIKit
 
-protocol MissionSettingsVCDelegate: AnyObject {
+protocol MissionSettingsVCDelegate:class {
     
     func missionSettingsViewController(_ missionSettingsViewController:MissionSettingsViewController, didSelectMissionAtIndex index:Int)
     

--- a/arcgis-ios-sdk-samples/Search/Find address/WorldAddressesViewController.swift
+++ b/arcgis-ios-sdk-samples/Search/Find address/WorldAddressesViewController.swift
@@ -15,7 +15,7 @@
 import UIKit
 
 
-protocol WorldAddressesVCDelegate:class {
+protocol WorldAddressesVCDelegate: AnyObject {
     func worldAddressesViewController(_ worldAddressesViewController: WorldAddressesViewController, didSelectAddress address:String)
 }
     

--- a/arcgis-ios-sdk-samples/Search/Find address/WorldAddressesViewController.swift
+++ b/arcgis-ios-sdk-samples/Search/Find address/WorldAddressesViewController.swift
@@ -15,7 +15,7 @@
 import UIKit
 
 
-protocol WorldAddressesVCDelegate: AnyObject {
+protocol WorldAddressesVCDelegate:class {
     func worldAddressesViewController(_ worldAddressesViewController: WorldAddressesViewController, didSelectAddress address:String)
 }
     

--- a/arcgis-ios-sdk-samples/Search/Offline geocode/SanDiegoAddressesViewController.swift
+++ b/arcgis-ios-sdk-samples/Search/Offline geocode/SanDiegoAddressesViewController.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 
-protocol SanDiegoAddressesVCDelegate:class {
+protocol SanDiegoAddressesVCDelegate: AnyObject {
     func sanDiegoAddressesViewController(_ sanDiegoAddressesViewController: SanDiegoAddressesViewController, didSelectAddress address:String)
 }
 

--- a/arcgis-ios-sdk-samples/Search/Offline geocode/SanDiegoAddressesViewController.swift
+++ b/arcgis-ios-sdk-samples/Search/Offline geocode/SanDiegoAddressesViewController.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 
-protocol SanDiegoAddressesVCDelegate: AnyObject {
+protocol SanDiegoAddressesVCDelegate:class {
     func sanDiegoAddressesViewController(_ sanDiegoAddressesViewController: SanDiegoAddressesViewController, didSelectAddress address:String)
 }
 

--- a/arcgis-ios-sdk-samples/Shared resources/Libraries/HorizontalPicker/HorizontalColorPicker.swift
+++ b/arcgis-ios-sdk-samples/Shared resources/Libraries/HorizontalPicker/HorizontalColorPicker.swift
@@ -16,7 +16,7 @@
 
 import UIKit
 
-protocol HorizontalColorPickerDelegate: AnyObject {
+protocol HorizontalColorPickerDelegate: class {
     func horizontalColorPicker(_ horizontalColorPicker:HorizontalColorPicker, didUpdateSelectedColor color: UIColor)
 }
 

--- a/arcgis-ios-sdk-samples/Shared resources/Libraries/HorizontalPicker/HorizontalColorPicker.swift
+++ b/arcgis-ios-sdk-samples/Shared resources/Libraries/HorizontalPicker/HorizontalColorPicker.swift
@@ -16,7 +16,7 @@
 
 import UIKit
 
-protocol HorizontalColorPickerDelegate: class {
+protocol HorizontalColorPickerDelegate: AnyObject {
     func horizontalColorPicker(_ horizontalColorPicker:HorizontalColorPicker, didUpdateSelectedColor color: UIColor)
 }
 

--- a/arcgis-ios-sdk-samples/Shared resources/Libraries/HorizontalPicker/HorizontalPicker.swift
+++ b/arcgis-ios-sdk-samples/Shared resources/Libraries/HorizontalPicker/HorizontalPicker.swift
@@ -16,7 +16,7 @@
 
 import UIKit
 
-protocol HorizontalPickerDelegate: AnyObject {
+protocol HorizontalPickerDelegate: class {
     func horizontalPicker(_ horizontalPicker:HorizontalPicker, didUpdateSelectedIndex index: Int)
 }
 

--- a/arcgis-ios-sdk-samples/Shared resources/Libraries/HorizontalPicker/HorizontalPicker.swift
+++ b/arcgis-ios-sdk-samples/Shared resources/Libraries/HorizontalPicker/HorizontalPicker.swift
@@ -16,7 +16,7 @@
 
 import UIKit
 
-protocol HorizontalPickerDelegate: class {
+protocol HorizontalPickerDelegate: AnyObject {
     func horizontalPicker(_ horizontalPicker:HorizontalPicker, didUpdateSelectedIndex index: Int)
 }
 


### PR DESCRIPTION
I switched all class-only protocol definitions to the [recommended syntax](https://docs.swift.org/swift-book/LanguageGuide/Protocols.html#ID281): using `protocol MyObjectDelegate: AnyObject { … }` rather than `protocol MyObjectDelegate: class { … }`