### PR TITLE
Enabled additional SwiftLint rule : unused_closure_parameter

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -25,7 +25,6 @@ disabled_rules: # rule identifiers to exclude from running
   - trailing_whitespace
   - type_body_length
   - type_name
-  - unused_closure_parameter
 
 opt_in_rules: # some rules are only opt-in
   - anyobject_protocol

--- a/arcgis-ios-sdk-samples/Content Display Logic/Model/SampleSearchEngine.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Model/SampleSearchEngine.swift
@@ -45,7 +45,7 @@ class SampleSearchEngine {
             let range = NSRange(location: 0, length: string.count)
             tagger.enumerateTags(in: range,
                                  scheme: NSLinguisticTagScheme.lexicalClass,
-                                 options: [.omitWhitespace, .omitPunctuation]) { (tag: NSLinguisticTag?, tokenRange: NSRange, sentenceRange: NSRange, _) in
+                                 options: [.omitWhitespace, .omitPunctuation]) { (tag, tokenRange, _, _) in
                                     guard let tag = tag else {
                                         return
                                     }

--- a/arcgis-ios-sdk-samples/Display information/Read symbols from a mobile style/ReadSymbolsFromMobileStyleSymbolViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Read symbols from a mobile style/ReadSymbolsFromMobileStyleSymbolViewController.swift
@@ -98,9 +98,9 @@ class ReadSymbolsFromMobileStyleSymbolViewController: UIViewController {
         
         symbolStyle.load { [weak self] error in
             guard error == nil else { return }
-            self?.symbolStyle.defaultSearchParameters { (searchParameters, error) in
+            self?.symbolStyle.defaultSearchParameters { (searchParameters, _) in
                 guard let searchParameters = searchParameters else { return }
-                self?.symbolStyle.searchSymbols(with: searchParameters) { (searchResults, error) in
+                self?.symbolStyle.searchSymbols(with: searchParameters) { (searchResults, _) in
                     guard let searchResults = searchResults else { return }
                     self?.symbolStyleSearchResults = searchResults
                 }

--- a/arcgis-ios-sdk-samples/Display information/Show legend/MILLegendTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Show legend/MILLegendTableViewController.swift
@@ -74,7 +74,7 @@ class MILLegendTableViewController: UITableViewController {
         let legendInfo = legendInfos[indexPath.row]
 
         cell.textLabel?.text = legendInfo.name
-        legendInfo.symbol?.createSwatch { (image, error) in
+        legendInfo.symbol?.createSwatch { (image, _) in
             if let updateCell = tableView.cellForRow(at: indexPath) {
                 updateCell.imageView?.image = image
                 updateCell.setNeedsLayout()

--- a/arcgis-ios-sdk-samples/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
@@ -114,7 +114,7 @@ class DeleteFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate, A
         //confirmation
         let alertController = UIAlertController(title: "Are you sure you want to delete the feature", message: nil, preferredStyle: .alert)
         //action for Yes
-        let alertAction = UIAlertAction(title: "Yes", style: .default) { [weak self] (action: UIAlertAction!) in
+        let alertAction = UIAlertAction(title: "Yes", style: .default) { [weak self] (_) in
             self?.deleteFeature(self!.selectedFeature)
         }
         alertController.addAction(alertAction)

--- a/arcgis-ios-sdk-samples/Edit data/Edit feature attachments/AttachmentsTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit feature attachments/AttachmentsTableViewController.swift
@@ -95,7 +95,7 @@ class AttachmentsTableViewController: UITableViewController {
         cell.textLabel?.text = attachment.name
         cell.imageView?.contentMode = .scaleAspectFit
         if attachment.hasFetchedData {
-            attachment.fetchData { (data: Data?, error: Error?) in
+            attachment.fetchData { (data, _) in
                 if let data = data {
                     cell.imageView?.image = UIImage(data: data)
                 }
@@ -133,7 +133,7 @@ class AttachmentsTableViewController: UITableViewController {
             //show progress hud
             SVProgressHUD.show(withStatus: "Applying edits")
             
-            table.applyEdits { [weak self] (result, error) in
+            table.applyEdits { [weak self] (_, error) in
                 //dismiss progress hud
                 SVProgressHUD.dismiss()
                 

--- a/arcgis-ios-sdk-samples/Edit data/Edit features (connected)/EditFeaturesOnlineViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit features (connected)/EditFeaturesOnlineViewController.swift
@@ -62,7 +62,7 @@ class EditFeaturesOnlineViewController: UIViewController, AGSGeoViewTouchDelegat
         //show progress hud
         SVProgressHUD.show(withStatus: "Applying edits")
         
-        (featureLayer.featureTable as! AGSServiceFeatureTable).applyEdits { [weak self] (result: [AGSFeatureEditResult]?, error: Error?) in
+        (featureLayer.featureTable as! AGSServiceFeatureTable).applyEdits { [weak self] (_, error) in
             SVProgressHUD.dismiss()
             
             if let error = error {

--- a/arcgis-ios-sdk-samples/Edit data/Offline edit and sync/OfflineEditingViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Offline edit and sync/OfflineEditingViewController.swift
@@ -129,19 +129,19 @@ class OfflineEditingViewController: UIViewController {
         
         for featureTable in generatedGeodatabase!.geodatabaseFeatureTables where featureTable.loadStatus == .loaded {
             dispatchGroup.enter()
-            featureTable.addedFeaturesCount { (count: Int, error: Error?) in
+            featureTable.addedFeaturesCount { (count, _) in
                 totalCount += count
                 dispatchGroup.leave()
             }
             
             dispatchGroup.enter()
-            featureTable.updatedFeaturesCount { (count: Int, error: Error?) in
+            featureTable.updatedFeaturesCount { (count, _) in
                 totalCount += count
                 dispatchGroup.leave()
             }
             
             dispatchGroup.enter()
-            featureTable.deletedFeaturesCount { (count: Int, error: Error?) in
+            featureTable.deletedFeaturesCount { (count, _) in
                 totalCount += count
                 dispatchGroup.leave()
             }
@@ -360,7 +360,7 @@ class OfflineEditingViewController: UIViewController {
         self.syncJob = syncJob
         syncJob.start(statusHandler: { (status) in
             SVProgressHUD.show(withStatus: status.statusString())
-        }, completion: { [weak self] (results, error) in
+        }, completion: { [weak self] (_, error) in
             SVProgressHUD.dismiss()
             
             if let error = error {
@@ -480,7 +480,7 @@ extension OfflineEditingViewController: AGSPopupsViewControllerDelegate {
             //Tell the user edits are being saved int the background
             SVProgressHUD.show(withStatus: "Saving feature details...")
             
-            (feature.featureTable as! AGSServiceFeatureTable).applyEdits { [weak self] (featureEditResult: [AGSFeatureEditResult]?, error: Error?) in
+            (feature.featureTable as! AGSServiceFeatureTable).applyEdits { [weak self] (_, error) in
                 SVProgressHUD.dismiss()
                 
                 if let error = error {

--- a/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/EditAttributesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/EditAttributesViewController.swift
@@ -61,7 +61,7 @@ class EditAttributesViewController: UIViewController, AGSGeoViewTouchDelegate, A
     func applyEdits() {
         SVProgressHUD.show(withStatus: "Applying edits")
         
-        featureTable.applyEdits { [weak self] (result: [AGSFeatureEditResult]?, error: Error?) in
+        featureTable.applyEdits { [weak self] (_, error) in
             SVProgressHUD.dismiss()
             
             guard let self = self else {

--- a/arcgis-ios-sdk-samples/Edit data/Update geometries (feature service)/EditGeometryViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update geometries (feature service)/EditGeometryViewController.swift
@@ -66,7 +66,7 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
     }
     
     func applyEdits() {
-        self.featureTable.applyEdits { [weak self] (result, error) in
+        self.featureTable.applyEdits { [weak self] (_, error) in
             if let error = error {
                 self?.presentAlert(error: error)
             } else {

--- a/arcgis-ios-sdk-samples/Features/Add delete related features/RelatedFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Add delete related features/RelatedFeaturesViewController.swift
@@ -130,7 +130,7 @@ class RelatedFeaturesViewController: UITableViewController {
         //show progress hud
         SVProgressHUD.show(withStatus: "Applying edits")
         
-        relatedTable.applyEdits { [weak self] (results: [AGSFeatureEditResult]?, error: Error?) in
+        relatedTable.applyEdits { [weak self] (_, error) in
             SVProgressHUD.dismiss()
             
             if let error = error {

--- a/arcgis-ios-sdk-samples/Maps/Generate offline map (overrides)/GenerateOfflineMapOverridesViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map (overrides)/GenerateOfflineMapOverridesViewController.swift
@@ -283,7 +283,7 @@ class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthentica
     
     private func showLoginQueryAlert() {
         let alertController = UIAlertController(title: nil, message: "This sample requires you to login in order to take the map's basemap offline. Would you like to continue?", preferredStyle: .alert)
-        let loginAction = UIAlertAction(title: "Login", style: .default) { [weak self] (action) in
+        let loginAction = UIAlertAction(title: "Login", style: .default) { [weak self] (_) in
             self?.addMap()
         }
         

--- a/arcgis-ios-sdk-samples/Maps/Generate offline map/GenerateOfflineMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map/GenerateOfflineMapViewController.swift
@@ -107,7 +107,7 @@ class GenerateOfflineMapViewController: UIViewController, AGSAuthenticationManag
         self.generateOfflineMapJob = generateOfflineMapJob
         
         //observe the job's progress
-        jobProgressObservation = generateOfflineMapJob.progress.observe(\.fractionCompleted, options: .new) { [weak self] (progress, change) in
+        jobProgressObservation = generateOfflineMapJob.progress.observe(\.fractionCompleted, options: .new) { [weak self] (progress, _) in
             DispatchQueue.main.async { [weak self] in
                 //update progress label
                 self?.progressLabel.text = progress.localizedDescription
@@ -218,7 +218,7 @@ class GenerateOfflineMapViewController: UIViewController, AGSAuthenticationManag
     
     private func showLoginQueryAlert() {
         let alertController = UIAlertController(title: nil, message: "This sample requires you to login in order to take the map's basemap offline. Would you like to continue?", preferredStyle: .alert)
-        let loginAction = UIAlertAction(title: "Login", style: .default) { [weak self] (action) in
+        let loginAction = UIAlertAction(title: "Login", style: .default) { [weak self] (_) in
             self?.addMap()
         }
         

--- a/arcgis-ios-sdk-samples/Maps/Map loaded/MapLoadedViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Map loaded/MapLoadedViewController.swift
@@ -33,7 +33,7 @@ class MapLoadedViewController: UIViewController {
         //assign map to map view
         mapView.map = map
         
-        mapLoadStatusObservation = map.observe(\.loadStatus, options: .initial) { [weak self] (map, change) in
+        mapLoadStatusObservation = map.observe(\.loadStatus, options: .initial) { [weak self] (_, _) in
             //update the banner label on main thread
             DispatchQueue.main.async { [weak self] in
                 self?.updateLoadStatusLabel()

--- a/arcgis-ios-sdk-samples/Maps/Show location history/LocationHistoryViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Show location history/LocationHistoryViewController.swift
@@ -120,7 +120,7 @@ class LocationHistoryViewController: UIViewController {
         let map = AGSMap(basemap: .lightGrayCanvasVector())
         mapView.map = map
 
-        map.load { [weak self, unowned map] (error) in
+        map.load { [weak self, unowned map] (_) in
             self?.trackBuilder = AGSPolylineBuilder(spatialReference: map.spatialReference)
         }
 

--- a/arcgis-ios-sdk-samples/Maps/Take screenshot/MapViewScreenshotViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Take screenshot/MapViewScreenshotViewController.swift
@@ -89,7 +89,7 @@ class MapViewScreenshotViewController: UIViewController {
             animations: {
                 flashView.alpha = 0
             },
-            completion: { [weak self] (finished) in
+            completion: { [weak self] (_) in
                 //On completion play the shutter sound
                 self?.playShutterSound()
                 flashView.removeFromSuperview()

--- a/arcgis-ios-sdk-samples/Route & Directions/Route around barriers/RouteAroundBarriersViewController.swift
+++ b/arcgis-ios-sdk-samples/Route & Directions/Route around barriers/RouteAroundBarriersViewController.swift
@@ -211,7 +211,7 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
             animations: { [weak self] in
                 self?.view.layoutIfNeeded()
             },
-            completion: { [weak self] (finished) in
+            completion: { [weak self] (_) in
                 self?.isDirectionsListVisible.toggle()
             }
         )
@@ -225,7 +225,7 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
             animations: { [weak self] in
                 self?.view.layoutIfNeeded()
             },
-            completion: { [weak self] (finished) in
+            completion: { [weak self] (_) in
                 if !visible {
                     self?.isDirectionsListVisible = false
                 }

--- a/arcgis-ios-sdk-samples/Search/Find place/FindPlaceViewController.swift
+++ b/arcgis-ios-sdk-samples/Search/Find place/FindPlaceViewController.swift
@@ -137,7 +137,7 @@ class FindPlaceViewController: UIViewController {
                 animations: { [weak self] in
                     self?.view.layoutIfNeeded()
                 },
-                completion: { [weak self] (finished) in
+                completion: { [weak self] (_) in
                     self?.isTableViewAnimating = false
                     self?.isTableViewVisible = expand
                 }
@@ -185,7 +185,7 @@ class FindPlaceViewController: UIViewController {
             for graphic in graphics {
                 multipoint.points.add(graphic.geometry as! AGSPoint)
             }
-            self.mapView.setViewpoint(AGSViewpoint(targetExtent: multipoint.extent)) { [weak self] (finished: Bool) in
+            self.mapView.setViewpoint(AGSViewpoint(targetExtent: multipoint.extent)) { [weak self] (_) in
                 self?.canDoExtentSearch = true
             }
         }


### PR DESCRIPTION
### Context

This PR proposes enabling the `unused_closure_parameter` SwiftLint rule, appeases the existing warnings. SwiftLint enables [this rule](https://github.com/realm/SwiftLint/blob/master/Rules.md#unused-closure-parameter) by default, but it is currently explicitly disabled in this project, as observed in this recent [PR review](https://github.com/Esri/arcgis-runtime-samples-ios/pull/758#discussion_r317627980).

### Notes

- Because this change is being proposed in parallel with another closure-related SwiftLint [change](https://github.com/Esri/arcgis-runtime-samples-ios/pull/765), I have expressed this PR against _that_ base branch (i.e., `sab/lint-trailing_closure`) for review clarity. While this _could_ be merged into that branch prior to merging #765 into `v.next`, we should probably just change the base branch of this PR (i.e., to `v.next`) once that PR has been merged.
- This does not need to be part of the 100.6 release.
- I smoke-tested the impacted samples, and noted no ill effects.