### PR TITLE
Migrate to Swift 5

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -43,7 +43,6 @@ opt_in_rules: # some rules are only opt-in
   - empty_xctest_method
   - explicit_init
   - extension_access_modifier
-  - fallthrough
   - fatal_error_message
   - first_where
   - function_default_parameter_at_end

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The ```master``` branch of this repository contains samples configured for the l
 ## Requirements
 
 * [ArcGIS Runtime SDK for iOS](https://developers.arcgis.com/ios/) 100.5.0 (or newer).
-* Xcode 10.1 (or newer)
+* Xcode 10.2 (or newer)
 
 The *ArcGIS Runtime SDK Samples app* has a *Target SDK* version of *11.0*, meaning that it can run on devices with *iOS 11.0* or newer.
 

--- a/arcgis-ios-sdk-samples.xcodeproj/project.pbxproj
+++ b/arcgis-ios-sdk-samples.xcodeproj/project.pbxproj
@@ -3770,12 +3770,12 @@
 				TargetAttributes = {
 					3E23A9DF1AFC28F6002E2214 = {
 						CreatedOnToolsVersion = 6.2;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					4CD2B5532142EAF900767D87 = {
 						CreatedOnToolsVersion = 9.4.1;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 3E23A9DF1AFC28F6002E2214;
 					};
@@ -4539,7 +4539,7 @@
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "arcgis-ios-sdk-samples/Content Display Logic/Samples-Bridging-Header.h";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -4571,7 +4571,7 @@
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "arcgis-ios-sdk-samples/Content Display Logic/Samples-Bridging-Header.h";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -4600,7 +4600,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.esri.arcgis-ios-sdk-samplesTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ArcGIS Runtime SDK Samples.app/ArcGIS Runtime SDK Samples";
 			};
@@ -4630,7 +4630,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.esri.arcgis-ios-sdk-samplesTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ArcGIS Runtime SDK Samples.app/ArcGIS Runtime SDK Samples";
 			};

--- a/arcgis-ios-sdk-samples/Analysis/Line of sight (geoelement)/LineOfSightGeoElementViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Line of sight (geoelement)/LineOfSightGeoElementViewController.swift
@@ -197,6 +197,8 @@ class LineOfSightGeoElementViewController: UIViewController {
             targetVisibilityLabel.text = "Visible"
             taxiGraphic.isSelected = true
         case .unknown:
+            fallthrough
+        @unknown default:
             targetVisibilityLabel.text = "Unknown"
             taxiGraphic.isSelected = false
         }

--- a/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/GroupByFieldsViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/GroupByFieldsViewController.swift
@@ -70,7 +70,7 @@ class GroupByFieldsViewController: UIViewController, UITableViewDataSource, UITa
                 cell.accessoryType = .none
                 
                 // Remove field from the group by fields
-                let index = selectedFieldNames.index(of: fieldNames[indexPath.row])
+                let index = selectedFieldNames.firstIndex(of: fieldNames[indexPath.row])
                 selectedFieldNames.remove(at: index!)
             }
             

--- a/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/OrderByFieldsViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/OrderByFieldsViewController.swift
@@ -104,7 +104,7 @@ class OrderByFieldsViewController: UIViewController, UITableViewDataSource, UITa
                 cell.accessoryType = .none
                 
                 // Remove field from the selected order by fields
-                let index = selectedOrderByFields.index(of: orderByFields[indexPath.row])
+                let index = selectedOrderByFields.firstIndex(of: orderByFields[indexPath.row])
                 selectedOrderByFields.remove(at: index!)
             }
             
@@ -147,15 +147,19 @@ class OrderByFieldsViewController: UIViewController, UITableViewDataSource, UITa
             return "Ascending"
         case .descending:
             return "Descending"
+        @unknown default:
+            return "Unknown"
         }
     }
     
-    private func imageFor(sortOrder: AGSSortOrder) -> UIImage {
+    private func imageFor(sortOrder: AGSSortOrder) -> UIImage? {
         switch sortOrder {
         case .ascending:
             return UIImage(named: "Ascending")!
         case .descending:
             return UIImage(named: "Descending")!
+        @unknown default:
+            return nil
         }
     }
 }

--- a/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/StatisticalQueryGroupAndSortViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/StatisticalQueryGroupAndSortViewController.swift
@@ -363,6 +363,8 @@ class StatisticalQueryGroupAndSortViewController: UIViewController, UITableViewD
             return "Ascending"
         case .descending:
             return "Descending"
+        @unknown default:
+            return "Unknown"
         }
     }
 }

--- a/arcgis-ios-sdk-samples/Analysis/Viewshed (camera)/ViewshedCameraViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Viewshed (camera)/ViewshedCameraViewController.swift
@@ -51,7 +51,8 @@ class ViewshedCameraViewController: UIViewController {
         scene.operationalLayers.add(buildings)
         
         // create a viewshed from the camera with minimum and maximum distance (in meters) from the observer (camera) at which visibility will be evaluated
-        viewshed = AGSLocationViewshed(camera: camera, minDistance: 1.0, maxDistance: 500.0)
+        let viewshed = AGSLocationViewshed(camera: camera, minDistance: 1.0, maxDistance: 500.0)
+        self.viewshed = viewshed
         
         // create an analysis overlay for the viewshed and to add it to the scene view
         let analysisOverlay = AGSAnalysisOverlay()

--- a/arcgis-ios-sdk-samples/Analysis/Viewshed (camera)/ViewshedCameraViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Viewshed (camera)/ViewshedCameraViewController.swift
@@ -52,12 +52,14 @@ class ViewshedCameraViewController: UIViewController {
         
         // create a viewshed from the camera with minimum and maximum distance (in meters) from the observer (camera) at which visibility will be evaluated
         let viewshed = AGSLocationViewshed(camera: camera, minDistance: 1.0, maxDistance: 500.0)
-        self.viewshed = viewshed
         
         // create an analysis overlay for the viewshed and to add it to the scene view
         let analysisOverlay = AGSAnalysisOverlay()
         analysisOverlay.analyses.add(viewshed)
         sceneView.analysisOverlays.add(analysisOverlay)
+        
+        // store the viewshed for later use
+        self.viewshed = viewshed
     }
     
     // MARK: - Actions

--- a/arcgis-ios-sdk-samples/Cloud & Portal/Integrated Windows Authentication/IntegratedWindowsAuthenticationViewController.swift
+++ b/arcgis-ios-sdk-samples/Cloud & Portal/Integrated Windows Authentication/IntegratedWindowsAuthenticationViewController.swift
@@ -79,8 +79,10 @@ class IntegratedWindowsAuthenticationViewController: UITableViewController {
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         
-        NotificationCenter.default.removeObserver(textDidChangeObserver)
-        textDidChangeObserver = nil
+        if let observer = textDidChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+            textDidChangeObserver = nil
+        }
     }
 }
 

