### PR TITLE
Change category labels to lower case

### DIFF
--- a/arcgis-ios-sdk-samples/Display information/Simple marker symbol/README.metadata.json
+++ b/arcgis-ios-sdk-samples/Display information/Simple marker symbol/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Display Information",
+    "category": "Display information",
     "description": "Show a simple marker symbol on a map.",
     "ignore": false,
     "images": [

--- a/arcgis-ios-sdk-samples/Display information/Simple renderer/README.metadata.json
+++ b/arcgis-ios-sdk-samples/Display information/Simple renderer/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Display Information",
+    "category": "Display information",
     "description": "Display common symbols for all graphics in a graphics overlay with a renderer.",
     "ignore": false,
     "images": [

--- a/arcgis-ios-sdk-samples/Display information/Sketch on the map/README.metadata.json
+++ b/arcgis-ios-sdk-samples/Display information/Sketch on the map/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Display Information",
+    "category": "Display information",
     "description": "Use the Sketch Editor to edit or sketch a new point, line, or polygon geometry on to a map.",
     "ignore": false,
     "images": [

--- a/arcgis-ios-sdk-samples/Display information/Unique value renderer/README.metadata.json
+++ b/arcgis-ios-sdk-samples/Display information/Unique value renderer/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Display Information",
+    "category": "Display information",
     "description": "Render features in a layer using a distinct symbol for each unique attribute value.",
     "ignore": false,
     "images": [


### PR DESCRIPTION
Make sure the "Display information" category has consistent labels.