### PR TITLE
Resolved failing test in MessageParserTests

### DIFF
--- a/arcgis-ios-sdk-samplesTests/Sample Tests/GraphicsOverlayDictionaryRenderer3DViewControllerTests.swift
+++ b/arcgis-ios-sdk-samplesTests/Sample Tests/GraphicsOverlayDictionaryRenderer3DViewControllerTests.swift
@@ -67,11 +67,11 @@ class MessageParserTests: XCTestCase {
         XCTAssertNotNil(firstMessage)
         
         let expectedPointCount = 36
-        let actualFirstMessagePointCount = firstMessage!.points.count
+        let actualFirstMessagePointCount = firstMessage?.points.count ?? 0
         XCTAssertEqual(actualFirstMessagePointCount, expectedPointCount)
-        
+
         let expectedMinimumAttributeCount = 7
-        let actualFirstMessageAttributeCount = firstMessage!.attributes.count
-        XCTAssertTrue(actualFirstMessageAttributeCount >= expectedMinimumAttributeCount)
+        let actualFirstMessageAttributeCount = firstMessage?.attributes.count ?? 0
+        XCTAssertGreaterThanOrEqual(actualFirstMessageAttributeCount, expectedMinimumAttributeCount)
     }
 }

--- a/arcgis-ios-sdk-samplesTests/Sample Tests/GraphicsOverlayDictionaryRenderer3DViewControllerTests.swift
+++ b/arcgis-ios-sdk-samplesTests/Sample Tests/GraphicsOverlayDictionaryRenderer3DViewControllerTests.swift
@@ -42,18 +42,36 @@ class GraphicsOverlayDictionaryRenderer3DViewControllerTests: XCTestCase {
 }
 
 class MessageParserTests: XCTestCase {
-    let messagesURL = Bundle.main.url(forResource: "Mil2525DMessages", withExtension: "xml")!
-    
     func testParseMessagesAtURL() {
-        let parser = MessageParser()
-        do {
-            let messagesData = try Data(contentsOf: messagesURL)
-            let messages = try parser.parseMessages(from: messagesData)
-            XCTAssertEqual(messages.count, 33)
-            XCTAssertEqual(messages.first?.points.count, 36)
-            XCTAssertEqual(messages.first?.attributes.count, 8)
-        } catch {
-            fatalError("Error parsing messages: \(error)")
+        let messagesURL = Bundle.main.url(forResource: "Mil2525DMessages", withExtension: "xml")!
+        
+        guard let messagesData = try? Data(contentsOf: messagesURL) else {
+            XCTFail("Error loading data from URL + \(messagesURL)")
+            return
         }
+        
+        let messages: [Message]
+        do {
+            let parser = MessageParser()
+            messages = try parser.parseMessages(from: messagesData)
+        } catch {
+            XCTFail("Error parsing messages: \(error)")
+            return
+        }
+        
+        let expectedMessageCount = 33
+        let actualMessageCount = messages.count
+        XCTAssertEqual(actualMessageCount, expectedMessageCount)
+
+        let firstMessage = messages.first
+        XCTAssertNotNil(firstMessage)
+        
+        let expectedPointCount = 36
+        let actualFirstMessagePointCount = firstMessage!.points.count
+        XCTAssertEqual(actualFirstMessagePointCount, expectedPointCount)
+        
+        let expectedMinimumAttributeCount = 7
+        let actualFirstMessageAttributeCount = firstMessage!.attributes.count
+        XCTAssertTrue(actualFirstMessageAttributeCount >= expectedMinimumAttributeCount)
     }
 }


### PR DESCRIPTION
### Context 
A failing test was encountered during review of #745. In conversation with @philium, we ascertained that the failure was introduced via #739.

This PR fixes the failing test. 

### Testing

1. Run existing tests (via Cmd+U) against `v.next`, noting a failure on [this line](https://github.com/Esri/arcgis-runtime-samples-ios/blob/a0efcf50a37c086c543b69ce0ee639783427ecae/arcgis-ios-sdk-samplesTests/Sample%20Tests/GraphicsOverlayDictionaryRenderer3DViewControllerTests.swift#L55).
1. Checkout the PR branch, re-run the test, and confirm that it now passes.
1. Review the code in the revised test, to guard against unintended regressions.