### PR TITLE
Enables the todo SwiftLint rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -14,7 +14,6 @@ disabled_rules: # rule identifiers to exclude from running
   - force_cast
   - line_length
   - notification_center_detachment
-  - todo
   - trailing_whitespace
   - type_body_length
   - type_name

--- a/arcgis-ios-sdk-samples/Edit data/Offline edit and sync/OfflineEditingViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Offline edit and sync/OfflineEditingViewController.swift
@@ -500,8 +500,6 @@ extension OfflineEditingViewController: AGSPopupsViewControllerDelegate {
         //Prepare the current view controller for sketch mode
         mapView.callout.isHidden = true
         
-        //TODO: Hide the feature
-        
         //hide the back button
         navigationItem.hidesBackButton = true
         //disable the code button

--- a/arcgis-ios-sdk-samples/Maps/Display device location/CustomContextSheet.swift
+++ b/arcgis-ios-sdk-samples/Maps/Display device location/CustomContextSheet.swift
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//TODO: Add logic to change direction of menu at runtime
-
 import UIKit
 
 protocol CustomContextSheetDelegate: AnyObject {


### PR DESCRIPTION
I enjoy this rule. It's not very becoming to have `TODO` scattered around a sample app.

Two statements I removed outright and the other two I attempted to "do". The issue is that these are in the Export Tiles sample which appears to have a data source error making it unusable.