### PR TITLE
Fix: missing feature layer in Download preplanned map area sample

### DIFF
--- a/arcgis-ios-sdk-samples/Maps/Download preplanned map/MapSelectionTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Download preplanned map/MapSelectionTableViewController.swift
@@ -194,23 +194,30 @@ class MapSelectionTableViewController: UITableViewController {
             offlineTask = AGSOfflineMapTask(onlineMap: onlineMap)
         }
         
-        guard let task = offlineTask else { return }
-        
+        let task = offlineTask!
         try? FileManager.default.removeItem(at: area.mapPackageURL)
-        
-        let job = task.downloadPreplannedOfflineMapJob(with: area, downloadDirectory: area.mapPackageURL)
-        currentJobs[area] = job
-        
-        let cell = tableView.cellForRow(at: indexPath) as? PreplannedMapAreaTableViewCell
-        cell?.progressView.observedProgress = job.progress
-        
-        job.start(statusHandler: nil) { [weak self] (result, error) in
+        let cell = self.tableView.cellForRow(at: indexPath) as? PreplannedMapAreaTableViewCell
+        // Create download parameters with default values.
+        task.defaultDownloadPreplannedOfflineMapParameters(with: area) { [weak self] (params, error) in
             guard let self = self else { return }
-            
-            if let result = result {
-                self.downloadPreplannedOfflineMapJob(job, didFinishWith: .success(result))
-            } else if let error = error {
-                self.downloadPreplannedOfflineMapJob(job, didFinishWith: .failure(error))
+            if let error = error {
+                print("Error fetching default parameters for the preplanned map : \(error.localizedDescription)")
+            } else if let params = params {
+                // Set update mode to no updates as the offline map is display-only.
+                params.updateMode = .noUpdates
+                // Create a download offline map job with fetched parameters.
+                let job = task.downloadPreplannedOfflineMapJob(with: params, downloadDirectory: area.mapPackageURL)
+                self.currentJobs[area] = job
+                cell?.progressView.observedProgress = job.progress
+                
+                job.start(statusHandler: nil) { [weak self] (result, error) in
+                    guard let self = self else { return }
+                    if let result = result {
+                        self.downloadPreplannedOfflineMapJob(job, didFinishWith: .success(result))
+                    } else if let error = error {
+                        self.downloadPreplannedOfflineMapJob(job, didFinishWith: .failure(error))
+                    }
+                }
             }
         }
     }

--- a/arcgis-ios-sdk-samples/Maps/Download preplanned map/MapSelectionTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Download preplanned map/MapSelectionTableViewController.swift
@@ -196,7 +196,6 @@ class MapSelectionTableViewController: UITableViewController {
         
         let task = offlineTask!
         try? FileManager.default.removeItem(at: area.mapPackageURL)
-        let cell = self.tableView.cellForRow(at: indexPath) as? PreplannedMapAreaTableViewCell
         // Create download parameters with default values.
         task.defaultDownloadPreplannedOfflineMapParameters(with: area) { [weak self] (params, error) in
             guard let self = self else { return }
@@ -208,6 +207,7 @@ class MapSelectionTableViewController: UITableViewController {
                 // Create a download offline map job with fetched parameters.
                 let job = task.downloadPreplannedOfflineMapJob(with: params, downloadDirectory: area.mapPackageURL)
                 self.currentJobs[area] = job
+                let cell = self.tableView.cellForRow(at: indexPath) as? PreplannedMapAreaTableViewCell
                 cell?.progressView.observedProgress = job.progress
                 
                 job.start(statusHandler: nil) { [weak self] (result, error) in


### PR DESCRIPTION
This PR fixes the issue that in `Download preplanned map area` sample, no feature layer is displayed for offline preplanned maps. This is due to the `AGSDownloadPreplannedOfflineMapParameters.updateMode` need to be set explicitly.