### PR TITLE
Fix bug in Unique Value Renderer

### DIFF
--- a/arcgis-ios-sdk-samples/Display information/Unique value renderer/UniqueValueRendererViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Unique value renderer/UniqueValueRendererViewController.swift
@@ -19,8 +19,6 @@ import ArcGIS
 class UniqueValueRendererViewController: UIViewController {
     @IBOutlet var mapView: AGSMapView!
     
-    private var featureLayer: AGSFeatureLayer!
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -34,6 +32,9 @@ class UniqueValueRendererViewController: UIViewController {
         let featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3")!)
         let featureLayer = AGSFeatureLayer(featureTable: featureTable)
         
+        //make unique value renderer and assign it to the feature layer
+        featureLayer.renderer = makeUniqueValueRenderer()
+        
         //add the layer to the map as operational layer
         map.operationalLayers.add(featureLayer)
         
@@ -43,15 +44,9 @@ class UniqueValueRendererViewController: UIViewController {
         //set initial viewpoint
         let center = AGSPoint(x: -12966000.5, y: 4441498.5, spatialReference: .webMercator())
         self.mapView.setViewpoint(AGSViewpoint(center: center, scale: 4e7))
-        
-        //add unique value renderer
-        self.addUniqueValueRenderer()
-        
-        //store the feature layer for later use
-        self.featureLayer = featureLayer
     }
-
-    private func addUniqueValueRenderer() {
+    
+    func makeUniqueValueRenderer() -> AGSUniqueValueRenderer {
         //instantiate a new unique value renderer
         let renderer = AGSUniqueValueRenderer()
         
@@ -77,7 +72,6 @@ class UniqueValueRendererViewController: UIViewController {
         //add the values to the renderer
         renderer.uniqueValues.append(contentsOf: [californiaValue, arizonaValue, nevadaValue])
         
-        //assign the renderer to the feature layer
-        self.featureLayer.renderer = renderer
+        return renderer
     }
 }

--- a/arcgis-ios-sdk-samples/Display information/Unique value renderer/UniqueValueRendererViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Unique value renderer/UniqueValueRendererViewController.swift
@@ -16,15 +16,26 @@
 import UIKit
 import ArcGIS
 
+/// A view controller that manages the interface of the Unique Value Renderer
+/// sample.
 class UniqueValueRendererViewController: UIViewController {
-    @IBOutlet var mapView: AGSMapView!
+    /// The map view managed by the view controller.
+    @IBOutlet var mapView: AGSMapView! {
+        didSet {
+            //assign map to the map view
+            mapView.map = makeMap()
+            
+            //set initial viewpoint
+            let center = AGSPoint(x: -12966000.5, y: 4441498.5, spatialReference: .webMercator())
+            mapView.setViewpoint(AGSViewpoint(center: center, scale: 4e7))
+        }
+    }
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        //add the source code button item to the right of navigation bar
-        (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["UniqueValueRendererViewController"]
-
+    /// Creates a map with a feature layer configured with a unique value
+    /// renderer.
+    ///
+    /// - Returns: A new `AGSMap` object.
+    func makeMap() -> AGSMap {
         //instantiate map with basemap
         let map = AGSMap(basemap: .topographic())
         
@@ -38,14 +49,13 @@ class UniqueValueRendererViewController: UIViewController {
         //add the layer to the map as operational layer
         map.operationalLayers.add(featureLayer)
         
-        //assign map to the map view
-        self.mapView.map = map
-        
-        //set initial viewpoint
-        let center = AGSPoint(x: -12966000.5, y: 4441498.5, spatialReference: .webMercator())
-        self.mapView.setViewpoint(AGSViewpoint(center: center, scale: 4e7))
+        return map
     }
     
+    /// Creates a unique value renderer configured to render California as red,
+    /// Arizona as green, and Nevada as blue.
+    ///
+    /// - Returns: A new `AGSUniqueValueRenderer` object.
     func makeUniqueValueRenderer() -> AGSUniqueValueRenderer {
         //instantiate a new unique value renderer
         let renderer = AGSUniqueValueRenderer()
@@ -73,5 +83,14 @@ class UniqueValueRendererViewController: UIViewController {
         renderer.uniqueValues.append(contentsOf: [californiaValue, arizonaValue, nevadaValue])
         
         return renderer
+    }
+    
+    // MARK: UIViewController
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        //add the source code button item to the right of navigation bar
+        (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["UniqueValueRendererViewController"]
     }
 }


### PR DESCRIPTION
`self.featureLayer` was being reference before its value had been set.

The first commit fixes the bug. The second commit updates the sample to match the style used in more recent sample implementations.