### PR TITLE
Remove extra forward slashes

### DIFF
--- a/arcgis-ios-sdk-samples/Geometry/Cut geometry/CutGeometryViewController.swift
+++ b/arcgis-ios-sdk-samples/Geometry/Cut geometry/CutGeometryViewController.swift
@@ -1,4 +1,4 @@
-//// Copyright 2018 Esri
+// Copyright 2018 Esri
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This addresses a linter issue generated by newer versions of SwiftLint.