### PR TITLE
Search bar text field background color changed for SearchForWebmapByKeywordViewController

### DIFF
--- a/arcgis-ios-sdk-samples/Cloud & Portal/Search for webmap by keyword/SearchForWebmapByKeywordViewController.swift
+++ b/arcgis-ios-sdk-samples/Cloud & Portal/Search for webmap by keyword/SearchForWebmapByKeywordViewController.swift
@@ -67,7 +67,12 @@ class SearchForWebmapByKeywordViewController: UICollectionViewController {
         searchBar.autocapitalizationType = .none
         
         if #available(iOS 13, *) {
-            // Do nothing, on iOS 13 the settings below have no effect.
+            // Change the backgroundColor to differentiate from nav bar color.
+            searchBar.searchTextField.backgroundColor = .white
+            // Set the color of "Cancel" text, to mimic the settings on iOS 12. On iOS 13 it is default to white.
+            searchBar.tintColor = .white
+            // Set the color of the insertion cursor as well as the text. The text is default to black color whereas the cursor is white.
+            searchBar.searchTextField.tintColor = .darkText
         } else {
             // This code is required to make the search bar look decent on iOS 12
             // This does not work on iOS 13, where the search bar looks different.


### PR DESCRIPTION
This PR solves a previous issue that causes search bar background color blend with the navigation bar, which also happens in `SearchForWebmapByKeywordViewController`