### PR TITLE
Perform Xcode 10.2 upgrade check

### DIFF
--- a/arcgis-ios-sdk-samples.xcodeproj/project.pbxproj
+++ b/arcgis-ios-sdk-samples.xcodeproj/project.pbxproj
@@ -3481,7 +3481,7 @@
 				);
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0940;
-				LastUpgradeCheck = 0940;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = Esri;
 				TargetAttributes = {
 					3E23A9DF1AFC28F6002E2214 = {
@@ -4054,6 +4054,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -4109,6 +4110,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;

--- a/arcgis-ios-sdk-samples.xcodeproj/xcshareddata/xcschemes/arcgis-ios-sdk-samples.xcscheme
+++ b/arcgis-ios-sdk-samples.xcodeproj/xcshareddata/xcschemes/arcgis-ios-sdk-samples.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
This PR updates the project settings to those recommended by Xcode 10.2. This addresses the "Upgrade to Recommended Settings" warning that Xcode 10.2 generates when opening the project. Xcode recommended enabling the `CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED` warning, although doing so has no effect since the app is not localized.

These changes are backwards compatible.