### PR TITLE
Increase loading priority of bundle resource request

### DIFF
--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ContentTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ContentTableViewController.swift
@@ -75,6 +75,7 @@ class ContentTableViewController: UITableViewController {
         //download on demand resources
         if !sample.dependencies.isEmpty {
             let bundleResourceRequest = NSBundleResourceRequest(tags: Set(sample.dependencies))
+            bundleResourceRequest.loadingPriority = NSBundleResourceRequestLoadingPriorityUrgent
             self.bundleResourceRequest = bundleResourceRequest
             
             //conditionally begin accessing to know if we need to show download progress view or not


### PR DESCRIPTION
The documentation for `NSBundleResourceRequestLoadingPriorityUrgent` states the following: "A special value for loading priority informing the system that the user cannot continue until the resources marked with the tags managed by the request are downloaded." Since we don't create the resource request until the user has selected the sample, this seems like an appropriate priority for us to use. Hopefully this will result in users being able to get to the sample faster.