### PR TITLE
Open a Scene (Portal Item): Fix scene view constraints

### DIFF
--- a/arcgis-ios-sdk-samples/Scenes/Open a scene (portal item)/OpenScene.storyboard
+++ b/arcgis-ios-sdk-samples/Scenes/Open a scene (portal item)/OpenScene.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="oI0-pg-r9z">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="oI0-pg-r9z">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,21 +11,21 @@
         <!--Open Scene View Controller-->
         <scene sceneID="qMc-Za-MJD">
             <objects>
-                <viewController id="oI0-pg-r9z" customClass="OpenSceneViewController" customModule="arcgis_ios_sdk_samples" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="oI0-pg-r9z" customClass="OpenSceneViewController" customModule="ArcGIS_Runtime_SDK_Samples" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Wvg-jB-teh">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ryt-GZ-85l" customClass="AGSSceneView">
-                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                             </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="jRW-g3-mXx" firstAttribute="trailing" secondItem="ryt-GZ-85l" secondAttribute="trailing" id="BgQ-MV-9tu"/>
+                            <constraint firstAttribute="trailing" secondItem="ryt-GZ-85l" secondAttribute="trailing" id="BgQ-MV-9tu"/>
                             <constraint firstItem="ryt-GZ-85l" firstAttribute="top" secondItem="jRW-g3-mXx" secondAttribute="top" id="JNq-wS-0zt"/>
                             <constraint firstAttribute="bottom" secondItem="ryt-GZ-85l" secondAttribute="bottom" id="VgJ-5E-mY1"/>
-                            <constraint firstItem="ryt-GZ-85l" firstAttribute="leading" secondItem="jRW-g3-mXx" secondAttribute="leading" id="qyt-Hr-y87"/>
+                            <constraint firstItem="ryt-GZ-85l" firstAttribute="leading" secondItem="Wvg-jB-teh" secondAttribute="leading" id="qyt-Hr-y87"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="jRW-g3-mXx"/>
                     </view>


### PR DESCRIPTION
Constrains the scene view's leading and trailing edges to the superview rather than the safe area so that the scene extends into the safe area.