### PR TITLE
Remove nil completion parameter in calls to UIViewController.dismiss(…

### DIFF
--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/AppInfoViewController.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/AppInfoViewController.swift
@@ -36,7 +36,7 @@ class AppInfoViewController: UIViewController {
     // MARK: - Actions
     
     @IBAction func closeAction() {
-        self.dismiss(animated: true, completion: nil)
+        self.dismiss(animated: true)
     }
 
 }

--- a/arcgis-ios-sdk-samples/Edit data/Edit feature attachments/AttachmentsTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit feature attachments/AttachmentsTableViewController.swift
@@ -154,11 +154,11 @@ class AttachmentsTableViewController: UITableViewController {
                 if let error = error {
                     self.presentAlert(error: error)
                 }
-                self.dismiss(animated: true, completion: nil)
+                self.dismiss(animated: true)
             }
             
         } else {
-            dismiss(animated: true, completion: nil)
+            dismiss(animated: true)
         }
         
     }

--- a/arcgis-ios-sdk-samples/Edit data/Edit features (connected)/EditFeaturesOnlineViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit features (connected)/EditFeaturesOnlineViewController.swift
@@ -53,7 +53,7 @@ class EditFeaturesOnlineViewController: UIViewController, AGSGeoViewTouchDelegat
     }
     
     private func dismissFeatureTemplatePickerVC() {
-        self.dismiss(animated: true, completion: nil)
+        self.dismiss(animated: true)
     }
     
     func applyEdits() {
@@ -122,7 +122,7 @@ class EditFeaturesOnlineViewController: UIViewController, AGSGeoViewTouchDelegat
     func popupsViewController(_ popupsViewController: AGSPopupsViewController, readyToEditGeometryWith sketchEditor: AGSSketchEditor?, for popup: AGSPopup) {
     
         //Dismiss the popup view controller
-        self.dismiss(animated: true, completion: nil)
+        self.dismiss(animated: true)
         
         //Prepare the current view controller for sketch mode
         self.mapView.callout.isHidden = true
@@ -243,7 +243,7 @@ class EditFeaturesOnlineViewController: UIViewController, AGSGeoViewTouchDelegat
         self.popupsVC.modalPresentationStyle = .formSheet
 
         //First, dismiss the Feature Template Picker
-        self.dismiss(animated: false, completion: nil)
+        self.dismiss(animated: false)
 
         //Next, Present the popup view controller
         self.present(self.popupsVC, animated: true) { [weak self] in

--- a/arcgis-ios-sdk-samples/Edit data/Offline edit and sync/OfflineEditingViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Offline edit and sync/OfflineEditingViewController.swift
@@ -471,7 +471,7 @@ extension OfflineEditingViewController: AGSPopupsViewControllerDelegate {
     func popupsViewController(_ popupsViewController: AGSPopupsViewController, readyToEditGeometryWith sketchEditor: AGSSketchEditor?, for popup: AGSPopup) {
         
         //Dismiss the popup view controller
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true)
         
         //Prepare the current view controller for sketch mode
         mapView.callout.isHidden = true
@@ -528,7 +528,7 @@ extension OfflineEditingViewController: AGSPopupsViewControllerDelegate {
     
     func popupsViewControllerDidFinishViewingPopups(_ popupsViewController: AGSPopupsViewController) {
         //dismiss the popups view controller
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true)
         popupsVC = nil
     }
 }

--- a/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/EAOptionsViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/EAOptionsViewController.swift
@@ -51,7 +51,7 @@ class EAOptionsViewController: UITableViewController {
     // MARK: - Actions
     
     @IBAction func cancelAction() {
-        self.dismiss(animated: true, completion: nil)
+        self.dismiss(animated: true)
     }
     
 }

--- a/arcgis-ios-sdk-samples/Features/Add delete related features/RelatedFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Add delete related features/RelatedFeaturesViewController.swift
@@ -198,6 +198,6 @@ class RelatedFeaturesViewController: UITableViewController {
     @IBAction private func doneAction() {
 
         //dismiss view controller
-        self.dismiss(animated: true, completion: nil)
+        self.dismiss(animated: true)
     }
 }

--- a/arcgis-ios-sdk-samples/Features/List related features/ListRelatedFeaturesVC.swift
+++ b/arcgis-ios-sdk-samples/Features/List related features/ListRelatedFeaturesVC.swift
@@ -166,6 +166,6 @@ class ListRelatedFeaturesVC: UIViewController, AGSGeoViewTouchDelegate {
     
     //to hide popover controller on rotation
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        self.dismiss(animated: true, completion: nil)
+        self.dismiss(animated: true)
     }
 }

--- a/arcgis-ios-sdk-samples/Layers/Manage sublayers/MapImageSublayersVC.swift
+++ b/arcgis-ios-sdk-samples/Layers/Manage sublayers/MapImageSublayersVC.swift
@@ -156,7 +156,7 @@ class MapImageSublayersVC: UITableViewController {
     @IBAction private func doneAction() {
         
         //dismiss view controller
-        self.dismiss(animated: true, completion: nil)
+        self.dismiss(animated: true)
         
         //update the removed sublayers array on the delegate
         self.delegate?.mapImageSublayersVC(mapImageSublayersVC: self, didCloseWith: self.removedMapImageSublayers)

--- a/arcgis-ios-sdk-samples/Scenes/Animate 3D graphic/Animate3DGraphicViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Animate 3D graphic/Animate3DGraphicViewController.swift
@@ -314,7 +314,7 @@ class Animate3DGraphicViewController: UIViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         
         // dismiss any shown view controllers
-        dismiss(animated: false, completion: nil)
+        dismiss(animated: false)
         
         if let controller = segue.destination as? CameraSettingsViewController {
             controller.orbitGeoElementCameraController = orbitGeoElementCameraController

--- a/arcgis-ios-sdk-samples/Search/Find address/FindAddressViewController.swift
+++ b/arcgis-ios-sdk-samples/Search/Find address/FindAddressViewController.swift
@@ -187,7 +187,7 @@ class FindAddressViewController: UIViewController, AGSGeoViewTouchDelegate, UISe
     func worldAddressesViewController(_ worldAddressesViewController: WorldAddressesViewController, didSelectAddress address: String) {
         self.searchBar.text = address
         self.geocodeSearchText(address)
-        self.dismiss(animated: true, completion: nil)
+        self.dismiss(animated: true)
         self.hideKeyboard()
     }
 }

--- a/arcgis-ios-sdk-samples/Search/Offline geocode/OfflineGeocodeViewController.swift
+++ b/arcgis-ios-sdk-samples/Search/Offline geocode/OfflineGeocodeViewController.swift
@@ -282,7 +282,7 @@ class GeocodeOfflineViewController: UIViewController, AGSGeoViewTouchDelegate, U
     func sanDiegoAddressesViewController(_ sanDiegoAddressesViewController: SanDiegoAddressesViewController, didSelectAddress address: String) {
         self.searchBar.text = address
         self.geocodeSearchText(address)
-        self.dismiss(animated: true, completion: nil)
+        self.dismiss(animated: true)
     }
     
 }


### PR DESCRIPTION
…animated:completion:)

The `completion` parameter has a default value of `nil`.