### PR TITLE
Fixes warning for SwiftLint v0.29.1

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -31,7 +31,6 @@ opt_in_rules: # some rules are only opt-in
   - anyobject_protocol
   - array_init
   - attributes
-  - closure_body_length
   - closure_end_indentation
   - closure_spacing
   - collection_alignment

--- a/arcgis-ios-sdk-samples/Features/Feature layer rendering mode (map)/FeatureLayerRenderingModeMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer rendering mode (map)/FeatureLayerRenderingModeMapViewController.swift
@@ -75,7 +75,7 @@ class FeatureLayerRenderingModeMapViewController: UIViewController {
             self.dynamicMapView.setViewpoint(zoomedInViewpoint, duration: 5, completion: nil)
             self.staticMapView.setViewpoint(zoomedInViewpoint, duration: 5, completion: nil)
         }
-        zoomed = !zoomed
+        zoomed.toggle()
     }
     
 }

--- a/arcgis-ios-sdk-samples/Scenes/Extrude graphics/ExtrudeGraphicsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Extrude graphics/ExtrudeGraphicsViewController.swift
@@ -99,7 +99,7 @@ class ExtrudeGraphicsViewController: UIViewController {
     //add a graphic to the graphics overlay for the given polygon
     private func addGraphicForPolygon(_ polygon: AGSPolygon) {
         
-        let rand = arc4random_uniform(UInt32(self.maxHeight))
+        let rand = Int.random(in: 0...maxHeight)
         
         let graphic = AGSGraphic(geometry: polygon, symbol: nil, attributes: nil)
         graphic.attributes.setValue(rand, forKey: "height")

--- a/arcgis-ios-sdk-samples/Search/Offline geocode/SanDiegoAddressesViewController.swift
+++ b/arcgis-ios-sdk-samples/Search/Offline geocode/SanDiegoAddressesViewController.swift
@@ -23,11 +23,13 @@ class SanDiegoAddressesViewController: UITableViewController {
     weak var delegate: SanDiegoAddressesVCDelegate?
     
     //prepopulated list of addresses
-    private var addresses = ["910 N Harbor Dr, San Diego, CA 92101",
+    private var addresses = [
+        "910 N Harbor Dr, San Diego, CA 92101",
         "2920 Zoo Dr, San Diego, CA 92101",
         "111 W Harbor Dr, San Diego, CA 92101",
         "868 4th Ave, San Diego, CA 92101",
-        "750 A St, San Diego, CA 92101"]
+        "750 A St, San Diego, CA 92101"
+    ]
     
     override func viewDidLoad() {
         super.viewDidLoad()


### PR DESCRIPTION
https://github.com/realm/SwiftLint/releases/tag/0.29.1

The warnings didn't appear to come from new default rules, but rather rules we had already implemented that the old version of SwiftLint has missed.

I just went ahead and removed `closure_body_length` since there doesn't seem to be a great way to conform to that rule and it's not critical to enforcing a uniform style, which is our goal with linting.