### PR TITLE
Uses progress object provided by the API

### DIFF
--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ContentTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ContentTableViewController.swift
@@ -118,18 +118,11 @@ class ContentTableViewController: UITableViewController {
         downloadProgressView?.show(withStatus: "Just a moment while we download data for this sample...", progress: 0)
         
         //add an observer to update the progress in download progress view
-        downloadProgressObservation = bundleResourceRequest.progress.observe(\.fractionCompleted, changeHandler: { [weak self] (progress, change) in
-            
-            guard let self = self else {
-                return
-            }
-            
+        downloadProgressObservation = bundleResourceRequest.progress.observe(\.fractionCompleted) { [weak self] (progress, _) in
             DispatchQueue.main.async {
-                if let progressFraction = self.bundleResourceRequest?.progress.fractionCompleted {
-                    self.downloadProgressView?.updateProgress(progress: CGFloat(progressFraction), animated: true)
-                }
+                self?.downloadProgressView?.updateProgress(progress: CGFloat(progress.fractionCompleted), animated: true)
             }
-        })
+        }
         
         //begin
         bundleResourceRequest.beginAccessingResources { [weak self] (error: Error?) in


### PR DESCRIPTION
Rather than going through `self` to get it.