### PR TITLE
Address Xcode 11.4 warnings

### DIFF
--- a/arcgis-ios-sdk-samples/Shared resources/Libraries/DemoTouchManager/DemoTouchManager.swift
+++ b/arcgis-ios-sdk-samples/Shared resources/Libraries/DemoTouchManager/DemoTouchManager.swift
@@ -318,8 +318,12 @@ private class DemoTouchesView: UIView {
                 removeTouch(touch)
             case .cancelled:
                 removeTouch(touch, cancelled: true)
-            case .stationary, .regionEntered, .regionMoved, .regionExited:
-                fallthrough
+            case .stationary:
+                break
+            #if compiler(>=5.2)
+            case .regionEntered, .regionMoved, .regionExited:
+                break
+            #endif
             @unknown default:
                 break
             }

--- a/arcgis-ios-sdk-samples/Shared resources/Libraries/DemoTouchManager/DemoTouchManager.swift
+++ b/arcgis-ios-sdk-samples/Shared resources/Libraries/DemoTouchManager/DemoTouchManager.swift
@@ -318,9 +318,8 @@ private class DemoTouchesView: UIView {
                 removeTouch(touch)
             case .cancelled:
                 removeTouch(touch, cancelled: true)
-            case .stationary:
-                // NOTE: I've never actually seen this state.
-                break
+            case .stationary, .regionEntered, .regionMoved, .regionExited:
+                fallthrough
             @unknown default:
                 break
             }


### PR DESCRIPTION
This PR addresses the following warning that is generated when building with Xcode 11.4:

<img width="601" alt="image" src="https://user-images.githubusercontent.com/2257493/77593725-e8aadd00-6eb1-11ea-8c2b-a705f45fbaec.png">