### PR TITLE
Update portal item identifier of mil2525d.stylx

### DIFF
--- a/arcgis-ios-sdk-samples/Content Display Logic/PortalItems.plist
+++ b/arcgis-ios-sdk-samples/Content Display Logic/PortalItems.plist
@@ -6,7 +6,7 @@
 	<array>
 		<dict>
 			<key>identifier</key>
-			<string>5de1ff8d2aa243558ba057fa922beb84</string>
+			<string>c78b149a1d52414682c86a5feeb13d30</string>
 			<key>filename</key>
 			<string>mil2525d.stylx</string>
 		</dict>


### PR DESCRIPTION
Hosting of the style file has moved to https://www.arcgis.com/home/item.html?id=c78b149a1d52414682c86a5feeb13d30.