### PR TITLE
Fix strong reference with weak capture in closures

### DIFF
--- a/arcgis-ios-sdk-samples/Analysis/Analyze hotspots/AnalyzeHotspotsViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Analyze hotspots/AnalyzeHotspotsViewController.swift
@@ -79,11 +79,7 @@ class AnalyzeHotspotsViewController: UIViewController, HotspotSettingsVCDelegate
         }, completion: { [weak self] (result: AGSGeoprocessingResult?, error: Error?) in
             //dismiss progress hud
             SVProgressHUD.dismiss()
-            
-            guard let self = self else {
-                return
-            }
-            
+            guard let self = self else { return }
             if let error = error {
                 //show error
                 self.presentAlert(error: error)
@@ -96,11 +92,14 @@ class AnalyzeHotspotsViewController: UIViewController, HotspotSettingsVCDelegate
                 self.mapView.map?.operationalLayers.add(result!.mapImageLayer!)
                 
                 //set map view's viewpoint to the new layer's full extent
-                (self.mapView.map?.operationalLayers.firstObject as! AGSLayer).load { (error: Error?) in
-                    if error == nil {
+                (self.mapView.map?.operationalLayers.firstObject as! AGSLayer).load { [weak self] (error: Error?) in
+                    guard let self = self else { return }
+                    if let error = error {
+                        self.presentAlert(error: error)
+                    } else {
                         //set viewpoint as the extent of the mapImageLayer
                         if let extent = result?.mapImageLayer?.fullExtent {
-                            self.mapView.setViewpointGeometry(extent, completion: nil)
+                            self.mapView.setViewpointGeometry(extent)
                         }
                     }
                 }
@@ -112,7 +111,6 @@ class AnalyzeHotspotsViewController: UIViewController, HotspotSettingsVCDelegate
     
     func hotspotSettingsViewController(_ hotspotSettingsViewController: HotspotSettingsViewController, didSelectDates fromDate: Date, toDate: Date) {
         hotspotSettingsViewController.dismiss(animated: true)
-        
         analyzeHotspots(fromDate, toDate: toDate)
     }
     

--- a/arcgis-ios-sdk-samples/Layers/Dictionary renderer with feature layer/FeatureLayerDictionaryRendererViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Dictionary renderer with feature layer/FeatureLayerDictionaryRendererViewController.swift
@@ -44,24 +44,26 @@ class FeatureLayerDictionaryRendererViewController: UIViewController {
         
         // Once geodatabase is done loading, create feature layers from each feature table.
         generatedGeodatabase.load { [weak self] (error: Error?) in
+            guard let self = self else { return }
             if let error = error {
-                self?.presentAlert(error: error)
+                self.presentAlert(error: error)
             } else {
                 for featureTable in generatedGeodatabase.geodatabaseFeatureTables {
                     // Create a feature layer from the feature table.
                     let featureLayer = AGSFeatureLayer(featureTable: featureTable)
                     // Set the minimum visibility scale.
                     featureLayer.minScale = 1000000
-                    featureLayer.load { (error: Error?) in
+                    featureLayer.load { [weak self] (error: Error?) in
+                        guard let self = self else { return }
                         if let error = error {
-                            self?.presentAlert(error: error)
+                            self.presentAlert(error: error)
                         } else {
                             // Set the viewpoint to the full extent of all layers.
-                            self?.mapView.setViewpointGeometry(featureLayer.fullExtent!)
+                            self.mapView.setViewpointGeometry(featureLayer.fullExtent!)
                         }
                     }
                     // Add each layer to the map.
-                    self!.mapView.map?.operationalLayers.add(featureLayer)
+                    self.mapView.map?.operationalLayers.add(featureLayer)
                     // Display features from the layer using mil2525d symbols.
                     featureLayer.renderer = AGSDictionaryRenderer(dictionarySymbolStyle: dictionarySymbol)
                 }


### PR DESCRIPTION
Refactor previous code that does not add a `weak` keyword to the capture list, which could hold a strong reference to the ViewController itself.