### PR TITLE
Add back the accidentally removed plist entry in the app

### DIFF
--- a/arcgis-ios-sdk-samples/Content Display Logic/ContentPList.plist
+++ b/arcgis-ios-sdk-samples/Content Display Logic/ContentPList.plist
@@ -289,6 +289,14 @@
 		<array>
 			<dict>
 				<key>displayName</key>
+				<string>Display subtype feature layer</string>
+				<key>storyboardName</key>
+				<string>DisplaySubtypeFeatureLayer</string>
+				<key>descriptionText</key>
+				<string>Display a composite layer of all the subtype values in a feature class.</string>
+			</dict>
+			<dict>
+				<key>displayName</key>
 				<string>Display annotation</string>
 				<key>storyboardName</key>
 				<string>DisplayAnnotation</string>


### PR DESCRIPTION
In #830 at [this commit](https://github.com/Esri/arcgis-runtime-samples-ios/pull/830/commits/f02101ca34441b2c6d10e69e74b4fbc7158c82ee), I removed the entry by accident. 

Add it back now, and would need to require @saratchandrakarumuri to do another check for the example in #826 , to make sure it is working correctly right now.