--- a/arcgis-ios-sdk-samples/Display information/Identify graphics/GOIdentifyViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Identify graphics/GOIdentifyViewController.swift
@@ -19,7 +19,7 @@ class GOIdentifyViewController: UIViewController, AGSGeoViewTouchDelegate {
     @IBOutlet private weak var mapView: AGSMapView!
     
     private var map: AGSMap!
-    private var graphicsOverlay: AGSGraphicsOverlay!
+    private let graphicsOverlay = AGSGraphicsOverlay()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -53,8 +53,6 @@ class GOIdentifyViewController: UIViewController, AGSGeoViewTouchDelegate {
         let polygonSymbol = AGSSimpleFillSymbol(style: AGSSimpleFillSymbolStyle.solid, color: .yellow, outline: nil)
         let polygonGraphic = AGSGraphic(geometry: polygonGeometry.toGeometry(), symbol: nil, attributes: nil)
         
-        //initialize the graphics overlay
-        self.graphicsOverlay = AGSGraphicsOverlay()
         //assign the renderer
         self.graphicsOverlay.renderer = AGSSimpleRenderer(symbol: polygonSymbol)
         //add the polygon graphic

--- a/arcgis-ios-sdk-samples/Display information/Show legend/MILShowLegendViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Show legend/MILShowLegendViewController.swift
@@ -20,7 +20,6 @@ class MILShowLegendViewController: UIViewController, UIAdaptivePresentationContr
     @IBOutlet private weak var legendBBI: UIBarButtonItem!
     
     private var map: AGSMap!
-    private var mapImageLayer: AGSArcGISMapImageLayer!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -36,9 +35,9 @@ class MILShowLegendViewController: UIViewController, UIAdaptivePresentationContr
         self.map.operationalLayers.add(tiledLayer)
         
         //create a map image layer using a url
-        self.mapImageLayer = AGSArcGISMapImageLayer(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer")!)
+        let mapImageLayer = AGSArcGISMapImageLayer(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer")!)
         //add the image layer to the map
-        self.map.operationalLayers.add(self.mapImageLayer)
+        self.map.operationalLayers.add(mapImageLayer)
         
         //create feature table using a url
         let featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0")!)

--- a/arcgis-ios-sdk-samples/Display information/Unique value renderer/UniqueValueRendererViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Unique value renderer/UniqueValueRendererViewController.swift
@@ -33,7 +33,6 @@ class UniqueValueRendererViewController: UIViewController {
         //create feature layer
         let featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3")!)
         let featureLayer = AGSFeatureLayer(featureTable: featureTable)
-        self.featureLayer = featureLayer
         
         //add the layer to the map as operational layer
         map.operationalLayers.add(featureLayer)
@@ -47,6 +46,9 @@ class UniqueValueRendererViewController: UIViewController {
         
         //add unique value renderer
         self.addUniqueValueRenderer()
+        
+        //store the feature layer for later use
+        self.featureLayer = featureLayer
     }
 
     private func addUniqueValueRenderer() {

--- a/arcgis-ios-sdk-samples/Display information/Unique value renderer/UniqueValueRendererViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Unique value renderer/UniqueValueRendererViewController.swift
@@ -32,10 +32,11 @@ class UniqueValueRendererViewController: UIViewController {
         
         //create feature layer
         let featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3")!)
-        self.featureLayer = AGSFeatureLayer(featureTable: featureTable)
+        let featureLayer = AGSFeatureLayer(featureTable: featureTable)
+        self.featureLayer = featureLayer
         
         //add the layer to the map as operational layer
-        map.operationalLayers.add(self.featureLayer)
+        map.operationalLayers.add(featureLayer)
         
         //assign map to the map view
         self.mapView.map = map

--- a/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
@@ -19,7 +19,6 @@ class AddFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate {
     @IBOutlet private var mapView: AGSMapView!
     
     private var featureTable: AGSServiceFeatureTable!
-    private var featureLayer: AGSFeatureLayer!
     private var lastQuery: AGSCancelable!
     
     override func viewDidLoad() {
@@ -41,7 +40,7 @@ class AddFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate {
         //instantiate service feature table using the url to the service
         self.featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0")!)
         //create a feature layer using the service feature table
-        self.featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
+        let featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
         
         //add the feature layer to the operational layers on map
         map.operationalLayers.add(featureLayer)

--- a/arcgis-ios-sdk-samples/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
@@ -42,7 +42,8 @@ class DeleteFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate, A
         //instantiate service feature table using the url to the service
         self.featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0")!)
         //create a feature layer using the service feature table
-        self.featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
+        let featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
+        self.featureLayer = featureLayer
         
         //add the feature layer to the operational layers on map
         map.operationalLayers.add(featureLayer)

--- a/arcgis-ios-sdk-samples/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
@@ -43,10 +43,12 @@ class DeleteFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate, A
         self.featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0")!)
         //create a feature layer using the service feature table
         let featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
-        self.featureLayer = featureLayer
         
         //add the feature layer to the operational layers on map
         map.operationalLayers.add(featureLayer)
+        
+        //store the feature layer for later use
+        self.featureLayer = featureLayer
     }
     
     func showCallout(for feature: AGSFeature, at tapLocation: AGSPoint) {

--- a/arcgis-ios-sdk-samples/Edit data/Edit features (connected)/EditFeaturesOnlineViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit features (connected)/EditFeaturesOnlineViewController.swift
@@ -41,7 +41,6 @@ class EditFeaturesOnlineViewController: UIViewController, AGSGeoViewTouchDelegat
         
         let featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0")!)
         let featureLayer = AGSFeatureLayer(featureTable: featureTable)
-        self.featureLayer = featureLayer
         self.map.operationalLayers.add(featureLayer)
         
         //initialize sketch editor and assign to map view
@@ -50,6 +49,9 @@ class EditFeaturesOnlineViewController: UIViewController, AGSGeoViewTouchDelegat
                 
         //hide the sketchToolbar initially
         self.sketchToolbar.isHidden = true
+        
+        //store the feature layer for later use
+        self.featureLayer = featureLayer
     }
     
     private func dismissFeatureTemplatePickerVC() {

--- a/arcgis-ios-sdk-samples/Edit data/Edit features (connected)/EditFeaturesOnlineViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit features (connected)/EditFeaturesOnlineViewController.swift
@@ -40,7 +40,8 @@ class EditFeaturesOnlineViewController: UIViewController, AGSGeoViewTouchDelegat
         self.mapView.touchDelegate = self
         
         let featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0")!)
-        self.featureLayer = AGSFeatureLayer(featureTable: featureTable)
+        let featureLayer = AGSFeatureLayer(featureTable: featureTable)
+        self.featureLayer = featureLayer
         self.map.operationalLayers.add(featureLayer)
         
         //initialize sketch editor and assign to map view

--- a/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/EditAttributesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/EditAttributesViewController.swift
@@ -41,12 +41,14 @@ class EditAttributesViewController: UIViewController, AGSGeoViewTouchDelegate, A
         
         self.featureTable = AGSServiceFeatureTable(url: URL(string: featureServiceURL)!)
         let featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
-        self.featureLayer = featureLayer
         
         self.map.operationalLayers.add(featureLayer)
         
         self.mapView.map = self.map
         self.mapView.touchDelegate = self
+        
+        //store the feature layer for later use
+        self.featureLayer = featureLayer
     }
     
     func showCallout(_ feature: AGSFeature, tapLocation: AGSPoint?) {

--- a/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/EditAttributesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/EditAttributesViewController.swift
@@ -40,9 +40,10 @@ class EditAttributesViewController: UIViewController, AGSGeoViewTouchDelegate, A
         self.map.initialViewpoint = AGSViewpoint(center: AGSPoint(x: 544871.19, y: 6806138.66, spatialReference: .webMercator()), scale: 2e6)
         
         self.featureTable = AGSServiceFeatureTable(url: URL(string: featureServiceURL)!)
-        self.featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
+        let featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
+        self.featureLayer = featureLayer
         
-        self.map.operationalLayers.add(self.featureLayer)
+        self.map.operationalLayers.add(featureLayer)
         
         self.mapView.map = self.map
         self.mapView.touchDelegate = self

--- a/arcgis-ios-sdk-samples/Edit data/Update geometries (feature service)/EditGeometryViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update geometries (feature service)/EditGeometryViewController.swift
@@ -40,12 +40,14 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
         
         self.featureTable = AGSServiceFeatureTable(url: URL(string: featureServiceURL)!)
         let featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
-        self.featureLayer = featureLayer
         
         self.map.operationalLayers.add(featureLayer)
 
         self.mapView.map = self.map
         self.mapView.touchDelegate = self
+        
+        //store the feature layer for later use
+        self.featureLayer = featureLayer
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/arcgis-ios-sdk-samples/Edit data/Update geometries (feature service)/EditGeometryViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update geometries (feature service)/EditGeometryViewController.swift
@@ -39,9 +39,10 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
         self.map.initialViewpoint = AGSViewpoint(center: AGSPoint(x: -9030446.96, y: 943791.32, spatialReference: .webMercator()), scale: 2e6)
         
         self.featureTable = AGSServiceFeatureTable(url: URL(string: featureServiceURL)!)
-        self.featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
+        let featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
+        self.featureLayer = featureLayer
         
-        self.map.operationalLayers.add(self.featureLayer)
+        self.map.operationalLayers.add(featureLayer)
 
         self.mapView.map = self.map
         self.mapView.touchDelegate = self

--- a/arcgis-ios-sdk-samples/Features/Add delete related features/AddDeleteRelatedFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Add delete related features/AddDeleteRelatedFeaturesViewController.swift
@@ -21,7 +21,6 @@ class AddDeleteRelatedFeaturesViewController: UIViewController, AGSGeoViewTouchD
     @IBOutlet var mapView: AGSMapView!
     
     private var parksFeatureTable: AGSServiceFeatureTable!
-    private var speciesFeatureTable: AGSServiceFeatureTable!
     private var parksFeatureLayer: AGSFeatureLayer!
     
     private var selectedPark: AGSFeature!
@@ -45,18 +44,19 @@ class AddDeleteRelatedFeaturesViewController: UIViewController, AGSGeoViewTouchD
         self.parksFeatureTable = AGSServiceFeatureTable(url: URL(string: "https://services2.arcgis.com/ZQgQTuoyBrtmoGdP/ArcGIS/rest/services/AlaskaNationalParksSpecies_Add_Delete/FeatureServer/0")!)
         
         //parks feature layer
-        self.parksFeatureLayer = AGSFeatureLayer(featureTable: self.parksFeatureTable)
+        let parksFeatureLayer = AGSFeatureLayer(featureTable: self.parksFeatureTable)
+        self.parksFeatureLayer = parksFeatureLayer
         
         //add feature layer to the map
-        map.operationalLayers.add(self.parksFeatureLayer)
+        map.operationalLayers.add(parksFeatureLayer)
         
         //species feature table (destination feature table)
         //related to the parks feature layer in a 1..M relationship
-        self.speciesFeatureTable = AGSServiceFeatureTable(url: URL(string: "https://services2.arcgis.com/ZQgQTuoyBrtmoGdP/ArcGIS/rest/services/AlaskaNationalParksSpecies_Add_Delete/FeatureServer/1")!)
+        let speciesFeatureTable = AGSServiceFeatureTable(url: URL(string: "https://services2.arcgis.com/ZQgQTuoyBrtmoGdP/ArcGIS/rest/services/AlaskaNationalParksSpecies_Add_Delete/FeatureServer/1")!)
         
         //add table to the map
         //for the related query to work, the related table should be present in the map
-        map.tables.addObjects(from: [speciesFeatureTable])
+        map.tables.add(speciesFeatureTable)
         
         //assign map to map view
         self.mapView.map = map

--- a/arcgis-ios-sdk-samples/Features/Add delete related features/AddDeleteRelatedFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Add delete related features/AddDeleteRelatedFeaturesViewController.swift
@@ -45,7 +45,6 @@ class AddDeleteRelatedFeaturesViewController: UIViewController, AGSGeoViewTouchD
         
         //parks feature layer
         let parksFeatureLayer = AGSFeatureLayer(featureTable: self.parksFeatureTable)
-        self.parksFeatureLayer = parksFeatureLayer
         
         //add feature layer to the map
         map.operationalLayers.add(parksFeatureLayer)
@@ -63,6 +62,9 @@ class AddDeleteRelatedFeaturesViewController: UIViewController, AGSGeoViewTouchD
         
         //set touch delegate
         self.mapView.touchDelegate = self
+        
+        //store the feature layer for later use
+        self.parksFeatureLayer = parksFeatureLayer
     }
     
     // MARK: - AGSGeoViewTouchDelegate

--- a/arcgis-ios-sdk-samples/Features/Change feature layer renderer/OverrideRendererViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Change feature layer renderer/OverrideRendererViewController.swift
@@ -37,9 +37,10 @@ class OverrideRendererViewController: UIViewController {
         //initialize feature table using a url to feature server url
         let featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0")!)
         //initialize feature layer with feature table
-        self.featureLayer = AGSFeatureLayer(featureTable: featureTable)
+        let featureLayer = AGSFeatureLayer(featureTable: featureTable)
+        self.featureLayer = featureLayer
         //add the feature layer to the operational layers on the map view
-        self.map.operationalLayers.add(self.featureLayer)
+        self.map.operationalLayers.add(featureLayer)
     }
     
     @IBAction private func overrideRenderer() {

--- a/arcgis-ios-sdk-samples/Features/Change feature layer renderer/OverrideRendererViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Change feature layer renderer/OverrideRendererViewController.swift
@@ -38,9 +38,11 @@ class OverrideRendererViewController: UIViewController {
         let featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0")!)
         //initialize feature layer with feature table
         let featureLayer = AGSFeatureLayer(featureTable: featureTable)
-        self.featureLayer = featureLayer
         //add the feature layer to the operational layers on the map view
         self.map.operationalLayers.add(featureLayer)
+        
+        //store the feature layer for later use
+        self.featureLayer = featureLayer
     }
     
     @IBAction private func overrideRenderer() {

--- a/arcgis-ios-sdk-samples/Features/Feature layer definition expression/DefinitionExpressionViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer definition expression/DefinitionExpressionViewController.swift
@@ -38,10 +38,11 @@ class DefinitionExpressionViewController: UIViewController {
         //create feature table using a url to feature server's layer
         let featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0")!)
         //create feature layer using this feature table
-        self.featureLayer = AGSFeatureLayer(featureTable: featureTable)
+        let featureLayer = AGSFeatureLayer(featureTable: featureTable)
+        self.featureLayer = featureLayer
         
         //add the feature layer to the map
-        self.map.operationalLayers.add(self.featureLayer)
+        self.map.operationalLayers.add(featureLayer)
     }
     
     @IBAction func applyDefinitionExpression() {

--- a/arcgis-ios-sdk-samples/Features/Feature layer definition expression/DefinitionExpressionViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer definition expression/DefinitionExpressionViewController.swift
@@ -39,10 +39,12 @@ class DefinitionExpressionViewController: UIViewController {
         let featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0")!)
         //create feature layer using this feature table
         let featureLayer = AGSFeatureLayer(featureTable: featureTable)
-        self.featureLayer = featureLayer
         
         //add the feature layer to the map
         self.map.operationalLayers.add(featureLayer)
+        
+        //store the feature layer for later use
+        self.featureLayer = featureLayer
     }
     
     @IBAction func applyDefinitionExpression() {

--- a/arcgis-ios-sdk-samples/Features/List related features/ListRelatedFeaturesVC.swift
+++ b/arcgis-ios-sdk-samples/Features/List related features/ListRelatedFeaturesVC.swift
@@ -48,7 +48,6 @@ class ListRelatedFeaturesVC: UIViewController, AGSGeoViewTouchDelegate {
         
         //feature layer for parks
         let parksFeatureLayer = AGSFeatureLayer(featureTable: self.parksFeatureTable)
-        self.parksFeatureLayer = parksFeatureLayer
         
         //add parks feature layer to the map
         map.operationalLayers.add(parksFeatureLayer)
@@ -69,6 +68,9 @@ class ListRelatedFeaturesVC: UIViewController, AGSGeoViewTouchDelegate {
         
         //set selection color
         mapView.selectionProperties.color = .yellow
+        
+        //store the feature layer for later use
+        self.parksFeatureLayer = parksFeatureLayer
     }
     
     // MARK: - AGSGeoViewTouchDelegate

--- a/arcgis-ios-sdk-samples/Features/List related features/ListRelatedFeaturesVC.swift
+++ b/arcgis-ios-sdk-samples/Features/List related features/ListRelatedFeaturesVC.swift
@@ -20,8 +20,6 @@ class ListRelatedFeaturesVC: UIViewController, AGSGeoViewTouchDelegate {
     
     private var parksFeatureLayer: AGSFeatureLayer!
     private var parksFeatureTable: AGSServiceFeatureTable!
-    private var preservesFeatureTable: AGSServiceFeatureTable!
-    private var speciesFeatureTable: AGSServiceFeatureTable!
     private var selectedPark: AGSArcGISFeature!
     private var screenPoint: CGPoint!
     
@@ -49,16 +47,17 @@ class ListRelatedFeaturesVC: UIViewController, AGSGeoViewTouchDelegate {
         self.parksFeatureTable = AGSServiceFeatureTable(url: URL(string: "https://services2.arcgis.com/ZQgQTuoyBrtmoGdP/arcgis/rest/services/AlaskaNationalParksPreservesSpecies_List/FeatureServer/1")!)
         
         //feature layer for parks
-        self.parksFeatureLayer = AGSFeatureLayer(featureTable: self.parksFeatureTable)
+        let parksFeatureLayer = AGSFeatureLayer(featureTable: self.parksFeatureTable)
+        self.parksFeatureLayer = parksFeatureLayer
         
         //add parks feature layer to the map
-        map.operationalLayers.add(self.parksFeatureLayer)
+        map.operationalLayers.add(parksFeatureLayer)
         
         //Feature table for related Preserves layer
-        self.preservesFeatureTable = AGSServiceFeatureTable(url: URL(string: "https://services2.arcgis.com/ZQgQTuoyBrtmoGdP/arcgis/rest/services/AlaskaNationalParksPreservesSpecies_List/FeatureServer/0")!)
+        let preservesFeatureTable = AGSServiceFeatureTable(url: URL(string: "https://services2.arcgis.com/ZQgQTuoyBrtmoGdP/arcgis/rest/services/AlaskaNationalParksPreservesSpecies_List/FeatureServer/0")!)
         
         //Feature table for related Species layer
-        self.speciesFeatureTable = AGSServiceFeatureTable(url: URL(string: "https://services2.arcgis.com/ZQgQTuoyBrtmoGdP/arcgis/rest/services/AlaskaNationalParksPreservesSpecies_List/FeatureServer/2")!)
+        let speciesFeatureTable = AGSServiceFeatureTable(url: URL(string: "https://services2.arcgis.com/ZQgQTuoyBrtmoGdP/arcgis/rest/services/AlaskaNationalParksPreservesSpecies_List/FeatureServer/2")!)
         
         //add these to the tables on the map
         //to query related features in a layer, the layer must either be added as a feature

--- a/arcgis-ios-sdk-samples/Geometry/Spatial operations/SpatialOperationsViewController.swift
+++ b/arcgis-ios-sdk-samples/Geometry/Spatial operations/SpatialOperationsViewController.swift
@@ -117,8 +117,9 @@ class SpatialOperationsViewController: UIViewController, OperationsListVCDelegat
         
         //create result graphic if not present
         if self.resultGraphic == nil {
-            self.resultGraphic = AGSGraphic(geometry: resultGeometry, symbol: symbol, attributes: nil)
-            self.graphicsOverlay.graphics.add(self.resultGraphic)
+            let graphic = AGSGraphic(geometry: resultGeometry, symbol: symbol, attributes: nil)
+            self.resultGraphic = graphic
+            self.graphicsOverlay.graphics.add(graphic)
         }
             //update the geometry if already present
         else {
@@ -142,8 +143,8 @@ class SpatialOperationsViewController: UIViewController, OperationsListVCDelegat
     
     func operationsListViewController(_ operationsListViewController: OperationsListViewController, didSelectOperation index: Int) {
         if index == 0 {
-            if self.resultGraphic != nil {
-                self.graphicsOverlay.graphics.remove(self.resultGraphic)
+            if let resultGraphic = resultGraphic {
+                self.graphicsOverlay.graphics.remove(resultGraphic)
                 self.resultGraphic = nil
             }
         } else {

--- a/arcgis-ios-sdk-samples/Geometry/Spatial operations/SpatialOperationsViewController.swift
+++ b/arcgis-ios-sdk-samples/Geometry/Spatial operations/SpatialOperationsViewController.swift
@@ -118,8 +118,8 @@ class SpatialOperationsViewController: UIViewController, OperationsListVCDelegat
         //create result graphic if not present
         if self.resultGraphic == nil {
             let graphic = AGSGraphic(geometry: resultGeometry, symbol: symbol, attributes: nil)
-            self.resultGraphic = graphic
             self.graphicsOverlay.graphics.add(graphic)
+            self.resultGraphic = graphic
         }
             //update the geometry if already present
         else {

--- a/arcgis-ios-sdk-samples/Layers/Change sublayer visibility/SublayerVisibilityViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Change sublayer visibility/SublayerVisibilityViewController.swift
@@ -32,7 +32,6 @@ class SublayerVisibilityViewController: UIViewController {
         
         //initialize the map image layer using a url
         let mapImageLayer = AGSArcGISMapImageLayer(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer")!)
-        self.mapImageLayer = mapImageLayer
         
         //add the image layer to the map
         self.map.operationalLayers.add(mapImageLayer)
@@ -42,6 +41,9 @@ class SublayerVisibilityViewController: UIViewController {
         
         //zoom to a custom viewpoint
         self.mapView.setViewpointCenter(AGSPoint(x: -11e6, y: 6e6, spatialReference: .webMercator()), scale: 9e7)
+        
+        //store the map image layer for later use
+        self.mapImageLayer = mapImageLayer
     }
     
     // MARK: - Navigation

--- a/arcgis-ios-sdk-samples/Layers/Change sublayer visibility/SublayerVisibilityViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Change sublayer visibility/SublayerVisibilityViewController.swift
@@ -31,10 +31,11 @@ class SublayerVisibilityViewController: UIViewController {
         self.map = AGSMap(basemap: .topographic())
         
         //initialize the map image layer using a url
-        self.mapImageLayer = AGSArcGISMapImageLayer(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer")!)
+        let mapImageLayer = AGSArcGISMapImageLayer(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer")!)
+        self.mapImageLayer = mapImageLayer
         
         //add the image layer to the map
-        self.map.operationalLayers.add(self.mapImageLayer)
+        self.map.operationalLayers.add(mapImageLayer)
         
         //assign the map to the map view
         self.mapView.map = self.map

--- a/arcgis-ios-sdk-samples/Layers/Hillshade renderer/HillshadeSettingsVC.swift
+++ b/arcgis-ios-sdk-samples/Layers/Hillshade renderer/HillshadeSettingsVC.swift
@@ -45,6 +45,7 @@ class HillshadeSettingsVC: UITableViewController {
         case .degree: return "Degree"
         case .percentRise: return "Percent Rise"
         case .scaled: return "Scaled"
+        @unknown default: return "Unknown"
         }
     }
     

--- a/arcgis-ios-sdk-samples/Layers/List KML contents/ListKMLContentsSceneViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/List KML contents/ListKMLContentsSceneViewController.swift
@@ -160,6 +160,8 @@ class ListKMLContentsSceneViewController: UIViewController {
             // only the camera parameter is used by the scene
             return AGSViewpoint(center: kmlViewpoint.location, scale: 1, camera: camera)
         case .unknown:
+            fallthrough
+        @unknown default:
             print("Unexpected AGSKMLViewpointType \(kmlViewpoint.type)")
             return nil
         }

--- a/arcgis-ios-sdk-samples/Layers/Manage sublayers/ManageSublayersViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Manage sublayers/ManageSublayersViewController.swift
@@ -33,10 +33,11 @@ class ManageSublayersViewController: UIViewController, MapImageSublayersViewCont
         let map = AGSMap(basemap: .streets())
         
         //initialize map image layer
-        self.mapImageLayer = AGSArcGISMapImageLayer(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer")!)
+        let mapImageLayer = AGSArcGISMapImageLayer(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer")!)
+        self.mapImageLayer = mapImageLayer
         
         //add layer to map
-        map.operationalLayers.add(self.mapImageLayer)
+        map.operationalLayers.add(mapImageLayer)
         
         //initial viewpoint
         let envelope = AGSEnvelope(xMin: -13834661.666904, yMin: 331181.323482, xMax: -8255704.998713, yMax: 9118038.075882, spatialReference: .webMercator())

--- a/arcgis-ios-sdk-samples/Layers/Manage sublayers/ManageSublayersViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Manage sublayers/ManageSublayersViewController.swift
@@ -34,7 +34,6 @@ class ManageSublayersViewController: UIViewController, MapImageSublayersViewCont
         
         //initialize map image layer
         let mapImageLayer = AGSArcGISMapImageLayer(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer")!)
-        self.mapImageLayer = mapImageLayer
         
         //add layer to map
         map.operationalLayers.add(mapImageLayer)
@@ -50,6 +49,9 @@ class ManageSublayersViewController: UIViewController, MapImageSublayersViewCont
         
         //create sublayers from tableSublayerSource
         self.createSublayers()
+        
+        //store the map image layer for later use
+        self.mapImageLayer = mapImageLayer
     }
     
     private func createSublayers() {

--- a/arcgis-ios-sdk-samples/Layers/Play a KML Tour/PlayKMLTourViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Play a KML Tour/PlayKMLTourViewController.swift
@@ -121,6 +121,8 @@ class PlayKMLTourViewController: UIViewController {
         case .playing:
             rewindButtonItem.isEnabled = true
             playPauseButtonItem = pauseButtonItem
+        @unknown default:
+            return
         }
         let indexOfPlayPause = toolbar.items!.midIndex
         toolbar.items![indexOfPlayPause] = playPauseButtonItem

--- a/arcgis-ios-sdk-samples/Maps/Display device location/DisplayLocationSettingsViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Display device location/DisplayLocationSettingsViewController.swift
@@ -41,10 +41,12 @@ class DisplayLocationSettingsViewController: UITableViewController {
             return "Navigation"
         case .compassNavigation:
             return "Compass Navigation"
+        @unknown default:
+            return "Unknown"
         }
     }
     
-    private func icon(for autoPanMode: AGSLocationDisplayAutoPanMode) -> UIImage {
+    private func icon(for autoPanMode: AGSLocationDisplayAutoPanMode) -> UIImage? {
         switch autoPanMode {
         case .off:
             return #imageLiteral(resourceName: "LocationDisplayOffIcon")
@@ -54,6 +56,8 @@ class DisplayLocationSettingsViewController: UITableViewController {
             return #imageLiteral(resourceName: "LocationDisplayNavigationIcon")
         case .compassNavigation:
             return #imageLiteral(resourceName: "LocationDisplayHeadingIcon")
+        @unknown default:
+            return nil
         }
     }
     

--- a/arcgis-ios-sdk-samples/Maps/Identify layers/IdentifyLayersViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Identify layers/IdentifyLayersViewController.swift
@@ -20,9 +20,6 @@ class IdentifyLayersViewController: UIViewController, AGSGeoViewTouchDelegate {
     
     private var map: AGSMap!
     
-    private var featureLayer: AGSFeatureLayer!
-    private var mapImageLayer: AGSArcGISMapImageLayer!
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -33,25 +30,25 @@ class IdentifyLayersViewController: UIViewController, AGSGeoViewTouchDelegate {
         self.map = AGSMap(basemap: .topographic())
         
         //map image layer
-        self.mapImageLayer = AGSArcGISMapImageLayer(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer")!)
+        let mapImageLayer = AGSArcGISMapImageLayer(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer")!)
         
         //hide Continent and World layers
-        self.mapImageLayer.load { [weak self] (error: Error?) in
+        mapImageLayer.load { [weak mapImageLayer] (error: Error?) in
             if error == nil {
-                self?.mapImageLayer.subLayerContents[1].isVisible = false
-                self?.mapImageLayer.subLayerContents[2].isVisible = false
+                mapImageLayer?.subLayerContents[1].isVisible = false
+                mapImageLayer?.subLayerContents[2].isVisible = false
             }
         }
-        self.map.operationalLayers.add(self.mapImageLayer)
+        self.map.operationalLayers.add(mapImageLayer)
         
         //feature table
         let featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0")!)
     
         //feature layer
-        self.featureLayer = AGSFeatureLayer(featureTable: featureTable)
+        let featureLayer = AGSFeatureLayer(featureTable: featureTable)
         
         //add feature layer add to the operational layers
-        self.map.operationalLayers.add(self.featureLayer)
+        self.map.operationalLayers.add(featureLayer)
         
         //set initial viewpoint to a specific region
         self.map.initialViewpoint = AGSViewpoint(center: AGSPoint(x: -10977012.785807, y: 4514257.550369, spatialReference: .webMercator()), scale: 68015210)

--- a/arcgis-ios-sdk-samples/Maps/Manage operational layers/MMLLayersViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Manage operational layers/MMLLayersViewController.swift
@@ -149,6 +149,8 @@ class MMLLayersViewController: UITableViewController {
             })
         case .none:
             break
+        @unknown default:
+            break
         }
     }
 }

--- a/arcgis-ios-sdk-samples/Maps/Map loaded/MapLoadedViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Map loaded/MapLoadedViewController.swift
@@ -65,6 +65,8 @@ private extension AGSLoadStatus {
         case .notLoaded:
             return "Not Loaded"
         case .unknown:
+            fallthrough
+        @unknown default:
             return "Unknown"
         }
     }

--- a/arcgis-ios-sdk-samples/Maps/Map reference scale/MapReferenceScaleLayerSelectionViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Map reference scale/MapReferenceScaleLayerSelectionViewController.swift
@@ -53,7 +53,7 @@ class MapReferenceScaleLayerSelectionViewController: UITableViewController {
     ///
     /// - Parameter layer: A layer.
     func selectLayer(_ layer: AGSLayer) {
-        guard let row = layers.index(of: layer) else { return }
+        guard let row = layers.firstIndex(of: layer) else { return }
         let indexPath = IndexPath(row: row, section: 0)
         indexPathsForSelectedRows.insert(indexPath)
     }

--- a/arcgis-ios-sdk-samples/Maps/Map reference scale/MapReferenceScaleSettingsViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Map reference scale/MapReferenceScaleSettingsViewController.swift
@@ -107,7 +107,7 @@ class MapReferenceScaleSettingsViewController: UITableViewController {
             }
         })
         
-        if let row = possibleReferenceScales.index(of: Int(map.referenceScale.rounded(.toNearestOrAwayFromZero))) {
+        if let row = possibleReferenceScales.firstIndex(of: Int(map.referenceScale.rounded(.toNearestOrAwayFromZero))) {
             referenceScalePickerView.selectRow(row, inComponent: 0, animated: false)
         }
         

--- a/arcgis-ios-sdk-samples/Maps/Read a geopackage/GPKGLayersViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Read a geopackage/GPKGLayersViewController.swift
@@ -138,7 +138,7 @@ class GPKGLayersViewController: UITableViewController {
             tableView.deleteRows(at: [indexPath], with: .automatic)
             
             // Insert the removed row back in the section for layers not in the map.
-            if let index = layersNotInMap.index(of: layer) {
+            if let index = layersNotInMap.firstIndex(of: layer) {
                 let newIndexPath = IndexPath(row: index, section: 1)
                 tableView.insertRows(at: [newIndexPath], with: .automatic)
             }

--- a/arcgis-ios-sdk-samples/Route & Directions/Offline routing/OfflineRoutingViewController.swift
+++ b/arcgis-ios-sdk-samples/Route & Directions/Offline routing/OfflineRoutingViewController.swift
@@ -128,8 +128,9 @@ class OfflineRoutingViewController: UIViewController, AGSGeoViewTouchDelegate {
     func geoView(_ geoView: AGSGeoView, didLongPressAtScreenPoint screenPoint: CGPoint, mapPoint: AGSPoint) {
         //add the graphic at that point
         //keep a reference to that graphic to update the geometry if moved
-        self.longPressedGraphic = self.graphicForLocation(mapPoint)
-        self.stopGraphicsOverlay.graphics.add(self.longPressedGraphic)
+        let graphic = graphicForLocation(mapPoint)
+        self.longPressedGraphic = graphic
+        self.stopGraphicsOverlay.graphics.add(graphic)
         //clear the route graphic
         self.longPressedRouteGraphic = nil
         //route
@@ -218,12 +219,12 @@ class OfflineRoutingViewController: UIViewController, AGSGeoViewTouchDelegate {
     func displayRoutesOnMap(_ routes: [AGSRoute]?, isLongPressedResult: Bool) {
         //if a route graphic for previous request (in case of long press)
         //exists then remove it
-        if self.longPressedRouteGraphic != nil {
+        if let longPressedRouteGraphic = longPressedRouteGraphic {
             //update distance and time
             self.totalTime -= Double(truncating: self.longPressedGraphic.attributes["routeTime"] as! NSNumber)
             self.totalDistance -= Double(truncating: self.longPressedGraphic.attributes["routeLength"] as! NSNumber)
             
-            self.routeGraphicsOverlay.graphics.remove(self.longPressedRouteGraphic)
+            self.routeGraphicsOverlay.graphics.remove(longPressedRouteGraphic)
             self.longPressedRouteGraphic = nil
         }
         

--- a/arcgis-ios-sdk-samples/Route & Directions/Offline routing/OfflineRoutingViewController.swift
+++ b/arcgis-ios-sdk-samples/Route & Directions/Offline routing/OfflineRoutingViewController.swift
@@ -129,8 +129,8 @@ class OfflineRoutingViewController: UIViewController, AGSGeoViewTouchDelegate {
         //add the graphic at that point
         //keep a reference to that graphic to update the geometry if moved
         let graphic = graphicForLocation(mapPoint)
-        self.longPressedGraphic = graphic
         self.stopGraphicsOverlay.graphics.add(graphic)
+        self.longPressedGraphic = graphic
         //clear the route graphic
         self.longPressedRouteGraphic = nil
         //route

--- a/arcgis-ios-sdk-samples/Scenes/Extrude graphics/ExtrudeGraphicsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Extrude graphics/ExtrudeGraphicsViewController.swift
@@ -20,7 +20,7 @@ import ArcGIS
 class ExtrudeGraphicsViewController: UIViewController {
     @IBOutlet var sceneView: AGSSceneView!
     
-    private var graphicsOverlay: AGSGraphicsOverlay!
+    private let graphicsOverlay = AGSGraphicsOverlay()
     
     private let cameraStartingPoint = AGSPoint(x: 83, y: 28.4, z: 20000, spatialReference: .wgs84())
     private let squareSize: Double = 0.01
@@ -43,9 +43,8 @@ class ExtrudeGraphicsViewController: UIViewController {
         self.sceneView.setViewpointCamera(camera)
         
         //add graphics overlay
-        self.graphicsOverlay = AGSGraphicsOverlay()
-        self.graphicsOverlay.sceneProperties?.surfacePlacement = .draped
-        self.sceneView.graphicsOverlays.add(self.graphicsOverlay)
+        graphicsOverlay.sceneProperties?.surfacePlacement = .draped
+        self.sceneView.graphicsOverlays.add(graphicsOverlay)
         
         //simple renderer with extrusion property
         let renderer = AGSSimpleRenderer()

--- a/arcgis-ios-sdk-samples/Scenes/Scene properties expressions/ScenePropertiesExpressionsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Scene properties expressions/ScenePropertiesExpressionsViewController.swift
@@ -57,8 +57,9 @@ class ScenePropertiesExpressionsViewController: UIViewController {
         coneSymbol.pitch = -90  //correct symbol's default pitch
         let conePoint = AGSPoint(x: 83.9, y: 28.404, z: 5000, spatialReference: .wgs84())
         let coneAttributes = ["HEADING": 0, "PITCH": 0]
-        self.coneGraphic = AGSGraphic(geometry: conePoint, symbol: coneSymbol, attributes: coneAttributes)
-        graphicsOverlay.graphics.add(self.coneGraphic)
+        let coneGraphic = AGSGraphic(geometry: conePoint, symbol: coneSymbol, attributes: coneAttributes)
+        self.coneGraphic = coneGraphic
+        graphicsOverlay.graphics.add(coneGraphic)
     }
     
     @IBAction func headingSliderValueChanged(_ slider: UISlider) {

--- a/arcgis-ios-sdk-samples/Scenes/Scene properties expressions/ScenePropertiesExpressionsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Scene properties expressions/ScenePropertiesExpressionsViewController.swift
@@ -58,8 +58,8 @@ class ScenePropertiesExpressionsViewController: UIViewController {
         let conePoint = AGSPoint(x: 83.9, y: 28.404, z: 5000, spatialReference: .wgs84())
         let coneAttributes = ["HEADING": 0, "PITCH": 0]
         let coneGraphic = AGSGraphic(geometry: conePoint, symbol: coneSymbol, attributes: coneAttributes)
-        self.coneGraphic = coneGraphic
         graphicsOverlay.graphics.add(coneGraphic)
+        self.coneGraphic = coneGraphic
     }
     
     @IBAction func headingSliderValueChanged(_ slider: UISlider) {

--- a/arcgis-ios-sdk-samples/Scenes/Surface placements/SurfacePlacementsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Surface placements/SurfacePlacementsViewController.swift
@@ -86,6 +86,7 @@ private extension AGSSurfacePlacement {
         case .absolute: return "Absolute"
         case .relative: return "Relative"
         case .relativeToScene: return "Relative to Scene"
+        @unknown default: return "Unknown"
         }
     }
 }

--- a/arcgis-ios-sdk-samples/Search/Find address/FindAddressViewController.swift
+++ b/arcgis-ios-sdk-samples/Search/Find address/FindAddressViewController.swift
@@ -22,7 +22,7 @@ class FindAddressViewController: UIViewController, AGSGeoViewTouchDelegate, UISe
     
     private var locatorTask: AGSLocatorTask!
     private var geocodeParameters: AGSGeocodeParameters!
-    private var graphicsOverlay: AGSGraphicsOverlay!
+    private let graphicsOverlay = AGSGraphicsOverlay()
     
     private let locatorURL = "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer"
     
@@ -37,8 +37,7 @@ class FindAddressViewController: UIViewController, AGSGeoViewTouchDelegate, UISe
         self.mapView.map = map
         self.mapView.touchDelegate = self
         
-        //initialize the graphics overlay and add to the map view
-        self.graphicsOverlay = AGSGraphicsOverlay()
+        //add the graphics overlay to the map view
         self.mapView.graphicsOverlays.add(self.graphicsOverlay)
         
         //initialize locator task

--- a/arcgis-ios-sdk-samples/Search/Find place/FindPlaceViewController.swift
+++ b/arcgis-ios-sdk-samples/Search/Find place/FindPlaceViewController.swift
@@ -27,7 +27,7 @@ class FindPlaceViewController: UIViewController {
     private var textFieldLocationButton: UIButton!
     
     private var map: AGSMap!
-    private var graphicsOverlay: AGSGraphicsOverlay!
+    private let graphicsOverlay = AGSGraphicsOverlay()
     
     private var locatorTask: AGSLocatorTask!
     private var suggestResults: [AGSSuggestResult]!
@@ -82,9 +82,8 @@ class FindPlaceViewController: UIViewController {
             }
         }
         
-        //instantiate the graphicsOverlay and add to the map view
-        self.graphicsOverlay = AGSGraphicsOverlay()
-        self.mapView.graphicsOverlays.add(self.graphicsOverlay)
+        //add the graphicsOverlay to the map view
+        self.mapView.graphicsOverlays.add(graphicsOverlay)
         
         //initialize locator task
         self.locatorTask = AGSLocatorTask(url: URL(string: "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer")!)

--- a/arcgis-ios-sdk-samples/Search/Offline geocode/OfflineGeocodeViewController.swift
+++ b/arcgis-ios-sdk-samples/Search/Offline geocode/OfflineGeocodeViewController.swift
@@ -23,7 +23,7 @@ class GeocodeOfflineViewController: UIViewController, AGSGeoViewTouchDelegate, U
     private var locatorTask: AGSLocatorTask!
     private var geocodeParameters: AGSGeocodeParameters!
     private var reverseGeocodeParameters: AGSReverseGeocodeParameters!
-    private var graphicsOverlay: AGSGraphicsOverlay!
+    private let graphicsOverlay = AGSGraphicsOverlay()
     private var locatorTaskOperation: AGSCancelable!
     private var magnifierOffset: CGPoint!
     private var longPressedAndMoving = false
@@ -48,9 +48,8 @@ class GeocodeOfflineViewController: UIViewController, AGSGeoViewTouchDelegate, U
         //will need that to show callout
         self.mapView.touchDelegate = self
         
-        //initialize the graphics overlay and add to the map view
+        //add the graphics overlay to the map view
         //will add the resulting graphics to this overlay
-        self.graphicsOverlay = AGSGraphicsOverlay()
         self.mapView.graphicsOverlays.add(self.graphicsOverlay)
         
         //initialize locator task

--- a/arcgis-ios-sdk-samples/Shared resources/Extensions/AGSExtensions.swift
+++ b/arcgis-ios-sdk-samples/Shared resources/Extensions/AGSExtensions.swift
@@ -29,6 +29,8 @@ extension AGSJobStatus {
             return "Succeeded"
         case .failed:
             return "Failed"
+        @unknown default:
+            return "Unknown"
         }
     }
 }

--- a/arcgis-ios-sdk-samples/Shared resources/Libraries/DemoTouchView/DemoTouchView.swift
+++ b/arcgis-ios-sdk-samples/Shared resources/Libraries/DemoTouchView/DemoTouchView.swift
@@ -321,6 +321,8 @@ private class DemoTouchesView: UIView {
             case .stationary:
                 // NOTE: I've never actually seen this state.
                 break
+            @unknown default:
+                break
             }
         }
     }


### PR DESCRIPTION
Most of the changes are to address new warnings. Xcode now warns when passing an IUO to a method that takes `Any` (not `Any?`), so I switched to using a non-optional local variable in most of those cases. A few of them I was able to make the property non-optional instead.