### PR TITLE
Improve SwiftLint config

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -67,8 +67,6 @@ opt_in_rules: # some rules are only opt-in
   - sorted_first_last
   - static_operator
   - toggle_bool
-  - unused_import
-  - unused_private_declaration
   - untyped_error_in_catch
   - vertical_parameter_alignment_on_call
   - vertical_whitespace_closing_braces


### PR DESCRIPTION
Removes unrecognized rule (`unused_private_declaration`) and analyzer rule in wrong place (`unused_import`). The analyzer rule may be reintroduced in the right place at a later date.