### PR TITLE
Fix Xcode project indentation

### DIFF
--- a/arcgis-ios-sdk-samples.xcodeproj/project.pbxproj
+++ b/arcgis-ios-sdk-samples.xcodeproj/project.pbxproj
@@ -3098,8 +3098,8 @@
 				4C9912392245536C00CCBC2A /* PlayKMLTourViewController.swift */,
 			);
 			path = "Play a KML Tour";
-            sourceTree = "<group>";
-        };
+			sourceTree = "<group>";
+		};
 		4CA72CF5224D2F4400F8DCE1 /* Scene Layer Packages */ = {
 			isa = PBXGroup;
 			children = (


### PR DESCRIPTION
Incorrect indentation was introduced as a result of manually resolving a merge conflict. Xcode fixed the indentation, but not right away.