### PR TITLE
Copy READMEs into a single directory

### DIFF
--- a/arcgis-ios-sdk-samples.xcodeproj/project.pbxproj
+++ b/arcgis-ios-sdk-samples.xcodeproj/project.pbxproj
@@ -4086,7 +4086,7 @@
 				4CB506D1224C2C20006A3471 /* Download Portal Item Data */,
 				3E23A9DE1AFC28F6002E2214 /* Resources */,
 				3E03F0951B056DC40078EB36 /* CopyFiles */,
-				3ED029A21B8E5D4D00ACA70D /* ShellScript */,
+				3ED029A21B8E5D4D00ACA70D /* Copy READMEs */,
 				4C73C838211130E000B0F9C7 /* Embed Frameworks */,
 				4CBDB3192190E88F006E5D39 /* Lint Code */,
 				4CDAB076226F93D400DD983C /* Strip Frameworks */,
@@ -4486,18 +4486,19 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		3ED029A21B8E5D4D00ACA70D /* ShellScript */ = {
+		3ED029A21B8E5D4D00ACA70D /* Copy READMEs */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = "Copy READMEs";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "echo $BUILT_PRODUCTS_DIR\n#readme for the project to skip\nDEFAULT_README=$SRCROOT/README.md\n#find all README.md files in the project\nfind ${SRCROOT} -name \"README.md\" | while read file\ndo\n    #skip if its the default readme for project\n    if [ \"$file\" = \"$DEFAULT_README\" ]\n    then\n        echo $BUILT_PRODUCTS_DIR\n        continue\n    fi\n    #extract the folder name from the path\n    FILE_PATH=$(dirname \"$file\")\n    FOLDER_NAME=$(basename \"$FILE_PATH\")\n    #path of the folder to be created for each readme\n    BUILD_APP_DIR=${BUILT_PRODUCTS_DIR}/${CONTENTS_FOLDER_PATH}/${FOLDER_NAME}\n\n    #for legacy setting the build folder is also within the SRCROOT folder\n    #check if source path is equal to destination then skip\n    if [ \"$file\" != \"${BUILD_APP_DIR}/README.md\" ]\n    then\n        mkdir -p \"${BUILD_APP_DIR}\"\n        cp \"${file}\" \"${BUILD_APP_DIR}/README.md\"\n    fi\ndone\n";
+			shellScript = "#directory to which the readmes will be copied\nREADMES_DIR=${BUILT_PRODUCTS_DIR}/${CONTENTS_FOLDER_PATH}/READMEs\nmkdir -p \"${READMES_DIR}\"\n\n#readme for the project to skip\nDEFAULT_README=$SRCROOT/README.md\n\n#find all README.md files in the project\nfind ${SRCROOT} -name \"README.md\" | while read file\ndo\n    #skip if its the default readme for project\n    if [ \"$file\" = \"$DEFAULT_README\" ]\n    then\n        echo $BUILT_PRODUCTS_DIR\n        continue\n    fi\n    \n    #extract the folder name from the path\n    FILE_PATH=$(dirname \"$file\")\n    FOLDER_NAME=$(basename \"$FILE_PATH\")\n    \n    cp \"${file}\" \"${READMES_DIR}/${FOLDER_NAME}.md\"\ndone\n";
 		};
 		4CB506D1224C2C20006A3471 /* Download Portal Item Data */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/arcgis-ios-sdk-samples/Content Display Logic/Model/Sample.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Model/Sample.swift
@@ -42,6 +42,6 @@ extension Sample: Decodable {
 
 extension Sample {
     var readmeURL: URL? {
-        return Bundle.main.url(forResource: "README", withExtension: "md", subdirectory: name)
+        return Bundle.main.url(forResource: name, withExtension: "md", subdirectory: "READMEs")
     }
 }


### PR DESCRIPTION
Rather than putting each README in a separate directory, this puts them all in the same directory. This helps to clean up the app bundle.