### PR TITLE
Add Bristol3DModel as dependency of Choose Camera Controller sample

### DIFF
--- a/arcgis-ios-sdk-samples/Content Display Logic/ContentPList.plist
+++ b/arcgis-ios-sdk-samples/Content Display Logic/ContentPList.plist
@@ -1410,6 +1410,10 @@
 				<string>ChooseCameraController</string>
 				<key>descriptionText</key>
 				<string>Control the behavior of the camera in a scene.</string>
+				<key>dependency</key>
+				<array>
+					<string>Bristol3DModel</string>
+				</array>
 			</dict>
 		</array>
 	</dict>


### PR DESCRIPTION
Fixes a bug where the model could not be found at runtime.