### PR TITLE
Enabled additional SwiftLint rule : trailing_closure

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -67,6 +67,7 @@ opt_in_rules: # some rules are only opt-in
   - sorted_first_last
   - static_operator
   - toggle_bool
+  - trailing_closure
   - untyped_error_in_catch
   - vertical_parameter_alignment_on_call
   - vertical_whitespace_closing_braces

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -25,7 +25,6 @@ disabled_rules: # rule identifiers to exclude from running
   - trailing_whitespace
   - type_body_length
   - type_name
-  - unused_closure_parameter
 
 opt_in_rules: # some rules are only opt-in
   - anyobject_protocol

--- a/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/StatisticalQueryGroupAndSortViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/StatisticalQueryGroupAndSortViewController.swift
@@ -48,7 +48,7 @@ class StatisticalQueryGroupAndSortViewController: UIViewController, UITableViewD
         self.serviceFeatureTable = serviceFeatureTable
         
         // Load feature table
-        serviceFeatureTable.load(completion: { [weak self] (error) in
+        serviceFeatureTable.load { [weak self] (error) in
             guard let self = self else {
                 return
             }
@@ -62,7 +62,7 @@ class StatisticalQueryGroupAndSortViewController: UIViewController, UITableViewD
             // Set title
             let tableName = serviceFeatureTable.tableName
             self.titleLabel.text = "Statistics: \(tableName)"
-
+            
             // Get field names
             self.fieldNames = serviceFeatureTable.fields.compactMap { (field) -> String? in
                 if field.type != .OID && field.type != .globalID {
@@ -79,7 +79,7 @@ class StatisticalQueryGroupAndSortViewController: UIViewController, UITableViewD
                 }
                 return nil
             }
-        })
+        }
         
         // Setup UI Controls
         setupUI()
@@ -113,7 +113,7 @@ class StatisticalQueryGroupAndSortViewController: UIViewController, UITableViewD
         statisticsQueryParameters.orderByFields = selectedOrderByFields
         
         // Execute the statistical query with parameters
-        serviceFeatureTable?.queryStatistics(with: statisticsQueryParameters, completion: { [weak self] (statisticsQueryResult, error) in
+        serviceFeatureTable?.queryStatistics(with: statisticsQueryParameters) { [weak self] (statisticsQueryResult, error) in
             guard let self = self else {
                 return
             }
@@ -126,7 +126,7 @@ class StatisticalQueryGroupAndSortViewController: UIViewController, UITableViewD
                 self.statisticsQueryResult = statisticsQueryResult
                 self.performSegue(withIdentifier: "ShowResultsSegue", sender: self)
             }
-        })
+        }
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {

--- a/arcgis-ios-sdk-samples/Analysis/Statistical query/StatisticalQueryViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Statistical query/StatisticalQueryViewController.swift
@@ -79,7 +79,7 @@ class StatisticalQueryViewController: UIViewController {
         }
         
         // Execute the statistical query with parameters
-        serviceFeatureTable?.queryStatistics(with: statisticsQueryParameters, completion: { [weak self] (statisticsQueryResult, error) in
+        serviceFeatureTable?.queryStatistics(with: statisticsQueryParameters) { [weak self] (statisticsQueryResult, error) in
             //
             // If there an error, display it
             guard error == nil else {
@@ -102,6 +102,6 @@ class StatisticalQueryViewController: UIViewController {
                 // Show result
                 self?.presentAlert(title: "Statistical Query Results", message: resultMessage)
             }
-        })
+        }
     }
 }

--- a/arcgis-ios-sdk-samples/Cloud & Portal/Search for webmap by keyword/SearchForWebmapByKeywordViewController.swift
+++ b/arcgis-ios-sdk-samples/Cloud & Portal/Search for webmap by keyword/SearchForWebmapByKeywordViewController.swift
@@ -142,13 +142,13 @@ class SearchForWebmapByKeywordViewController: UICollectionViewController {
             cell.thumbnail.image = image
         } else {
             cell.thumbnail.image = UIImage(named: "Placeholder")
-            portalItem.thumbnail?.load(completion: { [weak self] (error: Error?) in
+            portalItem.thumbnail?.load { [weak self] (error: Error?) in
                 if let error = error {
                     print("Error downloading thumbnail :: \(error.localizedDescription)")
                 } else {
                     self?.collectionView.reloadItems(at: [indexPath])
                 }
-            })
+            }
         }
         
         return cell

--- a/arcgis-ios-sdk-samples/Content Display Logic/Model/SampleSearchEngine.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Model/SampleSearchEngine.swift
@@ -45,30 +45,29 @@ class SampleSearchEngine {
             let range = NSRange(location: 0, length: string.count)
             tagger.enumerateTags(in: range,
                                  scheme: NSLinguisticTagScheme.lexicalClass,
-                                 options: [.omitWhitespace, .omitPunctuation],
-                                 using: { (tag: NSLinguisticTag?, tokenRange: NSRange, sentenceRange: NSRange, _) in
-                guard let tag = tag else {
-                    return
-                }
-               
-                if  [NSLinguisticTag.noun, .verb, .adjective, .otherWord].contains(tag) {
-                    let word = ((string as NSString).substring(with: tokenRange) as String).lowercased()
-                    
-                    //trivial comparisons
-                    if word != "`." && word != "```" && word != "`" {
-                        //if word already exists in the dictionary
-                        if var samples = displayNamesByReadmeWords[word] {
-                            //add the sample display name to the list if not already present
-                            if !samples.contains(sampleDisplayName) {
-                                samples.append(sampleDisplayName)
-                                displayNamesByReadmeWords[word] = samples
-                            }
-                        } else {
-                            displayNamesByReadmeWords[word] = [sampleDisplayName]
-                        }
-                    }
-                }
-            })
+                                 options: [.omitWhitespace, .omitPunctuation]) { (tag: NSLinguisticTag?, tokenRange: NSRange, sentenceRange: NSRange, _) in
+                                    guard let tag = tag else {
+                                        return
+                                    }
+                                    
+                                    if  [NSLinguisticTag.noun, .verb, .adjective, .otherWord].contains(tag) {
+                                        let word = ((string as NSString).substring(with: tokenRange) as String).lowercased()
+                                        
+                                        //trivial comparisons
+                                        if word != "`." && word != "```" && word != "`" {
+                                            //if word already exists in the dictionary
+                                            if var samples = displayNamesByReadmeWords[word] {
+                                                //add the sample display name to the list if not already present
+                                                if !samples.contains(sampleDisplayName) {
+                                                    samples.append(sampleDisplayName)
+                                                    displayNamesByReadmeWords[word] = samples
+                                                }
+                                            } else {
+                                                displayNamesByReadmeWords[word] = [sampleDisplayName]
+                                            }
+                                        }
+                                    }
+            }
         }
         
         // index all nodes

