### PR TITLE
Change development region from English to en

### DIFF
--- a/arcgis-ios-sdk-samples.xcodeproj/project.pbxproj
+++ b/arcgis-ios-sdk-samples.xcodeproj/project.pbxproj
@@ -3499,7 +3499,7 @@
 			};
 			buildConfigurationList = 3E23A9DB1AFC28F6002E2214 /* Build configuration list for PBXProject "arcgis-ios-sdk-samples" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,


### PR DESCRIPTION
Prevents a warning when building with Xcode 10.2 since `English` has been deprecated in favor of `en`. This change is backwards compatible with Xcode 10.1.