### PR TITLE
Prevents the table view from being loaded prematurely.

### DIFF
--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ContentTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ContentTableViewController.swift
@@ -19,7 +19,8 @@ class ContentTableViewController: UITableViewController {
     /// The samples to display in the table. Searching adjusts this value
     var displayedSamples = [Sample](){
         didSet{
-            tableView?.reloadData()
+            guard isViewLoaded else { return }
+            tableView.reloadData()
         }
     }
     


### PR DESCRIPTION
The problem is that the table view is loaded on demand, so accessing the property causes it to load if it isn't already.