### PR TITLE
Makes PlaneStatsViewController more useful

### DIFF
--- a/arcgis-ios-sdk-samples/Scenes/Animate 3D graphic/PlaneStatsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Animate 3D graphic/PlaneStatsViewController.swift
@@ -16,10 +16,57 @@
 import UIKit
 
 class PlaneStatsViewController: UITableViewController {
+    var frame: Frame? {
+        didSet {
+            updateUI()
+        }
+    }
+    let measurementFormatter: MeasurementFormatter = {
+        let formatter = MeasurementFormatter()
+        formatter.numberFormatter.maximumFractionDigits = 0
+        formatter.unitOptions = .providedUnit
+        return formatter
+    }()
     
-    @IBOutlet var altitudeLabel: UILabel!
-    @IBOutlet var headingLabel: UILabel!
-    @IBOutlet var pitchLabel: UILabel!
-    @IBOutlet var rollLabel: UILabel!
+    @IBOutlet private var altitudeLabel: UILabel!
+    @IBOutlet private var headingLabel: UILabel!
+    @IBOutlet private var pitchLabel: UILabel!
+    @IBOutlet private var rollLabel: UILabel!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        updateUI()
+    }
+    
+    private var tableViewContentSizeObservation: NSKeyValueObservation?
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        tableViewContentSizeObservation = tableView.observe(\.contentSize) { [unowned self] (tableView, _) in
+            self.preferredContentSize = CGSize(width: self.preferredContentSize.width, height: tableView.contentSize.height)
+        }
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        tableViewContentSizeObservation = nil
+    }
+    
+    func updateUI() {
+        guard isViewLoaded else { return }
+        if let frame = frame {
+            measurementFormatter.unitStyle = .medium
+            altitudeLabel.text = measurementFormatter.string(from: frame.altitude)
+            measurementFormatter.unitStyle = .short
+            headingLabel.text = measurementFormatter.string(from: frame.heading)
+            pitchLabel.text = measurementFormatter.string(from: frame.pitch)
+            rollLabel.text = measurementFormatter.string(from: frame.roll)
+        } else {
+            altitudeLabel.text = ""
+            headingLabel.text = ""
+            pitchLabel.text = ""
+            rollLabel.text = ""
+        }
+    }
     
 }


### PR DESCRIPTION
Also uses measurement formatter for display of altitude, heading, pitch, and roll.

I realize you aren't responsible for `PlaneStatsViewController` being so simple, but it is nice to make it pull its own weight. And using measurement formatter for displaying value+symbol is a better pattern to model.