### PR TITLE
Route Around Barriers: Prevent animation on appearance

### DIFF
--- a/arcgis-ios-sdk-samples/Route & Directions/Route around barriers/RouteAroundBarriersViewController.swift
+++ b/arcgis-ios-sdk-samples/Route & Directions/Route around barriers/RouteAroundBarriersViewController.swift
@@ -39,7 +39,7 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
         didSet {
             let flag = generatedRoute != nil
             self.directionsListBBI.isEnabled = flag
-            self.setRouteDetailsVisibility(visible: flag)
+            self.setRouteDetailsVisibility(visible: flag, animated: true)
             self.directionsListViewController.route = generatedRoute
         }
     }
@@ -67,8 +67,15 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
         //get default parameters
         self.getDefaultParameters()
         
+//        //hide directions list
+//        self.setRouteDetailsVisibility(visible: false)
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
         //hide directions list
-        self.setRouteDetailsVisibility(visible: false)
+        self.setRouteDetailsVisibility(visible: generatedRoute != nil, animated: false)
     }
 
     // MARK: - Route logic
@@ -216,10 +223,11 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
         )
     }
     
-    func setRouteDetailsVisibility(visible: Bool) {
+    func setRouteDetailsVisibility(visible: Bool, animated: Bool) {
         self.directionsBottomConstraint.constant = visible ? -115 : -150
+        let duration: TimeInterval = animated ? 0.3 : 0
         UIView.animate(
-            withDuration: 0.3,
+            withDuration: duration,
             animations: { [weak self] in
                 self?.view.layoutIfNeeded()
             },

--- a/arcgis-ios-sdk-samples/Route & Directions/Route around barriers/RouteAroundBarriersViewController.swift
+++ b/arcgis-ios-sdk-samples/Route & Directions/Route around barriers/RouteAroundBarriersViewController.swift
@@ -66,9 +66,6 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
         
         //get default parameters
         self.getDefaultParameters()
-        
-//        //hide directions list
-//        self.setRouteDetailsVisibility(visible: false)
     }
     
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
The Route Around Barriers view controller was animating the layout of its view while the view was appearing on screen. This ensures that the view is fully laid out before appearing.