### PR TITLE
Refactor TilePackagesListViewController

### DIFF
--- a/arcgis-ios-sdk-samples/Layers/ArcGIS tiled layer (tile cache)/LocalTiledLayerViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/ArcGIS tiled layer (tile cache)/LocalTiledLayerViewController.swift
@@ -16,7 +16,7 @@
 import UIKit
 import ArcGIS
 
-class LocalTiledLayerViewController: UIViewController, TilePackagesListVCDelegate {
+class LocalTiledLayerViewController: UIViewController, TilePackagesListViewControllerDelegate {
     @IBOutlet weak var mapView: AGSMapView!
     
     override func viewDidLoad() {
@@ -44,12 +44,12 @@ class LocalTiledLayerViewController: UIViewController, TilePackagesListVCDelegat
         }
     }
     
-    // MARK: - TilePackagesListVCDelegate
+    // MARK: - TilePackagesListViewControllerDelegate
     
     //called when a selection is made in the tile packages list
-    func tilePackagesListViewController(_ tilePackagesListViewController: TilePackagesListViewController, didSelectTPKWithPath path: String) {
+    func tilePackagesListViewController(_ tilePackagesListViewController: TilePackagesListViewController, didSelectTilePackageAt url: URL) {
         //create a new map with selected tile package as the basemap
-        let localTiledLayer = AGSArcGISTiledLayer(tileCache: AGSTileCache(fileURL: URL(fileURLWithPath: path)))
+        let localTiledLayer = AGSArcGISTiledLayer(tileCache: AGSTileCache(fileURL: url))
         let map = AGSMap(basemap: AGSBasemap(baseLayer: localTiledLayer))
         self.mapView.map = map
         

--- a/arcgis-ios-sdk-samples/Layers/ArcGIS tiled layer (tile cache)/TilePackagesListViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/ArcGIS tiled layer (tile cache)/TilePackagesListViewController.swift
@@ -74,7 +74,7 @@ class TilePackagesListViewController: UITableViewController {
 
 extension TilePackagesListViewController /* UITableViewDataSource */ {
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return 2
+        return Section.allCases.count
     }
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/arcgis-ios-sdk-samples/Layers/ArcGIS tiled layer (tile cache)/TilePackagesListViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/ArcGIS tiled layer (tile cache)/TilePackagesListViewController.swift
@@ -33,15 +33,18 @@ class TilePackagesListViewController: UITableViewController {
     }
     
     func fetchTilePackages() {
+        // Fetch URLs for tile packages in the main bundle.
         if let urls = Bundle.main.urls(forResourcesWithExtension: "tpk", subdirectory: nil) {
             bundleTilePackageURLs = urls
         }
         
-        if let documentDirectoryURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first,
-            let subpaths = FileManager.default.subpaths(atPath: documentDirectoryURL.path) {
+        // Fetch URLs for tile packages in the documents directory.
+        let documentDirectoryURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        if let subpaths = FileManager.default.subpaths(atPath: documentDirectoryURL.path) {
             let predicate = NSPredicate(format: "SELF MATCHES %@", ".*tpk$")
-            let tpks = subpaths.filter { predicate.evaluate(with: $0) }
-            documentTilePacakgeURLs = tpks.map { documentDirectoryURL.appendingPathComponent($0) }
+            documentTilePacakgeURLs = subpaths.lazy
+                .filter { predicate.evaluate(with: $0) }
+                .map { documentDirectoryURL.appendingPathComponent($0) }
         }
     }
     

--- a/arcgis-ios-sdk-samples/Layers/ArcGIS tiled layer (tile cache)/TilePackagesListViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/ArcGIS tiled layer (tile cache)/TilePackagesListViewController.swift
@@ -48,24 +48,40 @@ class TilePackagesListViewController: UITableViewController {
         }
     }
     
+    /// A section in the table view.
+    ///
+    /// - bundle: The section showing tile packages in the bundle.
+    /// - documentsDirectory: The section showing tile packages in the documents
+    /// directory.
+    enum Section: CaseIterable {
+        case bundle
+        case documentsDirectory
+    }
+    
+    /// Returns the `URL` corresponding to the row at the given index path.
+    ///
+    /// - Parameter indexPath: An index path.
+    /// - Returns: A `URL`.
     func urlForRow(at indexPath: IndexPath) -> URL {
-        if indexPath.section == 0 {
+        switch Section.allCases[indexPath.section] {
+        case .bundle:
             return bundleTilePackageURLs[indexPath.row]
-        } else {
+        case .documentsDirectory:
             return documentTilePacakgeURLs[indexPath.row]
         }
     }
-    
-    // MARK: - UITableViewDataSource
-    
+}
+
+extension TilePackagesListViewController /* UITableViewDataSource */ {
     override func numberOfSections(in tableView: UITableView) -> Int {
         return 2
     }
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if section == 0 {
+        switch Section.allCases[section] {
+        case .bundle:
             return bundleTilePackageURLs.count
-        } else {
+        case .documentsDirectory:
             return documentTilePacakgeURLs.count
         }
     }
@@ -77,11 +93,16 @@ class TilePackagesListViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return section == 0 ? "From the bundle" : "From the documents directory"
+        switch Section.allCases[section] {
+        case .bundle:
+            return "From the bundle"
+        case .documentsDirectory:
+            return "From the documents directory"
+        }
     }
-    
-    // MARK: - UITableViewDelegate
-    
+}
+
+extension TilePackagesListViewController /* UITableViewDelegate */ {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let url = urlForRow(at: indexPath)
         delegate?.tilePackagesListViewController(self, didSelectTilePackageAt: url)


### PR DESCRIPTION
- Remove implicitly unwrapped arrays.
- Use URLs instead of paths.
- Rename delegate.