### PR TITLE
Fix bug in Animate 3D Graphic sample

### DIFF
--- a/arcgis-ios-sdk-samples/Scenes/Animate 3D graphic/Animate3DGraphicViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Animate 3D graphic/Animate3DGraphicViewController.swift
@@ -239,9 +239,9 @@ class Animate3DGraphicViewController: UIViewController {
         
         //update the properties on the model
         planeModelGraphic.geometry = frame.position
-        planeModelGraphic.attributes["HEADING"] = frame.heading
-        planeModelGraphic.attributes["PITCH"] = frame.pitch
-        planeModelGraphic.attributes["ROLL"] = frame.roll
+        planeModelGraphic.attributes["HEADING"] = frame.heading.value
+        planeModelGraphic.attributes["PITCH"] = frame.pitch.value
+        planeModelGraphic.attributes["ROLL"] = frame.roll.value
         
         //2D plane
         triangleGraphic.geometry = frame.position


### PR DESCRIPTION
Assigns the measurement value (`Double`) rather than the measurement itself (`NSMeasurement`).