### PR TITLE
UILabel safe area fix

### DIFF
--- a/arcgis-ios-sdk-samples/Augmented reality/Collect data in AR/CollectDataAR.storyboard
+++ b/arcgis-ios-sdk-samples/Augmented reality/Collect data in AR/CollectDataAR.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eeF-1C-KCv">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eeF-1C-KCv">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="H1P-pM-V3w" customClass="ArcGISARView" customModule="ArcGISToolkit">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="769"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dpR-4S-84i">
@@ -66,18 +66,18 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="5Gu-LX-mPv" firstAttribute="leading" secondItem="WLY-wp-9Ey" secondAttribute="leading" id="DPt-Xs-hrp"/>
-                            <constraint firstItem="3xw-tF-tjx" firstAttribute="leading" secondItem="WLY-wp-9Ey" secondAttribute="leading" id="HWG-32-nsX"/>
-                            <constraint firstItem="dpR-4S-84i" firstAttribute="bottom" secondItem="WLY-wp-9Ey" secondAttribute="bottom" placeholder="YES" id="JmG-FP-sMl"/>
-                            <constraint firstAttribute="bottom" secondItem="H1P-pM-V3w" secondAttribute="bottom" id="KDK-4l-D2R"/>
+                            <constraint firstItem="5Gu-LX-mPv" firstAttribute="leading" secondItem="XZF-OQ-lPz" secondAttribute="leading" id="DPt-Xs-hrp"/>
+                            <constraint firstItem="3xw-tF-tjx" firstAttribute="leading" secondItem="XZF-OQ-lPz" secondAttribute="leading" id="HWG-32-nsX"/>
+                            <constraint firstItem="dpR-4S-84i" firstAttribute="top" secondItem="H1P-pM-V3w" secondAttribute="bottom" symbolic="YES" id="Iuy-3Z-b9b"/>
                             <constraint firstItem="H1P-pM-V3w" firstAttribute="trailing" secondItem="XZF-OQ-lPz" secondAttribute="trailing" id="KF0-rr-Wyj"/>
-                            <constraint firstItem="WLY-wp-9Ey" firstAttribute="trailing" secondItem="5Gu-LX-mPv" secondAttribute="trailing" id="TgR-0a-jZK"/>
-                            <constraint firstItem="WLY-wp-9Ey" firstAttribute="trailing" secondItem="3xw-tF-tjx" secondAttribute="trailing" id="d9a-b8-dd1"/>
+                            <constraint firstItem="dpR-4S-84i" firstAttribute="bottom" secondItem="WLY-wp-9Ey" secondAttribute="bottom" id="KKh-cw-AlI"/>
+                            <constraint firstAttribute="trailing" secondItem="5Gu-LX-mPv" secondAttribute="trailing" id="TgR-0a-jZK"/>
+                            <constraint firstAttribute="trailing" secondItem="3xw-tF-tjx" secondAttribute="trailing" id="d9a-b8-dd1"/>
                             <constraint firstItem="dpR-4S-84i" firstAttribute="trailing" secondItem="XZF-OQ-lPz" secondAttribute="trailing" id="dLA-it-9ON"/>
                             <constraint firstItem="5Gu-LX-mPv" firstAttribute="top" secondItem="3xw-tF-tjx" secondAttribute="bottom" id="dfP-2T-pBH"/>
                             <constraint firstItem="3xw-tF-tjx" firstAttribute="top" secondItem="WLY-wp-9Ey" secondAttribute="top" id="ecz-5b-hXa"/>
                             <constraint firstItem="H1P-pM-V3w" firstAttribute="leading" secondItem="XZF-OQ-lPz" secondAttribute="leading" id="lBQ-ez-qgx"/>
-                            <constraint firstItem="H1P-pM-V3w" firstAttribute="top" secondItem="XZF-OQ-lPz" secondAttribute="top" id="raA-rk-d0R"/>
+                            <constraint firstItem="H1P-pM-V3w" firstAttribute="top" secondItem="WLY-wp-9Ey" secondAttribute="top" id="raA-rk-d0R"/>
                             <constraint firstItem="dpR-4S-84i" firstAttribute="leading" secondItem="XZF-OQ-lPz" secondAttribute="leading" id="xDn-ZI-Qjh"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="WLY-wp-9Ey"/>

--- a/arcgis-ios-sdk-samples/Augmented reality/Collect data in AR/CollectDataAR.swift
+++ b/arcgis-ios-sdk-samples/Augmented reality/Collect data in AR/CollectDataAR.swift
@@ -87,9 +87,6 @@ class CollectDataAR: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Constrain toolbar to the scene view's attribution label
-        toolbar.bottomAnchor.constraint(equalTo: arView.sceneView.attributionTopAnchor).isActive = true
-
         // Create and prep the calibration view controller
         calibrationVC = CollectDataARCalibrationViewController(arcgisARView: arView)
         calibrationVC?.preferredContentSize = CGSize(width: 250, height: 100)

