### PR TITLE
Adds missing import statement

### DIFF
--- a/arcgis-ios-sdk-samples/Content Display Logic/Model/Sample.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Model/Sample.swift
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+import Foundation
+
 struct Sample: Hashable {
     
     var name: String


### PR DESCRIPTION
The file uses `URL`, but it wasn't being imported.