### PR TITLE
Removes ATS exceptions for arcgis.com and arcgisonline.com

### DIFF
--- a/arcgis-ios-sdk-samples/Info.plist
+++ b/arcgis-ios-sdk-samples/Info.plist
@@ -41,20 +41,6 @@
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>
-			<key>arcgis.com</key>
-			<dict>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-				<key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-			<key>arcgisonline.com</key>
-			<dict>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-				<key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
 			<key>buienradar.nl</key>
 			<dict>
 				<key>NSIncludesSubdomains</key>


### PR DESCRIPTION
All traffic through these domains is now `https` so we can remove these exceptions. This affects a lot of samples and while there shouldn't be any issues, changing this now lets us have ample time to find bugs before the next release.