### PR TITLE
Convex hull README fix

### DIFF
--- a/arcgis-ios-sdk-samples/Geometry/Convex hull/README.md
+++ b/arcgis-ios-sdk-samples/Geometry/Convex hull/README.md
@@ -15,7 +15,7 @@ Tap on the map to add points. Tap the "Create" button to generate the convex hul
 ## How it works
 
 1. Create an input geometry such as an `AGSMultipoint` object.
-2. 2. Use `class AGSGeometryEngine.convexHull(for:)` to create a new `AGSGeometry` object representing the convex hull of the input points. The returned geometry will either be a `AGSPoint`, `AGSPolyline`, or `AGSPolygon` based on the number of input points.
+2. Use `class AGSGeometryEngine.convexHull(for:)` to create a new `AGSGeometry` object representing the convex hull of the input points. The returned geometry will either be a `AGSPoint`, `AGSPolyline`, or `AGSPolygon` based on the number of input points.
 
 ## Relevant API
 


### PR DESCRIPTION
Remove redundant number in the list.

I just found the typo when I was reviewing the README, and removed it immediately. 
Sorry for the trouble.