### PR TITLE
Fix references to images retrieved from ArcGIS.bundle.

### DIFF
--- a/arcgis-ios-sdk-samples/Edit data/Edit feature attachments/AttachmentsListViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit feature attachments/AttachmentsListViewController.swift
@@ -94,7 +94,7 @@ class AttachmentsListViewController: UIViewController, UITableViewDataSource, UI
         let attachment = self.attachments[indexPath.row]
         cell.textLabel?.text = attachment.name
         
-        cell.imageView?.image = UIImage(named: "ArcGIS.bundle/CloudDownload")
+        cell.imageView?.image = UIImage(named: "CloudDownload", in: AGSBundle(), compatibleWith: nil)
         cell.imageView?.contentMode = UIViewContentMode.scaleAspectFit
         cell.imageView?.autoresizingMask = UIViewAutoresizing()
         cell.imageView?.clipsToBounds = true

--- a/arcgis-ios-sdk-samples/Search/Offline geocode/OfflineGeocodeViewController.swift
+++ b/arcgis-ios-sdk-samples/Search/Offline geocode/OfflineGeocodeViewController.swift
@@ -80,7 +80,7 @@ class GeocodeOfflineViewController: UIViewController, AGSGeoViewTouchDelegate, U
         
         //the total amount by which we will need to offset the callout along y-axis
         //to show it correctly centered on the pushpin's head in the magnifier
-        let img = UIImage(named: "ArcGIS.bundle/Magnifier.png")!
+        let img = UIImage(named: "Magnifier", in: AGSBundle(), compatibleWith: nil)!
         self.magnifierOffset = CGPoint(x: 0, y: -img.size.height)
     }
     


### PR DESCRIPTION
These crash in the simulator when running from Xcode. However, the published 100.3.0 app doesn't crash (🤔 any thoughts on that, @philium?).

Either way I think the update is desirable.