--- a/arcgis-ios-sdk-samples/Augmented reality/Display scenes in tabletop AR/DisplayScenesInTabletopAR.storyboard
+++ b/arcgis-ios-sdk-samples/Augmented reality/Display scenes in tabletop AR/DisplayScenesInTabletopAR.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="9jd-tI-OWR">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="9jd-tI-OWR">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="C5S-t5-nxA" customClass="ArcGISARView" customModule="ArcGISToolkit">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="852"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Move the phone slowly to begin tracking." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3LI-jX-nbZ">
@@ -32,13 +30,13 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="C5S-t5-nxA" firstAttribute="top" secondItem="UlC-uU-6kg" secondAttribute="top" id="V9t-Oo-Wba"/>
-                            <constraint firstItem="3LI-jX-nbZ" firstAttribute="leading" secondItem="1At-b3-BXl" secondAttribute="leading" id="YXg-op-B0O"/>
+                            <constraint firstItem="C5S-t5-nxA" firstAttribute="top" secondItem="1At-b3-BXl" secondAttribute="top" id="V9t-Oo-Wba"/>
+                            <constraint firstItem="3LI-jX-nbZ" firstAttribute="leading" secondItem="UlC-uU-6kg" secondAttribute="leading" id="YXg-op-B0O"/>
                             <constraint firstItem="3LI-jX-nbZ" firstAttribute="top" secondItem="1At-b3-BXl" secondAttribute="top" id="c0V-kc-B2k"/>
                             <constraint firstAttribute="bottom" secondItem="C5S-t5-nxA" secondAttribute="bottom" id="e6d-eP-Jg1"/>
                             <constraint firstAttribute="trailing" secondItem="C5S-t5-nxA" secondAttribute="trailing" id="jJ7-KT-4WU"/>
                             <constraint firstItem="C5S-t5-nxA" firstAttribute="leading" secondItem="UlC-uU-6kg" secondAttribute="leading" id="vGK-ZX-fHi"/>
-                            <constraint firstItem="3LI-jX-nbZ" firstAttribute="trailing" secondItem="1At-b3-BXl" secondAttribute="trailing" id="zgu-r4-5DN"/>
+                            <constraint firstItem="3LI-jX-nbZ" firstAttribute="trailing" secondItem="UlC-uU-6kg" secondAttribute="trailing" id="zgu-r4-5DN"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="1At-b3-BXl"/>
                     </view>

--- a/arcgis-ios-sdk-samples/Augmented reality/Explore scenes in flyover AR/ExploreScenesInFlyoverAR.storyboard
+++ b/arcgis-ios-sdk-samples/Augmented reality/Explore scenes in flyover AR/ExploreScenesInFlyoverAR.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="wbC-YQ-IFf">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="wbC-YQ-IFf">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="arp-qo-cpt" customClass="ArcGISARView" customModule="ArcGISToolkit">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="852"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Setting up ARKit" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hvw-so-ZTT">
@@ -34,11 +32,11 @@
                         <constraints>
                             <constraint firstItem="Hvw-so-ZTT" firstAttribute="top" secondItem="Jsj-Q3-6Gy" secondAttribute="top" id="COM-6c-ceI"/>
                             <constraint firstAttribute="trailing" secondItem="arp-qo-cpt" secondAttribute="trailing" id="HkV-3l-y1E"/>
-                            <constraint firstItem="Hvw-so-ZTT" firstAttribute="leading" secondItem="Jsj-Q3-6Gy" secondAttribute="leading" id="PmF-n7-C70"/>
+                            <constraint firstItem="Hvw-so-ZTT" firstAttribute="leading" secondItem="MDC-IB-9ba" secondAttribute="leading" id="PmF-n7-C70"/>
                             <constraint firstItem="arp-qo-cpt" firstAttribute="leading" secondItem="MDC-IB-9ba" secondAttribute="leading" id="Wfe-cL-GI6"/>
                             <constraint firstAttribute="bottom" secondItem="arp-qo-cpt" secondAttribute="bottom" id="nMd-qD-U6I"/>
-                            <constraint firstItem="arp-qo-cpt" firstAttribute="top" secondItem="MDC-IB-9ba" secondAttribute="top" id="xfq-QR-o6j"/>
-                            <constraint firstItem="Jsj-Q3-6Gy" firstAttribute="trailing" secondItem="Hvw-so-ZTT" secondAttribute="trailing" id="y9g-tD-vwY"/>
+                            <constraint firstItem="arp-qo-cpt" firstAttribute="top" secondItem="Jsj-Q3-6Gy" secondAttribute="top" id="xfq-QR-o6j"/>
+                            <constraint firstAttribute="trailing" secondItem="Hvw-so-ZTT" secondAttribute="trailing" id="y9g-tD-vwY"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="Jsj-Q3-6Gy"/>
                     </view>


### PR DESCRIPTION
In the 3 AR examples, the info `UILabel`s' background does not extend into the safe area correctly. Also, the `ArcGISARView` the `Collect data AR` example overlap with the toolbar and labels incorrectly. This PR address those issues.

Below attached the screenshot comparisons between original and fixed versions.

## Collect data AR
|Original|After fix|
|------ | ------|
|<img width=375 src="https://user-images.githubusercontent.com/9660181/78412237-7def5500-75c7-11ea-8ca8-a93a481b1bf8.png">|<img width=375 src="https://user-images.githubusercontent.com/9660181/78412235-7c259180-75c7-11ea-9254-b5029ed61dcf.png">|

## Display scenes in tabletop AR
|Original|After fix|
|------ | ------|
|<img width=375 src="https://user-images.githubusercontent.com/9660181/78412301-af682080-75c7-11ea-9c37-aed0b15579a6.png">|<img width=375 src="https://user-images.githubusercontent.com/9660181/78412296-ad05c680-75c7-11ea-9597-b8d046cd18f7.png">|

## Explore scenes in flyover AR
|Original|After fix|
|------ | ------|
|<img width=375 src="https://user-images.githubusercontent.com/9660181/78412322-c575e100-75c7-11ea-93fa-65d39a0d8678.png">|<img width=375 src="https://user-images.githubusercontent.com/9660181/78412318-c1e25a00-75c7-11ea-934a-1b1eaddabd1c.png">|

