### PR TITLE
Change OptionsTableViewController.Option initializer to take an image…

### DIFF
--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/OptionsTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/OptionsTableViewController.swift
@@ -17,29 +17,25 @@ import UIKit
 /// A basic interface for selecting one options from a list,
 /// showing the checkmark accessory for the selected cell.
 class OptionsTableViewController: UITableViewController {
+    struct Option {
+        let label: String
+        let image: UIImage?
+        
+        init(label: String, image: UIImage? = nil) {
+            self.label = label
+            self.image = image
+        }
+    }
     
     private let options: [Option]
     private var selectedIndex: Int
     private let onChange: (Int) -> Void
     
-    struct Option {
-        let label: String
-        let image: UIImage?
-        
-        init(label: String, imageName: String? = nil) {
-            self.label = label
-            if let imageName = imageName {
-                self.image = UIImage(named: imageName)
-            } else {
-                self.image = nil
-            }
-        }
-    }
-    
     convenience init(labels: [String], selectedIndex: Int, onChange: @escaping (Int) -> Void) {
         let options = labels.map { Option(label: $0) }
         self.init(options: options, selectedIndex: selectedIndex, onChange: onChange)
     }
+    
     init(options: [Option], selectedIndex: Int, onChange: @escaping (Int) -> Void) {
         self.options = options
         self.selectedIndex = selectedIndex
@@ -81,10 +77,9 @@ class OptionsTableViewController: UITableViewController {
         selectedIndex = indexPath.row
         onChange(indexPath.row)
     }
-    
 }
+
 private class OptionCell: UITableViewCell {
-    
     override func setSelected(_ selected: Bool, animated: Bool) {
         accessoryType = selected ? .checkmark : .none
     }

--- a/arcgis-ios-sdk-samples/Maps/Display device location/DisplayLocationSettingsViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Display device location/DisplayLocationSettingsViewController.swift
@@ -45,16 +45,16 @@ class DisplayLocationSettingsViewController: UITableViewController {
         }
     }
     
-    private func iconImageName(for autoPanMode: AGSLocationDisplayAutoPanMode) -> String {
+    private func icon(for autoPanMode: AGSLocationDisplayAutoPanMode) -> UIImage {
         switch autoPanMode {
         case .off:
-            return "LocationDisplayOffIcon"
+            return #imageLiteral(resourceName: "LocationDisplayOffIcon")
         case .recenter:
-            return "LocationDisplayDefaultIcon"
+            return #imageLiteral(resourceName: "LocationDisplayDefaultIcon")
         case .navigation:
-            return "LocationDisplayNavigationIcon"
+            return #imageLiteral(resourceName: "LocationDisplayNavigationIcon")
         case .compassNavigation:
-            return "LocationDisplayHeadingIcon"
+            return #imageLiteral(resourceName: "LocationDisplayHeadingIcon")
         }
     }
     
@@ -127,9 +127,7 @@ class DisplayLocationSettingsViewController: UITableViewController {
             let autoPanMode = locationDisplay?.autoPanMode,
             let selectedIndex = orderedAutoPanModes.firstIndex(of: autoPanMode) {
             
-            let options = orderedAutoPanModes.map { (mode) -> OptionsTableViewController.Option in
-                OptionsTableViewController.Option(label: label(for: mode), imageName: iconImageName(for: mode))
-            }
+            let options = orderedAutoPanModes.map { OptionsTableViewController.Option(label: label(for: $0), image: icon(for: $0)) }
 
             let controller = OptionsTableViewController(options: options, selectedIndex: selectedIndex) { (index) in
                 // get the mode for the index


### PR DESCRIPTION
… rather than an image name

It really should be the callers responsibility to lookup images by name.