### PR TITLE
Enables the identifier_name SwiftLint rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -14,7 +14,6 @@ disabled_rules: # rule identifiers to exclude from running
   - for_where
   - force_cast
   - function_body_length
-  - identifier_name
   - line_length
   - notification_center_detachment
   - todo
@@ -70,3 +69,9 @@ opt_in_rules: # some rules are only opt-in
   - untyped_error_in_catch
   - vertical_parameter_alignment_on_call
   - yoda_condition
+
+identifier_name:
+  excluded: # allowed non-conforming identifiers
+    - x
+    - y
+    - z

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -71,7 +71,5 @@ opt_in_rules: # some rules are only opt-in
   - yoda_condition
 
 identifier_name:
-  excluded: # allowed non-conforming identifiers
-    - x
-    - y
-    - z
+  min_length:
+    warning: 0 # do not flag short identifiers

--- a/arcgis-ios-sdk-samples/Analysis/Analyze hotspots/AnalyzeHotspotsViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Analyze hotspots/AnalyzeHotspotsViewController.swift
@@ -105,8 +105,8 @@ class AnalyzeHotspotsViewController: UIViewController, HotspotSettingsVCDelegate
     
     func hotspotSettingsViewController(_ hotspotSettingsViewController: HotspotSettingsViewController, didSelectDates fromDate: String, toDate: String) {
         
-        self.analyzeHotspots(fromDate, toDate: toDate)
-        self.toggleSettingsView(visible: false)
+        analyzeHotspots(fromDate, toDate: toDate)
+        setSettingsViewVisibility(visible: false)
     }
     
     // MARK: - Navigation
@@ -120,13 +120,13 @@ class AnalyzeHotspotsViewController: UIViewController, HotspotSettingsVCDelegate
     
     // MARK: - Toggle settings view
     
-    private func toggleSettingsView(visible: Bool) {
-        self.containerView.isHidden = !visible
+    private func setSettingsViewVisibility(visible: Bool) {
+        containerView.isHidden = !visible
     }
     
     // MARK: - Actions
     
     @IBAction func changeDatesAction() {
-        self.toggleSettingsView(visible: true)
+        setSettingsViewVisibility(visible: true)
     }
 }

--- a/arcgis-ios-sdk-samples/Analysis/Analyze hotspots/AnalyzeHotspotsViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Analyze hotspots/AnalyzeHotspotsViewController.swift
@@ -106,7 +106,7 @@ class AnalyzeHotspotsViewController: UIViewController, HotspotSettingsVCDelegate
     func hotspotSettingsViewController(_ hotspotSettingsViewController: HotspotSettingsViewController, didSelectDates fromDate: String, toDate: String) {
         
         self.analyzeHotspots(fromDate, toDate: toDate)
-        self.toggleSettingsView(on: false)
+        self.toggleSettingsView(visible: false)
     }
     
     // MARK: - Navigation
@@ -120,13 +120,13 @@ class AnalyzeHotspotsViewController: UIViewController, HotspotSettingsVCDelegate
     
     // MARK: - Toggle settings view
     
-    private func toggleSettingsView(on: Bool) {
-        self.containerView.isHidden = !on
+    private func toggleSettingsView(visible: Bool) {
+        self.containerView.isHidden = !visible
     }
     
     // MARK: - Actions
     
     @IBAction func changeDatesAction() {
-        self.toggleSettingsView(on: true)
+        self.toggleSettingsView(visible: true)
     }
 }

--- a/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/StatisticalQueryGroupAndSortViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/StatisticalQueryGroupAndSortViewController.swift
@@ -299,18 +299,10 @@ class StatisticalQueryGroupAndSortViewController: UIViewController, UITableViewD
                 selectedGroupByFieldNames.remove(at: indexPath.row)
                 
                 // Remove field from the order by fields
-                for (index, orderByField) in orderByFields.enumerated().reversed() {
-                    if orderByField.fieldName == selectedGroupByFieldName {
-                        orderByFields.remove(at: index)
-                    }
-                }
+                orderByFields.removeAll { $0.fieldName == selectedGroupByFieldName }
                 
                 // Remove field from the selected order by fields
-                for (index, selectedOrderByField) in selectedOrderByFields.enumerated().reversed() {
-                    if selectedOrderByField.fieldName == selectedGroupByFieldName {
-                        selectedOrderByFields.remove(at: index)
-                    }
-                }
+                selectedOrderByFields.removeAll { $0.fieldName == selectedGroupByFieldName }
             }
         default:
             if !selectedOrderByFields.isEmpty {
@@ -349,10 +341,8 @@ class StatisticalQueryGroupAndSortViewController: UIViewController, UITableViewD
         }
         
         // Remove selected order by field if it's not part of the new order by fields
