### PR TITLE
Increase Xcode requirement to 11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The ```master``` branch of this repository contains samples configured for the l
 
 ## Requirements
 
-* [ArcGIS Runtime SDK for iOS](https://developers.arcgis.com/ios/) 100.6.0 (or newer).
-* [ArcGIS Runtime Toolkit for iOS ](https://github.com/Esri/arcgis-runtime-toolkit-ios) 100.6.0 (or newer)
+* [ArcGIS Runtime SDK for iOS](https://developers.arcgis.com/ios/) 100.6.0 (or newer)
+* [ArcGIS Runtime Toolkit for iOS](https://github.com/Esri/arcgis-runtime-toolkit-ios) 100.6.0 (or newer)
 * Xcode 11.0 (or newer)
 
 The *ArcGIS Runtime SDK Samples app* has a *Target SDK* version of *11.0*, meaning that it can run on devices with *iOS 11.0* or newer.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The ```master``` branch of this repository contains samples configured for the l
 ## Requirements
 
 * [ArcGIS Runtime SDK for iOS](https://developers.arcgis.com/ios/) 100.6.0 (or newer).
-* Xcode 10.2 (or newer)
+* Xcode 11.0 (or newer)
 
 The *ArcGIS Runtime SDK Samples app* has a *Target SDK* version of *11.0*, meaning that it can run on devices with *iOS 11.0* or newer.
 


### PR DESCRIPTION
This will allow us to take advantage of iOS 13 and Swift 5.1 features.