### PR TITLE
Identify KML Features: Removes reference to web view in README

### DIFF
--- a/arcgis-ios-sdk-samples/Layers/Identify KML features/README.md
+++ b/arcgis-ios-sdk-samples/Layers/Identify KML features/README.md
@@ -16,7 +16,7 @@ Note: the KML layer used in this sample contains a screen overlay. The screen ov
 2. Any existing callout is dismissed using `AGSCallout.dismiss()`
 3. `AGSGeoView.identifyLayer(_:screenPoint:tolerance:returnPopupsOnly:completion:)` is called with a reference to the KML layer, the tapped position, and a tolerance of `15` points.
 4. There are several types of KML features. This sample will only identify features of type `AGSKMLPlacemark`
-5. The `balloonContent` of the first returned KML placemark is then shown in a webview in a callout.
+5. The `balloonContent` of the first returned KML placemark is then shown in a callout.
 
 ## Relevant API
 


### PR DESCRIPTION
The sample doesn't use a web view anymore.