-        for (index, orderByField) in selectedOrderByFields.enumerated().reversed() {
-            if !orderByFields.contains(where: { $0.fieldName == orderByField.fieldName }) {
-                selectedOrderByFields.remove(at: index)
-            }
+        selectedOrderByFields.removeAll { (orderBy) -> Bool in
+            !orderByFields.contains { $0.fieldName == orderBy.fieldName }
         }
         
         // Reload sections

--- a/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/StatisticalQueryGroupAndSortViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/StatisticalQueryGroupAndSortViewController.swift
@@ -299,16 +299,16 @@ class StatisticalQueryGroupAndSortViewController: UIViewController, UITableViewD
                 selectedGroupByFieldNames.remove(at: indexPath.row)
                 
                 // Remove field from the order by fields
-                for (i, orderByField) in orderByFields.enumerated().reversed() {
+                for (index, orderByField) in orderByFields.enumerated().reversed() {
                     if orderByField.fieldName == selectedGroupByFieldName {
-                        orderByFields.remove(at: i)
+                        orderByFields.remove(at: index)
                     }
                 }
                 
                 // Remove field from the selected order by fields
-                for (i, selectedOrderByField) in selectedOrderByFields.enumerated().reversed() {
+                for (index, selectedOrderByField) in selectedOrderByFields.enumerated().reversed() {
                     if selectedOrderByField.fieldName == selectedGroupByFieldName {
-                        selectedOrderByFields.remove(at: i)
+                        selectedOrderByFields.remove(at: index)
                     }
                 }
             }
@@ -349,9 +349,9 @@ class StatisticalQueryGroupAndSortViewController: UIViewController, UITableViewD
         }
         
         // Remove selected order by field if it's not part of the new order by fields
-        for (i, orderByField) in selectedOrderByFields.enumerated().reversed() {
+        for (index, orderByField) in selectedOrderByFields.enumerated().reversed() {
             if !orderByFields.contains(where: { $0.fieldName == orderByField.fieldName }) {
-                selectedOrderByFields.remove(at: i)
+                selectedOrderByFields.remove(at: index)
             }
         }
         

--- a/arcgis-ios-sdk-samples/Edit data/Edit feature attachments/EditAttachmentViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit feature attachments/EditAttachmentViewController.swift
@@ -25,7 +25,7 @@ class EditAttachmentViewController: UIViewController, AGSGeoViewTouchDelegate, A
     private var lastQuery: AGSCancelable!
     
     private var selectedFeature: AGSArcGISFeature!
-    private let FEATURE_SERVICE_URL = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"
+    private let featureServiceURL = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -37,7 +37,7 @@ class EditAttachmentViewController: UIViewController, AGSGeoViewTouchDelegate, A
         //set initial viewpoint
         self.map.initialViewpoint = AGSViewpoint(center: AGSPoint(x: -471534.03, y: 7297552.03, spatialReference: .webMercator()), scale: 6e6)
         
-        self.featureTable = AGSServiceFeatureTable(url: URL(string: FEATURE_SERVICE_URL)!)
+        self.featureTable = AGSServiceFeatureTable(url: URL(string: featureServiceURL)!)
         self.featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
         
         self.map.operationalLayers.add(self.featureLayer)

--- a/arcgis-ios-sdk-samples/Edit data/Offline edit and sync/OfflineEditingViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Offline edit and sync/OfflineEditingViewController.swift
@@ -91,8 +91,8 @@ class OfflineEditingViewController: UIViewController {
                 }
                 if let featureServiceInfo = self.syncTask?.featureServiceInfo,
                     let map = self.mapView.map {
-                    for (index, layerInfo) in featureServiceInfo.layerInfos.enumerated().reversed() {
-                        
+                    for index in featureServiceInfo.layerInfos.indices.reversed() {
+                        let layerInfo = featureServiceInfo.layerInfos[index]
                         //For each layer in the serice, add a layer to the map
                         let layerURL = self.featureServiceURL.appendingPathComponent(String(index))
                         let featureTable = AGSServiceFeatureTable(url: layerURL)

--- a/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/EditAttributesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/EditAttributesViewController.swift
@@ -28,7 +28,7 @@ class EditAttributesViewController: UIViewController, AGSGeoViewTouchDelegate, A
     private var selectedFeature: AGSArcGISFeature!
     private let optionsSegueName = "OptionsSegue"
     
-    private let FEATURE_SERVICE_URL = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"
+    private let featureServiceURL = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -40,7 +40,7 @@ class EditAttributesViewController: UIViewController, AGSGeoViewTouchDelegate, A
         //set initial viewpoint
         self.map.initialViewpoint = AGSViewpoint(center: AGSPoint(x: 544871.19, y: 6806138.66, spatialReference: .webMercator()), scale: 2e6)
         
-        self.featureTable = AGSServiceFeatureTable(url: URL(string: FEATURE_SERVICE_URL)!)
+        self.featureTable = AGSServiceFeatureTable(url: URL(string: featureServiceURL)!)
         self.featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
         
         self.map.operationalLayers.add(self.featureLayer)

--- a/arcgis-ios-sdk-samples/Edit data/Update geometries (feature service)/EditGeometryViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update geometries (feature service)/EditGeometryViewController.swift
@@ -53,10 +53,10 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
         super.viewDidAppear(animated)
         
         //default state for toolbar is off
-        self.toggleToolbar(visible: false)
+        self.setToolbarVisibility(visible: false)
     }
     
-    func toggleToolbar(visible: Bool) {
+    func setToolbarVisibility(visible: Bool) {
         toolbarBottomConstraint.constant = visible ? 0 : -44 - view.safeAreaInsets.bottom
         
         UIView.animate(withDuration: 0.3, animations: { [weak self] () -> Void in
@@ -119,7 +119,7 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
         self.mapView.sketchEditor?.start(with: point)
         
         //show the toolbar
-        self.toggleToolbar(visible: true)
+        self.setToolbarVisibility(visible: true)
         
         //hide the feature for time being
         self.featureLayer.setFeature(self.selectedFeature, visible: false)
@@ -145,7 +145,7 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
         }
         
         //hide toolbar
-        self.toggleToolbar(visible: false)
+        self.setToolbarVisibility(visible: false)
         
         //disable sketch editor
         self.mapView.sketchEditor?.stop()

--- a/arcgis-ios-sdk-samples/Edit data/Update geometries (feature service)/EditGeometryViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update geometries (feature service)/EditGeometryViewController.swift
@@ -27,7 +27,7 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
     private var lastQuery: AGSCancelable!
     
     private var selectedFeature: AGSArcGISFeature!
-    private let FEATURE_SERVICE_URL = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"
+    private let featureServiceURL = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -39,7 +39,7 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
         //set initial viewpoint
         self.map.initialViewpoint = AGSViewpoint(center: AGSPoint(x: -9030446.96, y: 943791.32, spatialReference: .webMercator()), scale: 2e6)
         
-        self.featureTable = AGSServiceFeatureTable(url: URL(string: FEATURE_SERVICE_URL)!)
+        self.featureTable = AGSServiceFeatureTable(url: URL(string: featureServiceURL)!)
         self.featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
         
         self.map.operationalLayers.add(self.featureLayer)
@@ -53,11 +53,11 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
         super.viewDidAppear(animated)
         
         //default state for toolbar is off
-        self.toggleToolbar(false)
+        self.toggleToolbar(visible: false)
     }
     
-    func toggleToolbar(_ on: Bool) {
-        toolbarBottomConstraint.constant = on ? 0 : -44 - view.safeAreaInsets.bottom
+    func toggleToolbar(visible: Bool) {
+        toolbarBottomConstraint.constant = visible ? 0 : -44 - view.safeAreaInsets.bottom
         
         UIView.animate(withDuration: 0.3, animations: { [weak self] () -> Void in
             self?.view.layoutIfNeeded()
@@ -119,7 +119,7 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
         self.mapView.sketchEditor?.start(with: point)
         
         //show the toolbar
-        self.toggleToolbar(true)
+        self.toggleToolbar(visible: true)
         
         //hide the feature for time being
         self.featureLayer.setFeature(self.selectedFeature, visible: false)
@@ -145,7 +145,7 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
         }
         
         //hide toolbar
-        self.toggleToolbar(false)
+        self.toggleToolbar(visible: false)
         
         //disable sketch editor
         self.mapView.sketchEditor?.stop()

--- a/arcgis-ios-sdk-samples/Features/Feature layer rendering mode (map)/FeatureLayerRenderingModeMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer rendering mode (map)/FeatureLayerRenderingModeMapViewController.swift
@@ -20,7 +20,7 @@ class FeatureLayerRenderingModeMapViewController: UIViewController {
     @IBOutlet weak var dynamicMapView: AGSMapView!
     @IBOutlet weak var staticMapView: AGSMapView!
     
-    var _zoomed = false
+    private var isZoomed = false
     var zoomedInViewpoint: AGSViewpoint!
     var zoomedOutViewpoint: AGSViewpoint!
     
@@ -68,14 +68,14 @@ class FeatureLayerRenderingModeMapViewController: UIViewController {
     }
 
     @IBAction func animateZoom(_ sender: Any) {
-        if _zoomed {
+        if isZoomed {
             self.dynamicMapView.setViewpoint(zoomedOutViewpoint, duration: 5, completion: nil)
             self.staticMapView.setViewpoint(zoomedOutViewpoint, duration: 5, completion: nil)
         } else {
             self.dynamicMapView.setViewpoint(zoomedInViewpoint, duration: 5, completion: nil)
             self.staticMapView.setViewpoint(zoomedInViewpoint, duration: 5, completion: nil)
         }
-        _zoomed = !_zoomed
+        isZoomed = !isZoomed
     }
     
 }

--- a/arcgis-ios-sdk-samples/Features/Feature layer rendering mode (map)/FeatureLayerRenderingModeMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer rendering mode (map)/FeatureLayerRenderingModeMapViewController.swift
@@ -20,7 +20,7 @@ class FeatureLayerRenderingModeMapViewController: UIViewController {
     @IBOutlet weak var dynamicMapView: AGSMapView!
     @IBOutlet weak var staticMapView: AGSMapView!
     
-    private var isZoomed = false
+    private var zoomed = false
     var zoomedInViewpoint: AGSViewpoint!
     var zoomedOutViewpoint: AGSViewpoint!
     
@@ -68,14 +68,14 @@ class FeatureLayerRenderingModeMapViewController: UIViewController {
     }
 
     @IBAction func animateZoom(_ sender: Any) {
-        if isZoomed {
+        if zoomed {
             self.dynamicMapView.setViewpoint(zoomedOutViewpoint, duration: 5, completion: nil)
             self.staticMapView.setViewpoint(zoomedOutViewpoint, duration: 5, completion: nil)
         } else {
             self.dynamicMapView.setViewpoint(zoomedInViewpoint, duration: 5, completion: nil)
             self.staticMapView.setViewpoint(zoomedInViewpoint, duration: 5, completion: nil)
         }
-        isZoomed = !isZoomed
+        zoomed = !zoomed
     }
     
 }

--- a/arcgis-ios-sdk-samples/Features/Generate geodatabase/GenerateGeodatabaseViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Generate geodatabase/GenerateGeodatabaseViewController.swift
@@ -57,12 +57,13 @@ class GenerateGeodatabaseViewController: UIViewController {
                 print("Could not load feature service \(error)")
                 
             } else {
-                guard let self = self else {
+                guard let self = self,
+                    let featureServiceInfo = self.syncTask.featureServiceInfo else {
                     return
                 }
                 
-                for (index, layerInfo) in self.syncTask.featureServiceInfo!.layerInfos.enumerated().reversed() {
-                    
+                for index in featureServiceInfo.layerInfos.indices.reversed() {
+                    let layerInfo = featureServiceInfo.layerInfos[index]
                     //For each layer in the serice, add a layer to the map
                     let layerURL = self.syncTask.url!.appendingPathComponent(String(index))
                     let featureTable = AGSServiceFeatureTable(url: layerURL)

--- a/arcgis-ios-sdk-samples/Features/Service feature table (cache)/OnInteractionCacheViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Service feature table (cache)/OnInteractionCacheViewController.swift
@@ -21,7 +21,7 @@ class OnInteractionCacheViewController: UIViewController {
     
     private var map: AGSMap!
     
-    private let FEATURE_SERVICE_URL = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0"
+    private let featureServiceURL = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0"
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -41,7 +41,7 @@ class OnInteractionCacheViewController: UIViewController {
             spatialReference: .webMercator()))
         
         //feature layer
-        let featureTable = AGSServiceFeatureTable(url: URL(string: FEATURE_SERVICE_URL)!)
+        let featureTable = AGSServiceFeatureTable(url: URL(string: featureServiceURL)!)
         //set the request mode
         featureTable.featureRequestMode = AGSFeatureRequestMode.onInteractionCache
         let featureLayer = AGSFeatureLayer(featureTable: featureTable)

--- a/arcgis-ios-sdk-samples/Features/Service feature table (no cache)/OnInteractionNoCacheViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Service feature table (no cache)/OnInteractionNoCacheViewController.swift
@@ -21,7 +21,7 @@ class OnInteractionNoCacheViewController: UIViewController {
     
     private var map: AGSMap!
     
-    private let FEATURE_SERVICE_URL = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0"
+    private let featureServiceURL = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0"
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -41,7 +41,7 @@ class OnInteractionNoCacheViewController: UIViewController {
             spatialReference: .webMercator()))
         
         //feature layer
-        let featureTable = AGSServiceFeatureTable(url: URL(string: FEATURE_SERVICE_URL)!)
+        let featureTable = AGSServiceFeatureTable(url: URL(string: featureServiceURL)!)
         //set the request mode
         featureTable.featureRequestMode = AGSFeatureRequestMode.onInteractionNoCache
         let featureLayer = AGSFeatureLayer(featureTable: featureTable)

--- a/arcgis-ios-sdk-samples/Layers/WMTS layer/WMTSLayerViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/WMTS layer/WMTSLayerViewController.swift
@@ -22,7 +22,7 @@ class WMTSLayerViewController: UIViewController {
     private var map: AGSMap!
     private var wmtsService: AGSWMTSService!
     
-    private let WMTS_SERVICE_URL = URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer/WMTS")!
+    private let wmtsServiceURL = URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer/WMTS")!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -34,7 +34,7 @@ class WMTSLayerViewController: UIViewController {
         self.mapView.map = self.map
         
         //create a WMTS service with the service URL
-        self.wmtsService = AGSWMTSService(url: WMTS_SERVICE_URL)
+        self.wmtsService = AGSWMTSService(url: wmtsServiceURL)
         
         //load the WMTS service to access the service information
         self.wmtsService.load {[weak self] (error) in

--- a/arcgis-ios-sdk-samples/Maps/Display device location/CustomContextSheet.swift
+++ b/arcgis-ios-sdk-samples/Maps/Display device location/CustomContextSheet.swift
@@ -104,9 +104,9 @@ class CustomContextSheet: UIView {
         }
         
         //other buttons
-        for (index, image) in images.enumerated() {
+        for index in images.indices {
             
-            let button = self.button(image, highlightImage: self.highlightImages?[index], action: #selector(CustomContextSheet.valueChanged(_:)))
+            let button = self.button(images[index], highlightImage: highlightImages?[index], action: #selector(CustomContextSheet.valueChanged(_:)))
             button.isHidden = true
             self.insertSubview(button, at: 0)
             self.buttonsCollection.append(button)

--- a/arcgis-ios-sdk-samples/Maps/Display device location/CustomContextSheet.swift
+++ b/arcgis-ios-sdk-samples/Maps/Display device location/CustomContextSheet.swift
@@ -104,9 +104,9 @@ class CustomContextSheet: UIView {
         }
         
         //other buttons
-        for i in 0..<images.count {
+        for (index, image) in images.enumerated() {
             
-            let button = self.button(self.images[i], highlightImage: self.highlightImages?[i], action: #selector(CustomContextSheet.valueChanged(_:)))
+            let button = self.button(image, highlightImage: self.highlightImages?[index], action: #selector(CustomContextSheet.valueChanged(_:)))
             button.isHidden = true
             self.insertSubview(button, at: 0)
             self.buttonsCollection.append(button)
@@ -119,7 +119,7 @@ class CustomContextSheet: UIView {
             
             if self.titles != nil {
                 //labels
-                let label = self.label(self.titles[i])
+                let label = self.label(self.titles[index])
                 self.insertSubview(label, at: 0)
                 self.labelsCollection.append(label)
                 
@@ -211,17 +211,17 @@ class CustomContextSheet: UIView {
                 delay: 0,
                 animations: { [weak self] () -> Void in
                     if let weakSelf = self {
-                        let count = constraints.count
-                        for i in 0..<count {
+                        let constraintCount = constraints.count
+                        for frameIndex in 0..<constraintCount {
                             UIView.addKeyframe(
-                                withRelativeStartTime: Double(i) / Double(count),
-                                relativeDuration: 1 / Double(count),
+                                withRelativeStartTime: Double(frameIndex) / Double(constraintCount),
+                                relativeDuration: 1 / Double(constraintCount),
                                 animations: { () -> Void in
-                                    for j in i..<count {
-                                        let layout = constraints[j]
+                                    for layoutIndex in frameIndex..<constraintCount {
+                                        let layout = constraints[layoutIndex]
                                         layout.constant -= weakSelf.buttonDisplacement
                                     }
-                                    weakSelf.labelsCollection[i].alpha = 1
+                                    weakSelf.labelsCollection[frameIndex].alpha = 1
                                     weakSelf.layoutIfNeeded()
                                 }
                             )
@@ -251,17 +251,17 @@ class CustomContextSheet: UIView {
                 delay: 0,
                 animations: { [weak self] () -> Void in
                     if let weakSelf = self {
-                        let count = constraints.count
-                        for i in 0..<count {
+                        let constraintCount = constraints.count
+                        for frameIndex in 0..<constraintCount {
                             UIView.addKeyframe(
-                                withRelativeStartTime: Double(i) / Double(count),
-                                relativeDuration: 1 / Double(count),
+                                withRelativeStartTime: Double(frameIndex) / Double(constraintCount),
+                                relativeDuration: 1 / Double(constraintCount),
                                 animations: { () -> Void in
-                                    for j in (count - 1 - i)...count - 1 {
-                                        let layout = constraints[j]
+                                    for layoutIndex in (constraintCount - 1 - frameIndex)...constraintCount - 1 {
+                                        let layout = constraints[layoutIndex]
                                         layout.constant += weakSelf.buttonDisplacement
                                     }
-                                    weakSelf.labelsCollection[count - 1 - i].alpha = 0
+                                    weakSelf.labelsCollection[constraintCount - 1 - frameIndex].alpha = 0
                                     weakSelf.layoutIfNeeded()
                                 }
                             )

--- a/arcgis-ios-sdk-samples/Maps/Open map (URL)/OpenMapURLSettingsViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Open map (URL)/OpenMapURLSettingsViewController.swift
@@ -25,7 +25,7 @@ class OpenMapURLSettingsViewController: UITableViewController {
         super.viewWillAppear(animated)
         
         let selectedMapIndex = mapModels.firstIndex { (mapAtURL) -> Bool in
-            mapAtURL.id == initialSelectedID
+            mapAtURL.portalID == initialSelectedID
         }
         if let selectedMapIndex = selectedMapIndex {
             let selectedIndexPath = IndexPath(row: selectedMapIndex, section: 0)

--- a/arcgis-ios-sdk-samples/Maps/Open map (URL)/OpenMapURLViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Open map (URL)/OpenMapURLViewController.swift
@@ -28,23 +28,23 @@ class OpenMapURLViewController: UIViewController {
     struct MapAtURL {
         var title: String
         var thumbnailImage: UIImage
-        var id: String
+        var portalID: String
         
         var url: URL? {
-            return URL(string: "https://www.arcgis.com/home/item.html?id=\(id)")
+            return URL(string: "https://www.arcgis.com/home/item.html?id=\(portalID)")
         }
     }
     
     private let mapModels: [MapAtURL] = [
         MapAtURL(title: "Housing with Mortgages",
                  thumbnailImage: #imageLiteral(resourceName: "OpenMapURLThumbnail1"),
-                 id: "2d6fa24b357d427f9c737774e7b0f977"),
+                 portalID: "2d6fa24b357d427f9c737774e7b0f977"),
         MapAtURL(title: "USA Tapestry Segmentation",
                  thumbnailImage: #imageLiteral(resourceName: "OpenMapURLThumbnail2"),
-                 id: "01f052c8995e4b9e889d73c3e210ebe3"),
+                 portalID: "01f052c8995e4b9e889d73c3e210ebe3"),
         MapAtURL(title: "Geology of United States",
                  thumbnailImage: #imageLiteral(resourceName: "OpenMapURLThumbnail3"),
-                 id: "92ad152b9da94dee89b9e387dfe21acd")
+                 portalID: "92ad152b9da94dee89b9e387dfe21acd")
     ]
 
     override func viewDidLoad() {

--- a/arcgis-ios-sdk-samples/Route & Directions/Find service area interactive/FindServiceAreaInteractiveVC.swift
+++ b/arcgis-ios-sdk-samples/Route & Directions/Find service area interactive/FindServiceAreaInteractiveVC.swift
@@ -178,9 +178,8 @@ class FindServiceAreaInteractiveVC: UIViewController, AGSGeoViewTouchDelegate, S
                 //are the same across facilities, we only need to draw the resultPolygons at
                 //facility index 0. It will contain either merged or multipart polygons
                 if let polygons = result?.resultPolygons(atFacilityIndex: 0) {
-                    for j in 0..<polygons.count {
-                        let polygon = polygons[j]
-                        let fillSymbol = self.serviceAreaSymbol(for: j)
+                    for (index, polygon) in polygons.enumerated() {
+                        let fillSymbol = self.serviceAreaSymbol(for: index)
                         let graphic = AGSGraphic(geometry: polygon.geometry, symbol: fillSymbol, attributes: nil)
                         self.serviceAreaGraphicsOverlay.graphics.add(graphic)
                     }

--- a/arcgis-ios-sdk-samples/Route & Directions/Find service area interactive/FindServiceAreaInteractiveVC.swift
+++ b/arcgis-ios-sdk-samples/Route & Directions/Find service area interactive/FindServiceAreaInteractiveVC.swift
@@ -178,7 +178,8 @@ class FindServiceAreaInteractiveVC: UIViewController, AGSGeoViewTouchDelegate, S
                 //are the same across facilities, we only need to draw the resultPolygons at
                 //facility index 0. It will contain either merged or multipart polygons
                 if let polygons = result?.resultPolygons(atFacilityIndex: 0) {
-                    for (index, polygon) in polygons.enumerated() {
+                    for index in polygons.indices {
+                        let polygon = polygons[index]
                         let fillSymbol = self.serviceAreaSymbol(for: index)
                         let graphic = AGSGraphic(geometry: polygon.geometry, symbol: fillSymbol, attributes: nil)
                         self.serviceAreaGraphicsOverlay.graphics.add(graphic)

--- a/arcgis-ios-sdk-samples/Route & Directions/Offline routing/OfflineRoutingViewController.swift
+++ b/arcgis-ios-sdk-samples/Route & Directions/Offline routing/OfflineRoutingViewController.swift
@@ -248,7 +248,7 @@ class OfflineRoutingViewController: UIViewController, AGSGeoViewTouchDelegate {
             self.totalTime += route.totalTime
             self.totalDistance += route.totalLength
             
-            self.toggleDetailsView(visible: true)
+            self.setDetailsViewVisibility(visible: true)
         }
     }
     
@@ -270,7 +270,7 @@ class OfflineRoutingViewController: UIViewController, AGSGeoViewTouchDelegate {
         self.totalDistance = 0
         
         //hide the details view
-        self.toggleDetailsView(visible: false)
+        self.setDetailsViewVisibility(visible: false)
     }
     
     @IBAction func modeChanged(_ segmentedControl: UISegmentedControl) {
@@ -302,7 +302,7 @@ class OfflineRoutingViewController: UIViewController, AGSGeoViewTouchDelegate {
     
     // MARK: toggle details view
     
-    private func toggleDetailsView(visible: Bool) {
+    private func setDetailsViewVisibility(visible: Bool) {
         self.detailsViewBottomContraint.constant = visible ? 0 : -36
         
         UIView.animate(withDuration: 0.3) { [weak self] in

--- a/arcgis-ios-sdk-samples/Route & Directions/Offline routing/OfflineRoutingViewController.swift
+++ b/arcgis-ios-sdk-samples/Route & Directions/Offline routing/OfflineRoutingViewController.swift
@@ -248,7 +248,7 @@ class OfflineRoutingViewController: UIViewController, AGSGeoViewTouchDelegate {
             self.totalTime += route.totalTime
             self.totalDistance += route.totalLength
             
-            self.toggleDetailsView(on: true)
+            self.toggleDetailsView(visible: true)
         }
     }
     
@@ -270,7 +270,7 @@ class OfflineRoutingViewController: UIViewController, AGSGeoViewTouchDelegate {
         self.totalDistance = 0
         
         //hide the details view
-        self.toggleDetailsView(on: false)
+        self.toggleDetailsView(visible: false)
     }
     
     @IBAction func modeChanged(_ segmentedControl: UISegmentedControl) {
@@ -302,8 +302,8 @@ class OfflineRoutingViewController: UIViewController, AGSGeoViewTouchDelegate {
     
     // MARK: toggle details view
     
-    private func toggleDetailsView(on: Bool) {
-        self.detailsViewBottomContraint.constant = on ? 0 : -36
+    private func toggleDetailsView(visible: Bool) {
+        self.detailsViewBottomContraint.constant = visible ? 0 : -36
         
         UIView.animate(withDuration: 0.3) { [weak self] in
             self?.view.layoutIfNeeded()

--- a/arcgis-ios-sdk-samples/Route & Directions/Route around barriers/RouteAroundBarriersViewController.swift
+++ b/arcgis-ios-sdk-samples/Route & Directions/Route around barriers/RouteAroundBarriersViewController.swift
@@ -39,7 +39,7 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
         didSet {
             let flag = generatedRoute != nil
             self.directionsListBBI.isEnabled = flag
-            self.toggleRouteDetails(flag)
+            self.toggleRouteDetails(visible: flag)
             self.directionsListViewController.route = generatedRoute
         }
     }
@@ -68,7 +68,7 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
         self.getDefaultParameters()
         
         //hide directions list
-        self.toggleRouteDetails(false)
+        self.toggleRouteDetails(visible: false)
     }
 
     // MARK: - Route logic
@@ -216,15 +216,15 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
         )
     }
     
-    func toggleRouteDetails(_ on: Bool) {
-        self.directionsBottomConstraint.constant = on ? -115 : -150
+    func toggleRouteDetails(visible: Bool) {
+        self.directionsBottomConstraint.constant = visible ? -115 : -150
         UIView.animate(
             withDuration: 0.3,
             animations: { [weak self] () -> Void in
                 self?.view.layoutIfNeeded()
             },
             completion: { [weak self] (finished) -> Void in
-                if !on {
+                if !visible {
                     self?.isDirectionsListVisible = false
                 }
             }

--- a/arcgis-ios-sdk-samples/Route & Directions/Route around barriers/RouteAroundBarriersViewController.swift
+++ b/arcgis-ios-sdk-samples/Route & Directions/Route around barriers/RouteAroundBarriersViewController.swift
@@ -39,7 +39,7 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
         didSet {
             let flag = generatedRoute != nil
             self.directionsListBBI.isEnabled = flag
-            self.toggleRouteDetails(visible: flag)
+            self.setRouteDetailsVisibility(visible: flag)
             self.directionsListViewController.route = generatedRoute
         }
     }
@@ -68,7 +68,7 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
         self.getDefaultParameters()
         
         //hide directions list
-        self.toggleRouteDetails(visible: false)
+        self.setRouteDetailsVisibility(visible: false)
     }
 
     // MARK: - Route logic
@@ -216,7 +216,7 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
         )
     }
     
-    func toggleRouteDetails(visible: Bool) {
+    func setRouteDetailsVisibility(visible: Bool) {
         self.directionsBottomConstraint.constant = visible ? -115 : -150
         UIView.animate(
             withDuration: 0.3,

--- a/arcgis-ios-sdk-samples/Scenes/Extrude graphics/ExtrudeGraphicsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Extrude graphics/ExtrudeGraphicsViewController.swift
@@ -70,14 +70,17 @@ class ExtrudeGraphicsViewController: UIViewController {
     
     private func addGraphics() {
         //starting point
-        let x = self.cameraStartingPoint.x - 0.01
-        let y = self.cameraStartingPoint.y + 0.25
+        let x = cameraStartingPoint.x - 0.01
+        let y = cameraStartingPoint.y + 0.25
         
         //creating a grid of polygon graphics
-        for column in 0...6 {
-            for row in 0...4 {
-                let polygon = self.polygonForStartingPoint(AGSPoint(x: x + Double(column) * (squareSize + spacing), y: y + Double(row) * (squareSize + spacing), spatialReference: nil))
-                self.addGraphicForPolygon(polygon)
+        for column in stride(from: 0.0, through: 6.0, by: 1.0) {
+            for row in stride(from: 0.0, through: 4.0, by: 1.0) {
+                let startingX = x + column * (squareSize + spacing)
+                let startingY = y + row * (squareSize + spacing)
+                let startingPoint = AGSPoint(x: startingX, y: startingY, spatialReference: nil)
+                let polygon = polygonForStartingPoint(startingPoint)
+                addGraphicForPolygon(polygon)
             }
         }
     }

--- a/arcgis-ios-sdk-samples/Scenes/Extrude graphics/ExtrudeGraphicsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Extrude graphics/ExtrudeGraphicsViewController.swift
@@ -74,9 +74,9 @@ class ExtrudeGraphicsViewController: UIViewController {
         let y = self.cameraStartingPoint.y + 0.25
         
         //creating a grid of polygon graphics
-        for i in 0...6 {
-            for j in 0...4 {
-                let polygon = self.polygonForStartingPoint(AGSPoint(x: x + Double(i) * (squareSize + spacing), y: y + Double(j) * (squareSize + spacing), spatialReference: nil))
+        for column in 0...6 {
+            for row in 0...4 {
+                let polygon = self.polygonForStartingPoint(AGSPoint(x: x + Double(column) * (squareSize + spacing), y: y + Double(row) * (squareSize + spacing), spatialReference: nil))
                 self.addGraphicForPolygon(polygon)
             }
         }

--- a/arcgis-ios-sdk-samples/Scenes/Scene symbols/SceneSymbolsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Scene symbols/SceneSymbolsViewController.swift
@@ -66,8 +66,8 @@ class SceneSymbolsViewController: UIViewController {
         
         // Create graphics for each symbol.
         let symbols = [coneSymbol, cubeSymbol, cylinderSymbol, diamondSymbol, sphereSymbol, tetrahedronSymbol]
-        let graphics = symbols.enumerated().map { (i, symbol) -> AGSGraphic in
-            let point = AGSPoint(x: x + 0.01 * Double(i), y: y, z: z, spatialReference: .wgs84())
+        let graphics = symbols.enumerated().map { (index, symbol) -> AGSGraphic in
+            let point = AGSPoint(x: x + 0.01 * Double(index), y: y, z: z, spatialReference: .wgs84())
             return AGSGraphic(geometry: point, symbol: symbol)
         }
         

--- a/arcgis-ios-sdk-samples/Scenes/Scene symbols/SceneSymbolsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Scene symbols/SceneSymbolsViewController.swift
@@ -66,8 +66,8 @@ class SceneSymbolsViewController: UIViewController {
         
         // Create graphics for each symbol.
         let symbols = [coneSymbol, cubeSymbol, cylinderSymbol, diamondSymbol, sphereSymbol, tetrahedronSymbol]
-        let graphics = symbols.enumerated().map { (index, symbol) -> AGSGraphic in
-            let point = AGSPoint(x: x + 0.01 * Double(index), y: y, z: z, spatialReference: .wgs84())
+        let graphics = symbols.enumerated().map { (offset, symbol) -> AGSGraphic in
+            let point = AGSPoint(x: x + 0.01 * Double(offset), y: y, z: z, spatialReference: .wgs84())
             return AGSGraphic(geometry: point, symbol: symbol)
         }
         

--- a/arcgis-ios-sdk-samples/Shared resources/Libraries/DemoTouchView/DemoTouchView.swift
+++ b/arcgis-ios-sdk-samples/Shared resources/Libraries/DemoTouchView/DemoTouchView.swift
@@ -144,17 +144,17 @@ extension UIApplication {
             
             // dispatch touches to our view
             //
-            if let b = began {
-                DemoTouchesView.sharedInstance.touchesBegan(b, with: event)
+            if let began = began {
+                DemoTouchesView.sharedInstance.touchesBegan(began, with: event)
             }
-            if let m = moved {
-                DemoTouchesView.sharedInstance.touchesMoved(m, with: event)
+            if let moved = moved {
+                DemoTouchesView.sharedInstance.touchesMoved(moved, with: event)
             }
-            if let e = ended {
-                DemoTouchesView.sharedInstance.touchesEnded(e, with: event)
+            if let ended = ended {
+                DemoTouchesView.sharedInstance.touchesEnded(ended, with: event)
             }
-            if let c = cancelled {
-                DemoTouchesView.sharedInstance.touchesCancelled(c, with: event)
+            if let cancelled = cancelled {
+                DemoTouchesView.sharedInstance.touchesCancelled(cancelled, with: event)
             }
         }
         
@@ -392,30 +392,30 @@ private class DemoTouchesView: UIView {
     
     // MARK: Methods
     
-    func touchViewForPoint(_ pt: CGPoint) -> TouchView {
-        let tv = TouchView(center: pt, size: CGSize(width: touchSize, height: touchSize))
-        tv.backgroundColor = touchFillColor
-        tv.layer.borderWidth = touchBorderWidth
-        tv.layer.borderColor = touchBorderColor.cgColor
-        return tv
+    func touchViewForPoint(_ point: CGPoint) -> TouchView {
+        let touchView = TouchView(center: point, size: CGSize(width: touchSize, height: touchSize))
+        touchView.backgroundColor = touchFillColor
+        touchView.layer.borderWidth = touchBorderWidth
+        touchView.layer.borderColor = touchBorderColor.cgColor
+        return touchView
     }
     
     func pingLayerForTouch(_ touch: UITouch) -> PingLayer {
-        let pl = PingLayer(center: touch.location(in: self), fromRadius: 0, toRadius: touchSize)
-        pl.pingWidth = pingWidth
-        pl.pingColor = touchFillColor
-        return pl
+        let pingLayer = PingLayer(center: touch.location(in: self), fromRadius: 0, toRadius: touchSize)
+        pingLayer.pingWidth = pingWidth
+        pingLayer.pingColor = touchFillColor
+        return pingLayer
     }
     
     func updateTouches(_ touches: Set<NSObject>?) {
         
         currentTouches = touches as? Set<UITouch>
         
-        if let w = UIApplication.shared.keyWindow {
+        if let window = UIApplication.shared.keyWindow {
             
             if DemoTouchesView.sharedInstance.window == nil {
-                DemoTouchesView.sharedInstance.frame = w.frame
-                w.addSubview(DemoTouchesView.sharedInstance)
+                DemoTouchesView.sharedInstance.frame = window.frame
+                window.addSubview(DemoTouchesView.sharedInstance)
             } else {
 
                 // Ensure our DemoTouch view is always at the front of it's window
@@ -445,36 +445,36 @@ private class DemoTouchesView: UIView {
     }
     
     fileprivate func addTouch(_ touch: UITouch) {
-        let pt = touch.location(in: self)
-        let newTV = touchViewForPoint(pt)
+        let touchLocation = touch.location(in: self)
+        let newTouchView = touchViewForPoint(touchLocation)
         
-        DemoTouchesView.sharedInstance.addSubview(newTV)
-        touchViewMap[touch] = newTV
+        DemoTouchesView.sharedInstance.addSubview(newTouchView)
+        touchViewMap[touch] = newTouchView
     }
     
     fileprivate func moveTouch(_ touch: UITouch) {
-        if let tv = touchViewMap[touch] {
-            let pt = touch.location(in: self)
-            tv.center = pt
+        if let touchView = touchViewMap[touch] {
+            let touchLocation = touch.location(in: self)
+            touchView.center = touchLocation
         }
     }
     
     fileprivate func removeTouch(_ touch: UITouch, cancelled: Bool = false) {
-        if let tv = touchViewMap[touch] {
+        if let touchView = touchViewMap[touch] {
 
             let animations: (() -> Void) = {
-                tv.transform = CGAffineTransform(scaleX: 0.1, y: 0.1)
-                tv.alpha = 0.0
+                touchView.transform = CGAffineTransform(scaleX: 0.1, y: 0.1)
+                touchView.alpha = 0.0
                 
                 // only show the ping for a non-cancelled touch that hasn't moved (a touch that actually ended)
                 // basically, a single tap
                 //
-                if !cancelled && !tv.moved {
+                if !cancelled && !touchView.moved {
                     self.showPingForTouch(touch)
                 }
             }
             UIView.animate(withDuration: 0.25, animations: animations, completion: { (finished) in
-                tv.removeFromSuperview()
+                touchView.removeFromSuperview()
             }) 
             
             // stop tracking the touch
@@ -487,10 +487,10 @@ private class DemoTouchesView: UIView {
     //
     fileprivate func intensifyTouchView(_ touch: UITouch) {
         
-        if let tv = touchViewMap[touch] {
+        if let touchView = touchViewMap[touch] {
             
-            if tv.alpha < 1.0 {
-                tv.alpha += CGFloat(0.05)
+            if touchView.alpha < 1.0 {
+                touchView.alpha += CGFloat(0.05)
             }
         }
     }

--- a/arcgis-ios-sdk-samples/Shared resources/Libraries/ExpandableTableViewController/ExpandableTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Shared resources/Libraries/ExpandableTableViewController/ExpandableTableViewController.swift
@@ -159,17 +159,11 @@ class ExpandableTableViewController: UITableViewController {
         let sectionData = sectionItems[section]
         
         expandedSectionHeaderNumber = -1
-        if sectionData.isEmpty {
-            return
-        } else {
+        if !sectionData.isEmpty {
             UIView.animate(withDuration: 0.25, animations: {
                 imageView.image = UIImage(named: "Collapsed")
             })
-            var indexPaths = [IndexPath]()
-            for index in 0..<sectionData.count {
-                let indexPath = IndexPath(row: index, section: section)
-                indexPaths.append(indexPath)
-            }
+            let indexPaths = sectionData.indices.map { IndexPath(row: $0, section: section) }
             tableView!.beginUpdates()
             tableView!.deleteRows(at: indexPaths, with: .fade)
             tableView!.endUpdates()
@@ -186,11 +180,7 @@ class ExpandableTableViewController: UITableViewController {
             UIView.animate(withDuration: 0.25, animations: {
                 imageView.image = UIImage(named: "Expanded")
             })
-            var indexPaths = [IndexPath]()
-            for index in 0..<sectionData.count {
-                let indexPath = IndexPath(row: index, section: section)
-                indexPaths.append(indexPath)
-            }
+            let indexPaths = sectionData.indices.map { IndexPath(row: $0, section: section) }
             expandedSectionHeaderNumber = section
             tableView!.beginUpdates()
             tableView!.insertRows(at: indexPaths, with: UITableView.RowAnimation.fade)

--- a/arcgis-ios-sdk-samples/Shared resources/Libraries/ExpandableTableViewController/ExpandableTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Shared resources/Libraries/ExpandableTableViewController/ExpandableTableViewController.swift
@@ -165,13 +165,13 @@ class ExpandableTableViewController: UITableViewController {
             UIView.animate(withDuration: 0.25, animations: {
                 imageView.image = UIImage(named: "Collapsed")
             })
-            var indexesPath = [IndexPath]()
-            for i in 0 ..< sectionData.count {
-                let index = IndexPath(row: i, section: section)
-                indexesPath.append(index)
+            var indexPaths = [IndexPath]()
+            for index in 0..<sectionData.count {
+                let indexPath = IndexPath(row: index, section: section)
+                indexPaths.append(indexPath)
             }
             tableView!.beginUpdates()
-            tableView!.deleteRows(at: indexesPath, with: .fade)
+            tableView!.deleteRows(at: indexPaths, with: .fade)
             tableView!.endUpdates()
         }
     }
@@ -186,14 +186,14 @@ class ExpandableTableViewController: UITableViewController {
             UIView.animate(withDuration: 0.25, animations: {
                 imageView.image = UIImage(named: "Expanded")
             })
-            var indexesPath = [IndexPath]()
-            for i in 0 ..< sectionData.count {
-                let index = IndexPath(row: i, section: section)
-                indexesPath.append(index)
+            var indexPaths = [IndexPath]()
+            for index in 0..<sectionData.count {
+                let indexPath = IndexPath(row: index, section: section)
+                indexPaths.append(indexPath)
             }
             expandedSectionHeaderNumber = section
             tableView!.beginUpdates()
-            tableView!.insertRows(at: indexesPath, with: UITableView.RowAnimation.fade)
+            tableView!.insertRows(at: indexPaths, with: UITableView.RowAnimation.fade)
             tableView!.endUpdates()
         }
     }


### PR DESCRIPTION
@philium I started this before you commented on the macOS version. I think it's a decent rule. Even if you don't want it enabled, I think the app would benefit from the resultant changes.