### PR TITLE
Changes import from UIKit to Foundation

### DIFF
--- a/arcgis-ios-sdk-samples/Content Display Logic/Model/SampleSearchEngine.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Model/SampleSearchEngine.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import UIKit
+import Foundation
 
 class SampleSearchEngine {
     


### PR DESCRIPTION
`SampleSearchEngine` doesn't depend on anything from `UIKit`.