### PR TITLE
Remove unused functions in MobileMapViewController.swift

### DIFF
--- a/arcgis-ios-sdk-samples/Maps/Mobile map (search and route)/MobileMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Mobile map (search and route)/MobileMapViewController.swift
@@ -271,19 +271,4 @@ private extension AGSGeocodeResult {
         
         return addr
     }
-    
-    func attributeValueAs<T>(_ key: String) -> T? {
-        return attributes![key] as? T
-    }
-    
-    func attributeAsStringForKey(_ key: String) -> String? {
-        return attributeValueAs(key)
-    }
-    
-    func attributeAsNonEmptyStringForKey(_ key: String) -> String? {
-        if let value = attributeAsStringForKey(key) {
-            return value.isEmpty ? nil : value
-        }
-        return nil
-    }
 }


### PR DESCRIPTION
It turns out these three functions are not being used.