--- a/arcgis-ios-sdk-samples/Content Display Logic/Model/SampleSearchEngine.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Model/SampleSearchEngine.swift
@@ -45,7 +45,7 @@ class SampleSearchEngine {
             let range = NSRange(location: 0, length: string.count)
             tagger.enumerateTags(in: range,
                                  scheme: NSLinguisticTagScheme.lexicalClass,
-                                 options: [.omitWhitespace, .omitPunctuation]) { (tag: NSLinguisticTag?, tokenRange: NSRange, sentenceRange: NSRange, _) in
+                                 options: [.omitWhitespace, .omitPunctuation]) { (tag, tokenRange, _, _) in
                                     guard let tag = tag else {
                                         return
                                     }

--- a/arcgis-ios-sdk-samples/Display information/Read symbols from a mobile style/ReadSymbolsFromMobileStyleSymbolViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Read symbols from a mobile style/ReadSymbolsFromMobileStyleSymbolViewController.swift
@@ -27,7 +27,7 @@ class ReadSymbolsFromMobileStyleSymbolViewController: UIViewController {
     var symbolStyleSearchResults = [AGSSymbolStyleSearchResult]() {
         didSet {
             loadViewIfNeeded()
-            let searchResultsByCategory = Dictionary(grouping: symbolStyleSearchResults, by: { $0.category })
+            let searchResultsByCategory = Dictionary(grouping: symbolStyleSearchResults) { $0.category }
             settingsViewController.eyes = searchResultsByCategory["Eyes"] ?? []
             settingsViewController.mouths = searchResultsByCategory["Mouth"] ?? []
             settingsViewController.hats = searchResultsByCategory["Hat"] ?? []
@@ -98,13 +98,13 @@ class ReadSymbolsFromMobileStyleSymbolViewController: UIViewController {
         
         symbolStyle.load { [weak self] error in
             guard error == nil else { return }
-            self?.symbolStyle.defaultSearchParameters(completion: { (searchParameters, error) in
+            self?.symbolStyle.defaultSearchParameters { (searchParameters, error) in
                 guard let searchParameters = searchParameters else { return }
-                self?.symbolStyle.searchSymbols(with: searchParameters, completion: { (searchResults, error) in
+                self?.symbolStyle.searchSymbols(with: searchParameters) { (searchResults, error) in
                     guard let searchResults = searchResults else { return }
                     self?.symbolStyleSearchResults = searchResults
-                })
-            })
+                }
+            }
         }
     }
     

--- a/arcgis-ios-sdk-samples/Display information/Read symbols from a mobile style/ReadSymbolsFromMobileStyleSymbolViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Read symbols from a mobile style/ReadSymbolsFromMobileStyleSymbolViewController.swift
@@ -98,9 +98,9 @@ class ReadSymbolsFromMobileStyleSymbolViewController: UIViewController {
         
         symbolStyle.load { [weak self] error in
             guard error == nil else { return }
-            self?.symbolStyle.defaultSearchParameters { (searchParameters, error) in
+            self?.symbolStyle.defaultSearchParameters { (searchParameters, _) in
                 guard let searchParameters = searchParameters else { return }
-                self?.symbolStyle.searchSymbols(with: searchParameters) { (searchResults, error) in
+                self?.symbolStyle.searchSymbols(with: searchParameters) { (searchResults, _) in
                     guard let searchResults = searchResults else { return }
                     self?.symbolStyleSearchResults = searchResults
                 }

--- a/arcgis-ios-sdk-samples/Display information/Show legend/MILLegendTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Show legend/MILLegendTableViewController.swift
@@ -33,7 +33,7 @@ class MILLegendTableViewController: UITableViewController {
             } else {
                 //else if no sublayers fetch legend info
                 self.orderArray.append(layer)
-                layer.fetchLegendInfos(completion: { [weak self] (legendInfos: [AGSLegendInfo]?, error: Error?) in
+                layer.fetchLegendInfos { [weak self] (legendInfos, error) in
                     if let error = error {
                         print(error)
                     } else {
@@ -42,7 +42,7 @@ class MILLegendTableViewController: UITableViewController {
                             self?.tableView.reloadData()
                         }
                     }
-                })
+                }
             }
         }
     }
@@ -74,12 +74,12 @@ class MILLegendTableViewController: UITableViewController {
         let legendInfo = legendInfos[indexPath.row]
 
         cell.textLabel?.text = legendInfo.name
-        legendInfo.symbol?.createSwatch(completion: { (image: UIImage?, error: Error?) in
+        legendInfo.symbol?.createSwatch { (image, error) in
             if let updateCell = tableView.cellForRow(at: indexPath) {
                 updateCell.imageView?.image = image
                 updateCell.setNeedsLayout()
             }
-        })
+        }
         
         cell.backgroundColor = .clear
         

--- a/arcgis-ios-sdk-samples/Display information/Show legend/MILLegendTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Show legend/MILLegendTableViewController.swift
@@ -74,7 +74,7 @@ class MILLegendTableViewController: UITableViewController {
         let legendInfo = legendInfos[indexPath.row]
 
         cell.textLabel?.text = legendInfo.name
-        legendInfo.symbol?.createSwatch { (image, error) in
+        legendInfo.symbol?.createSwatch { (image, _) in
             if let updateCell = tableView.cellForRow(at: indexPath) {
                 updateCell.imageView?.image = image
                 updateCell.setNeedsLayout()

--- a/arcgis-ios-sdk-samples/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
@@ -114,7 +114,7 @@ class DeleteFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate, A
         //confirmation
         let alertController = UIAlertController(title: "Are you sure you want to delete the feature", message: nil, preferredStyle: .alert)
         //action for Yes
-        let alertAction = UIAlertAction(title: "Yes", style: .default) { [weak self] (action: UIAlertAction!) in
+        let alertAction = UIAlertAction(title: "Yes", style: .default) { [weak self] (_) in
             self?.deleteFeature(self!.selectedFeature)
         }
         alertController.addAction(alertAction)

--- a/arcgis-ios-sdk-samples/Edit data/Edit feature attachments/AttachmentsTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit feature attachments/AttachmentsTableViewController.swift
@@ -95,7 +95,7 @@ class AttachmentsTableViewController: UITableViewController {
         cell.textLabel?.text = attachment.name
         cell.imageView?.contentMode = .scaleAspectFit
         if attachment.hasFetchedData {
-            attachment.fetchData { (data: Data?, error: Error?) in
+            attachment.fetchData { (data, _) in
                 if let data = data {
                     cell.imageView?.image = UIImage(data: data)
                 }
@@ -133,7 +133,7 @@ class AttachmentsTableViewController: UITableViewController {
             //show progress hud
             SVProgressHUD.show(withStatus: "Applying edits")
             
-            table.applyEdits { [weak self] (result, error) in
+            table.applyEdits { [weak self] (_, error) in
                 //dismiss progress hud
                 SVProgressHUD.dismiss()
                 

--- a/arcgis-ios-sdk-samples/Edit data/Edit features (connected)/EditFeaturesOnlineViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit features (connected)/EditFeaturesOnlineViewController.swift
@@ -62,7 +62,7 @@ class EditFeaturesOnlineViewController: UIViewController, AGSGeoViewTouchDelegat
         //show progress hud
         SVProgressHUD.show(withStatus: "Applying edits")
         
-        (featureLayer.featureTable as! AGSServiceFeatureTable).applyEdits { [weak self] (result: [AGSFeatureEditResult]?, error: Error?) in
+        (featureLayer.featureTable as! AGSServiceFeatureTable).applyEdits { [weak self] (_, error) in
             SVProgressHUD.dismiss()
             
             if let error = error {

--- a/arcgis-ios-sdk-samples/Edit data/Offline edit and sync/OfflineEditingViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Offline edit and sync/OfflineEditingViewController.swift
@@ -129,19 +129,19 @@ class OfflineEditingViewController: UIViewController {
         
         for featureTable in generatedGeodatabase!.geodatabaseFeatureTables where featureTable.loadStatus == .loaded {
             dispatchGroup.enter()
-            featureTable.addedFeaturesCount { (count: Int, error: Error?) in
+            featureTable.addedFeaturesCount { (count, _) in
                 totalCount += count
                 dispatchGroup.leave()
             }
             
             dispatchGroup.enter()
-            featureTable.updatedFeaturesCount { (count: Int, error: Error?) in
+            featureTable.updatedFeaturesCount { (count, _) in
                 totalCount += count
                 dispatchGroup.leave()
             }
             
             dispatchGroup.enter()
-            featureTable.deletedFeaturesCount { (count: Int, error: Error?) in
+            featureTable.deletedFeaturesCount { (count, _) in
                 totalCount += count
                 dispatchGroup.leave()
             }
@@ -360,7 +360,7 @@ class OfflineEditingViewController: UIViewController {
         self.syncJob = syncJob
         syncJob.start(statusHandler: { (status) in
             SVProgressHUD.show(withStatus: status.statusString())
-        }, completion: { [weak self] (results, error) in
+        }, completion: { [weak self] (_, error) in
             SVProgressHUD.dismiss()
             
             if let error = error {
@@ -480,7 +480,7 @@ extension OfflineEditingViewController: AGSPopupsViewControllerDelegate {
             //Tell the user edits are being saved int the background
             SVProgressHUD.show(withStatus: "Saving feature details...")
             
-            (feature.featureTable as! AGSServiceFeatureTable).applyEdits { [weak self] (featureEditResult: [AGSFeatureEditResult]?, error: Error?) in
+            (feature.featureTable as! AGSServiceFeatureTable).applyEdits { [weak self] (_, error) in
                 SVProgressHUD.dismiss()
                 
                 if let error = error {

--- a/arcgis-ios-sdk-samples/Edit data/Offline edit and sync/OfflineEditingViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Offline edit and sync/OfflineEditingViewController.swift
@@ -129,22 +129,22 @@ class OfflineEditingViewController: UIViewController {
         
         for featureTable in generatedGeodatabase!.geodatabaseFeatureTables where featureTable.loadStatus == .loaded {
             dispatchGroup.enter()
-            featureTable.addedFeaturesCount(completion: { (count: Int, error: Error?) in
+            featureTable.addedFeaturesCount { (count: Int, error: Error?) in
                 totalCount += count
                 dispatchGroup.leave()
-            })
+            }
             
             dispatchGroup.enter()
-            featureTable.updatedFeaturesCount(completion: { (count: Int, error: Error?) in
+            featureTable.updatedFeaturesCount { (count: Int, error: Error?) in
                 totalCount += count
                 dispatchGroup.leave()
-            })
+            }
             
             dispatchGroup.enter()
-            featureTable.deletedFeaturesCount(completion: { (count: Int, error: Error?) in
+            featureTable.deletedFeaturesCount { (count: Int, error: Error?) in
                 totalCount += count
                 dispatchGroup.leave()
-            })
+            }
         }
         
         dispatchGroup.notify(queue: DispatchQueue.main) { [weak self] in
@@ -214,7 +214,7 @@ class OfflineEditingViewController: UIViewController {
         guard let generatedGeodatabase = generatedGeodatabase else {
             return
         }
-        generatedGeodatabase.load(completion: { [weak self] (error: Error?) in
+        generatedGeodatabase.load { [weak self] (error) in
             guard let self = self else {
                 return
             }
@@ -226,7 +226,7 @@ class OfflineEditingViewController: UIViewController {
                 
                 self.mapView.map?.operationalLayers.removeAllObjects()
                 
-                AGSLoadObjects(generatedGeodatabase.geodatabaseFeatureTables, { (success: Bool) in
+                AGSLoadObjects(generatedGeodatabase.geodatabaseFeatureTables) { (success) in
                     if success {
                         for featureTable in generatedGeodatabase.geodatabaseFeatureTables.reversed() {
                             //check if feature table has geometry
@@ -237,9 +237,9 @@ class OfflineEditingViewController: UIViewController {
                         }
                         self.presentAlert(message: "Now showing layers from the geodatabase")
                     }
-                })
+                }
             }
-        })
+        }
     }
     
     // MARK: - Actions
@@ -293,9 +293,9 @@ class OfflineEditingViewController: UIViewController {
         self.generateJob = generateJob
         
         //start the job
-        generateJob.start(statusHandler: { (status: AGSJobStatus) in
+        generateJob.start(statusHandler: { (status) in
             SVProgressHUD.show(withStatus: status.statusString())
-        }, completion: { [weak self] (object: AnyObject?, error: Error?) in
+        }, completion: { [weak self] (object, error) in
             SVProgressHUD.dismiss()
             
             guard let self = self else {
@@ -304,7 +304,7 @@ class OfflineEditingViewController: UIViewController {
             
             if let error = error {
                 self.presentAlert(error: error)
-            } else if let geodatabase = object as? AGSGeodatabase {
+            } else if let geodatabase = object {
                 //save a reference to the geodatabase
                 self.generatedGeodatabase = geodatabase
                 //add the layers from geodatabase
@@ -358,9 +358,9 @@ class OfflineEditingViewController: UIViewController {
         
         let syncJob = syncTask.syncJob(with: params, geodatabase: generatedGeodatabase)
         self.syncJob = syncJob
-        syncJob.start(statusHandler: { (status: AGSJobStatus) in
+        syncJob.start(statusHandler: { (status) in
             SVProgressHUD.show(withStatus: status.statusString())
-        }, completion: { [weak self] (results: [AGSSyncLayerResult]?, error: Error?) in
+        }, completion: { [weak self] (results, error) in
             SVProgressHUD.dismiss()
             
             if let error = error {

--- a/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/EditAttributesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/EditAttributesViewController.swift
@@ -61,7 +61,7 @@ class EditAttributesViewController: UIViewController, AGSGeoViewTouchDelegate, A
     func applyEdits() {
         SVProgressHUD.show(withStatus: "Applying edits")
         
-        featureTable.applyEdits(completion: { [weak self] (result: [AGSFeatureEditResult]?, error: Error?) in
+        featureTable.applyEdits { [weak self] (result: [AGSFeatureEditResult]?, error: Error?) in
             SVProgressHUD.dismiss()
             
             guard let self = self else {
@@ -74,7 +74,7 @@ class EditAttributesViewController: UIViewController, AGSGeoViewTouchDelegate, A
                 self.presentAlert(message: "Edits applied successfully")
                 self.showCallout(self.selectedFeature, tapLocation: nil)
             }
-        })
+        }
     }
     
     // MARK: - AGSGeoViewTouchDelegate

--- a/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/EditAttributesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/EditAttributesViewController.swift
@@ -61,7 +61,7 @@ class EditAttributesViewController: UIViewController, AGSGeoViewTouchDelegate, A
     func applyEdits() {
         SVProgressHUD.show(withStatus: "Applying edits")
         
-        featureTable.applyEdits { [weak self] (result: [AGSFeatureEditResult]?, error: Error?) in
+        featureTable.applyEdits { [weak self] (_, error) in
             SVProgressHUD.dismiss()
             
             guard let self = self else {

--- a/arcgis-ios-sdk-samples/Edit data/Update geometries (feature service)/EditGeometryViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update geometries (feature service)/EditGeometryViewController.swift
@@ -60,13 +60,13 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
     func setToolbarVisibility(visible: Bool) {
         toolbarBottomConstraint.constant = visible ? 0 : -44 - view.safeAreaInsets.bottom
         
-        UIView.animate(withDuration: 0.3, animations: { [weak self] in
+        UIView.animate(withDuration: 0.3) { [weak self] in
             self?.view.layoutIfNeeded()
-        }) 
+        }
     }
     
     func applyEdits() {
-        self.featureTable.applyEdits(completion: { [weak self] (result: [AGSFeatureEditResult]?, error: Error?) in
+        self.featureTable.applyEdits { [weak self] (result, error) in
             if let error = error {
                 self?.presentAlert(error: error)
             } else {
@@ -74,7 +74,7 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
             }
             //un hide the feature
             self?.featureLayer.setFeature(self!.selectedFeature, visible: true)
-        })
+        }
     }
     
     // MARK: - AGSGeoViewTouchDelegate
@@ -130,7 +130,7 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
     @IBAction func doneAction() {
         if let newGeometry = self.mapView.sketchEditor?.geometry {
             self.selectedFeature.geometry = newGeometry
-            self.featureTable.update(self.selectedFeature, completion: { [weak self] (error: Error?) in
+            self.featureTable.update(self.selectedFeature) { [weak self] (error) in
                 if let error = error {
                     self?.presentAlert(error: error)
                     
@@ -140,7 +140,7 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
                     //apply edits
                     self?.applyEdits()
                 }
-            })
+            }
         }
         
         //hide toolbar

--- a/arcgis-ios-sdk-samples/Edit data/Update geometries (feature service)/EditGeometryViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update geometries (feature service)/EditGeometryViewController.swift
@@ -66,7 +66,7 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
     }
     
     func applyEdits() {
-        self.featureTable.applyEdits { [weak self] (result, error) in
+        self.featureTable.applyEdits { [weak self] (_, error) in
             if let error = error {
                 self?.presentAlert(error: error)
             } else {

--- a/arcgis-ios-sdk-samples/Extensions/UIKit/UINavigationController.swift
+++ b/arcgis-ios-sdk-samples/Extensions/UIKit/UINavigationController.swift
@@ -22,9 +22,9 @@ extension UINavigationController {
         print(type(of: self), #function, separator: ".")
         let poppedViewControllers = popToViewController(viewController, animated: animated)
         if animated {
-            transitionCoordinator?.animate(alongsideTransition: nil, completion: { (_) in
+            transitionCoordinator?.animate(alongsideTransition: nil) { (_) in
                 completion()
-            })
+            }
         } else {
             completion()
         }

--- a/arcgis-ios-sdk-samples/Features/Add delete related features/RelatedFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Add delete related features/RelatedFeaturesViewController.swift
@@ -130,7 +130,7 @@ class RelatedFeaturesViewController: UITableViewController {
         //show progress hud
         SVProgressHUD.show(withStatus: "Applying edits")
         
-        relatedTable.applyEdits { [weak self] (results: [AGSFeatureEditResult]?, error: Error?) in
+        relatedTable.applyEdits { [weak self] (_, error) in
             SVProgressHUD.dismiss()
             
             if let error = error {

--- a/arcgis-ios-sdk-samples/Layers/Export tiles/ExportTilesViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Export tiles/ExportTilesViewController.swift
@@ -118,10 +118,10 @@ class ExportTilesViewController: UIViewController {
         //get the job
         job = exportTask.exportTileCacheJob(with: params, downloadFileURL: downloadFileURL)
         //run the job
-        job.start(statusHandler: { (status: AGSJobStatus) in
+        job.start(statusHandler: { (status) in
             //show job status
             SVProgressHUD.show(withStatus: status.statusString())
-        }, completion: { [weak self] (result: AnyObject?, error: Error?) in
+        }, completion: { [weak self] (result, error) in
             //hide progress view
             SVProgressHUD.dismiss()
             
@@ -136,10 +136,9 @@ class ExportTilesViewController: UIViewController {
                 if (error as NSError).code != NSUserCancelledError {
                     self.presentAlert(error: error)
                 }
-            } else {
+            } else if let tileCache = result {
                 self.visualEffectView.isHidden = false
                 
-                let tileCache = result as! AGSTileCache
                 let newTiledLayer = AGSArcGISTiledLayer(tileCache: tileCache)
                 self.previewMapView.map = AGSMap(basemap: AGSBasemap(baseLayer: newTiledLayer))
             }

--- a/arcgis-ios-sdk-samples/Layers/Group layers/GroupLayersViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Group layers/GroupLayersViewController.swift
@@ -50,13 +50,13 @@ class GroupLayersViewController: UIViewController {
                 let camera = AGSCamera(lookAt: extent.center, distance: 700, heading: 0, pitch: 60, roll: 0)
                 
                 // Zoom to the viewpoint specified by the camera position.
-                self?.sceneView.setViewpointCamera(camera, completion: { (_) in
+                self?.sceneView.setViewpointCamera(camera) { (_) in
                     DispatchQueue.main.async {
                         // Enable the bar button item to display
                         // the Table of Contents of operational layers.
                         self?.layersBarButtonItem.isEnabled = true
                     }
-                })
+                }
             }
         }
     }

--- a/arcgis-ios-sdk-samples/Layers/List KML contents/ListKMLContentsSceneViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/List KML contents/ListKMLContentsSceneViewController.swift
@@ -110,12 +110,12 @@ class ListKMLContentsSceneViewController: UIViewController {
         let group = DispatchGroup()
         group.enter()
         // we want to return the elevation synchronously, so run the task in the background and wait
-        surface.elevation(for: point, completion: { (elevation, error) in
+        surface.elevation(for: point) { (elevation, error) in
             if error == nil {
                 surfaceElevation = elevation
             }
             group.leave()
-        })
+        }
         // wait, but not longer than three seconds
         _ = group.wait(timeout: .now() + 3)
         return surfaceElevation

--- a/arcgis-ios-sdk-samples/Layers/Stretch renderer/StretchRendererSettingsVC.swift
+++ b/arcgis-ios-sdk-samples/Layers/Stretch renderer/StretchRendererSettingsVC.swift
@@ -121,9 +121,7 @@ class StretchRendererSettingsVC: UITableViewController {
         guard tableView.cellForRow(at: indexPath) == stretchTypeCell else {
             return
         }
-        let labels = StretchType.allCases.map({ (type) -> String in
-            return type.label
-        })
+        let labels = StretchType.allCases.map { return $0.label }
         let selectedIndex = stretchType.rawValue
         let optionsViewController = OptionsTableViewController(labels: labels, selectedIndex: selectedIndex) { (newIndex) in
             self.stretchType = StretchType(rawValue: newIndex)!

--- a/arcgis-ios-sdk-samples/Layers/Stretch renderer/StretchRendererSettingsVC.swift
+++ b/arcgis-ios-sdk-samples/Layers/Stretch renderer/StretchRendererSettingsVC.swift
@@ -121,7 +121,7 @@ class StretchRendererSettingsVC: UITableViewController {
         guard tableView.cellForRow(at: indexPath) == stretchTypeCell else {
             return
         }
-        let labels = StretchType.allCases.map { return $0.label }
+        let labels = StretchType.allCases.map { $0.label }
         let selectedIndex = stretchType.rawValue
         let optionsViewController = OptionsTableViewController(labels: labels, selectedIndex: selectedIndex) { (newIndex) in
             self.stretchType = StretchType(rawValue: newIndex)!

--- a/arcgis-ios-sdk-samples/Maps/Generate offline map (basemap by reference)/GenerateOfflineMapBasemapByReferenceViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map (basemap by reference)/GenerateOfflineMapBasemapByReferenceViewController.swift
@@ -129,14 +129,14 @@ class GenerateOfflineMapBasemapByReferenceViewController: UIViewController {
             return
         }
         let job = offlineMapTask.generateOfflineMapJob(with: parameters, downloadDirectory: downloadDirectoryURL)
-        job.start(statusHandler: nil, completion: { [weak self] (result, error) in
+        job.start(statusHandler: nil) { [weak self] (result, error) in
             guard let self = self else { return }
             if let result = result {
                 self.offlineMapGenerationDidSucceed(with: result)
             } else if let error = error {
                 self.offlineMapGenerationDidFail(with: error)
             }
-        })
+        }
         self.generateOfflineMapJob = job
         let downloadProgressView = DownloadProgressView()
         downloadProgressView.delegate = self

--- a/arcgis-ios-sdk-samples/Maps/Generate offline map (overrides)/GenerateOfflineMapOverridesViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map (overrides)/GenerateOfflineMapOverridesViewController.swift
@@ -135,7 +135,7 @@ class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthentica
         progressParentView.isHidden = false
         
         //start the job
-        generateOfflineMapJob.start(statusHandler: nil) { [weak self] (result: AGSGenerateOfflineMapResult?, error: Error?) in
+        generateOfflineMapJob.start(statusHandler: nil) { [weak self] (result, error) in
             guard let self = self else {
                 return
             }
@@ -251,7 +251,7 @@ class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthentica
             self.parameters = parameters
             
             //build the parameter overrides object to be configured by the user
-            offlineMapTask.generateOfflineMapParameterOverrides(with: parameters, completion: { [weak self] (parameterOverrides, error) in
+            offlineMapTask.generateOfflineMapParameterOverrides(with: parameters) { [weak self] (parameterOverrides, error) in
                 guard let self = self else {
                     return
                 }
@@ -268,7 +268,7 @@ class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthentica
                 
                 //now that we have the override object, show the overrides UI
                 self.openParameterOverridesViewController()
-            })
+            }
         }
     }
     

--- a/arcgis-ios-sdk-samples/Maps/Generate offline map (overrides)/GenerateOfflineMapOverridesViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map (overrides)/GenerateOfflineMapOverridesViewController.swift
@@ -283,7 +283,7 @@ class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthentica
     
     private func showLoginQueryAlert() {
         let alertController = UIAlertController(title: nil, message: "This sample requires you to login in order to take the map's basemap offline. Would you like to continue?", preferredStyle: .alert)
-        let loginAction = UIAlertAction(title: "Login", style: .default) { [weak self] (action) in
+        let loginAction = UIAlertAction(title: "Login", style: .default) { [weak self] (_) in
             self?.addMap()
         }
         

--- a/arcgis-ios-sdk-samples/Maps/Generate offline map (overrides)/OfflineMapParameterOverridesViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map (overrides)/OfflineMapParameterOverridesViewController.swift
@@ -225,7 +225,7 @@ class OfflineMapParameterOverridesViewController: UITableViewController {
     /// Retrieves the operational layer in the map with the given name, if it exists.
     private func operationalMapLayer(named name: String) -> AGSLayer? {
         let layers = map?.operationalLayers as? [AGSLayer]
-        return layers?.first(where: { $0.name == name })
+        return layers?.first { $0.name == name }
     }
     
     /// The service ID retrived from the layer's `AGSArcGISFeatureLayerInfo`, if it is a feature layer.

--- a/arcgis-ios-sdk-samples/Maps/Generate offline map/GenerateOfflineMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map/GenerateOfflineMapViewController.swift
@@ -107,20 +107,20 @@ class GenerateOfflineMapViewController: UIViewController, AGSAuthenticationManag
         self.generateOfflineMapJob = generateOfflineMapJob
         
         //observe the job's progress
-        jobProgressObservation = generateOfflineMapJob.progress.observe(\.fractionCompleted, options: .new, changeHandler: { [weak self] (progress, change) in
+        jobProgressObservation = generateOfflineMapJob.progress.observe(\.fractionCompleted, options: .new) { [weak self] (progress, change) in
             DispatchQueue.main.async { [weak self] in
                 //update progress label
                 self?.progressLabel.text = progress.localizedDescription
                 //update progress view
                 self?.progressView.progress = Float(progress.fractionCompleted)
             }
-        })
+        }
         
         //unhide the progress parent view
         progressParentView.isHidden = false
         
         //start the job
-        generateOfflineMapJob.start(statusHandler: nil) { [weak self] (result: AGSGenerateOfflineMapResult?, error: Error?) in
+        generateOfflineMapJob.start(statusHandler: nil) { [weak self] (result, error) in
             guard let self = self else {
                 return
             }

--- a/arcgis-ios-sdk-samples/Maps/Generate offline map/GenerateOfflineMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map/GenerateOfflineMapViewController.swift
@@ -107,7 +107,7 @@ class GenerateOfflineMapViewController: UIViewController, AGSAuthenticationManag
         self.generateOfflineMapJob = generateOfflineMapJob
         
         //observe the job's progress
-        jobProgressObservation = generateOfflineMapJob.progress.observe(\.fractionCompleted, options: .new) { [weak self] (progress, change) in
+        jobProgressObservation = generateOfflineMapJob.progress.observe(\.fractionCompleted, options: .new) { [weak self] (progress, _) in
             DispatchQueue.main.async { [weak self] in
                 //update progress label
                 self?.progressLabel.text = progress.localizedDescription
@@ -218,7 +218,7 @@ class GenerateOfflineMapViewController: UIViewController, AGSAuthenticationManag
     
     private func showLoginQueryAlert() {
         let alertController = UIAlertController(title: nil, message: "This sample requires you to login in order to take the map's basemap offline. Would you like to continue?", preferredStyle: .alert)
-        let loginAction = UIAlertAction(title: "Login", style: .default) { [weak self] (action) in
+        let loginAction = UIAlertAction(title: "Login", style: .default) { [weak self] (_) in
             self?.addMap()
         }
         

--- a/arcgis-ios-sdk-samples/Maps/Map loaded/MapLoadedViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Map loaded/MapLoadedViewController.swift
@@ -33,7 +33,7 @@ class MapLoadedViewController: UIViewController {
         //assign map to map view
         mapView.map = map
         
-        mapLoadStatusObservation = map.observe(\.loadStatus, options: .initial) { [weak self] (map, change) in
+        mapLoadStatusObservation = map.observe(\.loadStatus, options: .initial) { [weak self] (_, _) in
             //update the banner label on main thread
             DispatchQueue.main.async { [weak self] in
                 self?.updateLoadStatusLabel()

--- a/arcgis-ios-sdk-samples/Maps/Map reference scale/MapReferenceScaleSettingsViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Map reference scale/MapReferenceScaleSettingsViewController.swift
@@ -101,11 +101,11 @@ class MapReferenceScaleSettingsViewController: UITableViewController {
         
         // Update Reference Scale section.
         
-        referenceScaleObserver = map.observe(\.referenceScale, options: .initial, changeHandler: { [unowned self] (_, _) in
+        referenceScaleObserver = map.observe(\.referenceScale, options: .initial) { [unowned self] (_, _) in
             DispatchQueue.main.async {
                 self.referenceScaleLabel.text = self.string(fromScale: self.map.referenceScale)
             }
-        })
+        }
         
         if let row = possibleReferenceScales.firstIndex(of: Int(map.referenceScale.rounded(.toNearestOrAwayFromZero))) {
             referenceScalePickerView.selectRow(row, inComponent: 0, animated: false)

--- a/arcgis-ios-sdk-samples/Maps/Mobile map (search and route)/MobileMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Mobile map (search and route)/MobileMapViewController.swift
@@ -147,7 +147,7 @@ class MobileMapViewController: UIViewController, AGSGeoViewTouchDelegate {
             self.locatorTaskCancelable.cancel()
         }
         
-        self.locatorTaskCancelable = self.locatorTask?.reverseGeocode(withLocation: point, parameters: self.reverseGeocodeParameters, completion: { [weak self](results: [AGSGeocodeResult]?, error: Error?) in
+        self.locatorTaskCancelable = self.locatorTask?.reverseGeocode(withLocation: point, parameters: self.reverseGeocodeParameters) { [weak self] (results: [AGSGeocodeResult]?, error: Error?) in
             if let error = error {
                 self?.presentAlert(error: error)
             } else {
@@ -166,7 +166,7 @@ class MobileMapViewController: UIViewController, AGSGeoViewTouchDelegate {
                     self?.mapView.callout.dismiss()
                 }
             }
-        })
+        }
     }
     
     // MARK: - Route

--- a/arcgis-ios-sdk-samples/Maps/Read a geopackage/GPKGLayersViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Read a geopackage/GPKGLayersViewController.swift
@@ -40,9 +40,7 @@ class GPKGLayersViewController: UITableViewController {
             return allLayers
         }
         
-        return allLayers.filter({ layer -> Bool in
-            return !layersInMap.contains(layer)
-        })
+        return allLayers.filter { !layersInMap.contains($0) }
     }
     
     /// Returns the layer for the row at the given index path.

--- a/arcgis-ios-sdk-samples/Maps/Read a geopackage/ReadGeopackageViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Read a geopackage/ReadGeopackageViewController.swift
@@ -39,12 +39,12 @@ class ReadGeopackageViewController: UIViewController, UIPopoverPresentationContr
             let featureLayers = geoPackage.geoPackageFeatureTables.map { AGSFeatureLayer(featureTable: $0) }
             
             // Create raster layers for each raster in the geopackage.
-            let rasterLayers = geoPackage.geoPackageRasters.map({ raster -> AGSLayer in
+            let rasterLayers = geoPackage.geoPackageRasters.map { raster -> AGSLayer in
                 let rasterLayer = AGSRasterLayer(raster: raster)
                 //make it semi-transparent so it doesn't obscure the contents under it
                 rasterLayer.opacity = 0.55
                 return rasterLayer
-            })
+            }
 
             // Keep an array of all the feature layers and raster layers in this geopackage.
             self?.allLayers.append(contentsOf: rasterLayers)

--- a/arcgis-ios-sdk-samples/Maps/Show location history/LocationHistoryViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Show location history/LocationHistoryViewController.swift
@@ -120,7 +120,7 @@ class LocationHistoryViewController: UIViewController {
         let map = AGSMap(basemap: .lightGrayCanvasVector())
         mapView.map = map
 
-        map.load { [weak self, unowned map] (error) in
+        map.load { [weak self, unowned map] (_) in
             self?.trackBuilder = AGSPolylineBuilder(spatialReference: map.spatialReference)
         }
 

--- a/arcgis-ios-sdk-samples/Maps/Show location history/LocationHistoryViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Show location history/LocationHistoryViewController.swift
@@ -120,9 +120,9 @@ class LocationHistoryViewController: UIViewController {
         let map = AGSMap(basemap: .lightGrayCanvasVector())
         mapView.map = map
 
-        map.load(completion: { [weak self, unowned map] (error) in
+        map.load { [weak self, unowned map] (error) in
             self?.trackBuilder = AGSPolylineBuilder(spatialReference: map.spatialReference)
-        })
+        }
 
         mapView.graphicsOverlays.addObjects(from: [trackOverlay, locationsOverlay])
 

--- a/arcgis-ios-sdk-samples/Maps/Take screenshot/MapViewScreenshotViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Take screenshot/MapViewScreenshotViewController.swift
@@ -89,7 +89,7 @@ class MapViewScreenshotViewController: UIViewController {
             animations: {
                 flashView.alpha = 0
             },
-            completion: { [weak self] (finished) in
+            completion: { [weak self] (_) in
                 //On completion play the shutter sound
                 self?.playShutterSound()
                 flashView.removeFromSuperview()

--- a/arcgis-ios-sdk-samples/Route & Directions/Route around barriers/RouteAroundBarriersViewController.swift
+++ b/arcgis-ios-sdk-samples/Route & Directions/Route around barriers/RouteAroundBarriersViewController.swift
@@ -211,7 +211,7 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
             animations: { [weak self] in
                 self?.view.layoutIfNeeded()
             },
-            completion: { [weak self] (finished) in
+            completion: { [weak self] (_) in
                 self?.isDirectionsListVisible.toggle()
             }
         )
@@ -225,7 +225,7 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
             animations: { [weak self] in
                 self?.view.layoutIfNeeded()
             },
-            completion: { [weak self] (finished) in
+            completion: { [weak self] (_) in
                 if !visible {
                     self?.isDirectionsListVisible = false
                 }

--- a/arcgis-ios-sdk-samples/Scenes/Distance composite symbol/DistanceCompositeSymbolViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Distance composite symbol/DistanceCompositeSymbolViewController.swift
@@ -50,7 +50,7 @@ class DistanceCompositeSymbolViewController: UIViewController {
         coneSymbol.pitch = -90.0
         
         let modelSymbol = AGSModelSceneSymbol(name: "Bristol", extension: "dae", scale: 100.0)
-        modelSymbol.load(completion: { [weak self] (error) in
+        modelSymbol.load { [weak self] (error) in
             if let error = error {
                 self?.presentAlert(error: error)
                 return
@@ -74,6 +74,6 @@ class DistanceCompositeSymbolViewController: UIViewController {
             cameraController.cameraPitchOffset = 80
             cameraController.cameraHeadingOffset = -30
             self?.sceneView.cameraController = cameraController
-        })
+        }
     }
 }

--- a/arcgis-ios-sdk-samples/Search/Find address/FindAddressViewController.swift
+++ b/arcgis-ios-sdk-samples/Search/Find address/FindAddressViewController.swift
@@ -72,7 +72,7 @@ class FindAddressViewController: UIViewController, AGSGeoViewTouchDelegate, UISe
         self.mapView.callout.dismiss()
         
         //perform geocode with input text
-        self.locatorTask.geocode(withSearchText: text, parameters: self.geocodeParameters, completion: { [weak self] (results: [AGSGeocodeResult]?, error: Error?) in
+        self.locatorTask.geocode(withSearchText: text, parameters: self.geocodeParameters) { [weak self] (results: [AGSGeocodeResult]?, error: Error?) in
             guard let self = self else {
                 return
             }
@@ -91,7 +91,7 @@ class FindAddressViewController: UIViewController, AGSGeoViewTouchDelegate, UISe
                 //provide feedback in case of failure
                 self.presentAlert(message: "No results found")
             }
-        })
+        }
     }
     
     // MARK: - Callout

--- a/arcgis-ios-sdk-samples/Search/Find place/FindPlaceViewController.swift
+++ b/arcgis-ios-sdk-samples/Search/Find place/FindPlaceViewController.swift
@@ -137,7 +137,7 @@ class FindPlaceViewController: UIViewController {
                 animations: { [weak self] in
                     self?.view.layoutIfNeeded()
                 },
-                completion: { [weak self] (finished) in
+                completion: { [weak self] (_) in
                     self?.isTableViewAnimating = false
                     self?.isTableViewVisible = expand
                 }
@@ -185,7 +185,7 @@ class FindPlaceViewController: UIViewController {
             for graphic in graphics {
                 multipoint.points.add(graphic.geometry as! AGSPoint)
             }
-            self.mapView.setViewpoint(AGSViewpoint(targetExtent: multipoint.extent)) { [weak self] (finished: Bool) in
+            self.mapView.setViewpoint(AGSViewpoint(targetExtent: multipoint.extent)) { [weak self] (_) in
                 self?.canDoExtentSearch = true
             }
         }

--- a/arcgis-ios-sdk-samples/Search/Find place/FindPlaceViewController.swift
+++ b/arcgis-ios-sdk-samples/Search/Find place/FindPlaceViewController.swift
@@ -321,10 +321,10 @@ class FindPlaceViewController: UIViewController {
             //if no, then goecode the suggestion
             //else use the geocoded location, to find the POIs
             if self.preferredSearchLocation == nil {
-                self.geocodeUsingSuggestResult(self.selectedSuggestResult, completion: { [weak self] in
+                self.geocodeUsingSuggestResult(self.selectedSuggestResult) { [weak self] in
                     //find the POIs wrt location
                     self?.geocodePOIs(poi, location: self!.preferredSearchLocation, extent: nil)
-                })
+                }
             } else {
                 self.geocodePOIs(poi, location: self.preferredSearchLocation, extent: nil)
             }

--- a/arcgis-ios-sdk-samples/Search/Offline geocode/OfflineGeocodeViewController.swift
+++ b/arcgis-ios-sdk-samples/Search/Offline geocode/OfflineGeocodeViewController.swift
@@ -93,7 +93,7 @@ class GeocodeOfflineViewController: UIViewController, AGSGeoViewTouchDelegate, U
         self.graphicsOverlay.graphics.removeAllObjects()
         
         //perform geocode with the input
-        self.locatorTask.geocode(withSearchText: text, parameters: self.geocodeParameters, completion: { [weak self]  (results: [AGSGeocodeResult]?, error: Error?) in
+        self.locatorTask.geocode(withSearchText: text, parameters: self.geocodeParameters) { [weak self]  (results: [AGSGeocodeResult]?, error: Error?) in
             guard let self = self else {
                 return
             }
@@ -114,7 +114,7 @@ class GeocodeOfflineViewController: UIViewController, AGSGeoViewTouchDelegate, U
                     self.presentAlert(message: "No results found")
                 }
             }
-        })
+        }
     }
     
     private func reverseGeocode(point: AGSPoint) {

--- a/arcgis-ios-sdk-samples/Utility Network/Connected Trace/ConnectedTraceViewController.swift
+++ b/arcgis-ios-sdk-samples/Utility Network/Connected Trace/ConnectedTraceViewController.swift
@@ -28,7 +28,7 @@ class ConnectedTraceViewController: UIViewController, AGSGeoViewTouchDelegate {
     
     private let featureServiceURL = URL(string: "https://sampleserver7.arcgisonline.com/arcgis/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer")!
     private var layers: [AGSFeatureLayer] {
-        return [115, 100].map({
+        return [115, 100].map {
             let featureTable = AGSServiceFeatureTable(url: featureServiceURL.appendingPathComponent("\($0)"))
             let layer = AGSFeatureLayer(featureTable: featureTable)
             if $0 == 115 {
@@ -36,7 +36,7 @@ class ConnectedTraceViewController: UIViewController, AGSGeoViewTouchDelegate {
                 layer.renderer = AGSSimpleRenderer(symbol: AGSSimpleLineSymbol(style: .solid, color: lineColor, width: 3))
             }
             return layer
-        })
+        }
     }
 
     private let map: AGSMap
@@ -212,7 +212,7 @@ class ConnectedTraceViewController: UIViewController, AGSGeoViewTouchDelegate {
 
             SVProgressHUD.show(withStatus: "Trace Completed. Selecting features…")
 
-            let groupedElements = Dictionary(grouping: elementTraceResult.elements, by: { $0.networkSource.name })
+            let groupedElements = Dictionary(grouping: elementTraceResult.elements) { $0.networkSource.name }
             
             let selectionGroup = DispatchGroup()
 
@@ -221,7 +221,7 @@ class ConnectedTraceViewController: UIViewController, AGSGeoViewTouchDelegate {
 
                 selectionGroup.enter()
                 print("Requesting features for \(networkName)")
-                self.utilityNetwork.features(for: elements, completion: { [layer, networkName] (features, error) in
+                self.utilityNetwork.features(for: elements) { [layer, networkName] (features, error) in
                     defer {
                         print("Result From: \(networkName)")
                         selectionGroup.leave()
@@ -235,18 +235,18 @@ class ConnectedTraceViewController: UIViewController, AGSGeoViewTouchDelegate {
                     guard let features = features else { return }
                     
                     layer.select(features)
-                })
+                }
             }
             
-            selectionGroup.notify(queue: .main, execute: { [weak self] in
+            selectionGroup.notify(queue: .main) { [weak self] in
                 self?.setStatus(message: "Trace completed.")
                 SVProgressHUD.dismiss()
-            })
+            }
         }
     }
     
     func clearSelection() {
-        map.operationalLayers.lazy.compactMap({ $0 as? AGSFeatureLayer }).forEach({ $0.clearSelection() })
+        map.operationalLayers.lazy.compactMap { $0 as? AGSFeatureLayer }.forEach { $0.clearSelection() }
     }
     
     // MARK: Terminal Selection UI
@@ -256,9 +256,9 @@ class ConnectedTraceViewController: UIViewController, AGSGeoViewTouchDelegate {
             let terminalPicker = UIAlertController(title: "Select a terminal", message: nil, preferredStyle: .actionSheet)
             
             for terminal in terminals {
-                let action = UIAlertAction(title: terminal.name, style: .default, handler: { [terminal] _ in
+                let action = UIAlertAction(title: terminal.name, style: .default) { [terminal] _ in
                     completion(terminal)
-                })
+                }
                 
                 terminalPicker.addAction(action)
             }

--- a/arcgis-ios-sdk-samples/Utility Network/Connected Trace/ConnectedTraceViewController.swift
+++ b/arcgis-ios-sdk-samples/Utility Network/Connected Trace/ConnectedTraceViewController.swift
@@ -246,7 +246,9 @@ class ConnectedTraceViewController: UIViewController, AGSGeoViewTouchDelegate {
     }
     
     func clearSelection() {
-        map.operationalLayers.lazy.compactMap { $0 as? AGSFeatureLayer }.forEach { $0.clearSelection() }
+        map.operationalLayers.lazy
+            .compactMap { $0 as? AGSFeatureLayer }
+            .forEach { $0.clearSelection() }
     }
     
     // MARK: Terminal Selection UI


### PR DESCRIPTION
### Context

This PR proposes enabling the `trailing_closure` SwiftLint rule, and appeases the existing warnings. [The rule](https://github.com/realm/SwiftLint/blob/master/Rules.md#trailing-closure) is _not_ enabled by default, unlike the rules for [`multiple_closures_with_trailing_closure`](https://github.com/realm/SwiftLint/blob/master/Rules.md#multiple-closures-with-trailing-closure) & [`empty_parentheses_with_trailing_closure`](https://github.com/realm/SwiftLint/blob/master/Rules.md#empty-parentheses-with-trailing-closure).

### Impetus

This was rightly called out in a [recent PR review](https://github.com/Esri/arcgis-runtime-samples-ios/pull/758#discussion_r315765353), but also overlooked in a [separate review](https://github.com/Esri/arcgis-runtime-samples-ios/pull/751/files#diff-69ab99ba03b38a0a6688fc7ec682b742R123). I thought it would be great to promote some additional consistency.

### Notes

- This does not need to be part of the 100.6 release.
- I smoke-tested the impacted samples, and noted no ill effects.