### PR TITLE
Update download script for archive with multiple files

### DIFF
--- a/Scripts/download-portal-item-data.swift
+++ b/Scripts/download-portal-item-data.swift
@@ -27,7 +27,7 @@ import Foundation
 
 protocol URLProvider {
     func makeURL(filename: String) -> URL
-    func makeSubFolderForArchive(folderName: String) -> URL
+    func makeSubFolderURLForArchive(folderName: String) -> URL
 }
 
 struct DestinationURLProvider: URLProvider {
@@ -46,8 +46,8 @@ struct DestinationURLProvider: URLProvider {
     /// Make a sub-folder path for the extracted files from an archive.
     ///
     /// - Parameter folderName: The name of the folder.
-    /// - Returns: A URL of the folder.
-    func makeSubFolderForArchive(folderName: String) -> URL {
+    /// - Returns: A URL to the folder.
+    func makeSubFolderURLForArchive(folderName: String) -> URL {
         var url = downloadDirectory
         if let subdirectory = fileTypes.first(where: { $0.value.contains("zip") })?.key {
             url.appendPathComponent(subdirectory, isDirectory: true)
@@ -138,7 +138,8 @@ func downloadFile(at sourceURL: URL, destinationURLProvider: URLProvider, comple
                 if isArchive {
                     let fileCount = try countFilesInArchive(at: temporaryURL)
                     print("File count in the archive is \(fileCount)")
-                    extractURL = destinationURLProvider.makeSubFolderForArchive(folderName: (suggestedFilename as NSString).deletingPathExtension)
+                    // Extract to a sub-folder with the same name as the archive without the extension.
+                    extractURL = destinationURLProvider.makeSubFolderURLForArchive(folderName: (suggestedFilename as NSString).deletingPathExtension)
                 }
                 
                 try FileManager.default.createDirectory(at: downloadURL.deletingLastPathComponent(), withIntermediateDirectories: true)
@@ -241,8 +242,8 @@ portalItems.forEach { (portalURLString, portalItems) in
         let isFileExist: Bool = FileManager.default.fileExists(atPath: destinationURLProvider.makeURL(filename: filename).path)
         
         // Check if there is a sub-folder for the corresponding archive, and the sub-folder is empty or not.
-        // The corresponding sub-folder has the same name as the archive, but without the extension.
-        let subFolderURL = destinationURLProvider.makeSubFolderForArchive(folderName: (filename as NSString).deletingPathExtension)
+        // The corresponding sub-folder has the same name as the archive without the extension.
+        let subFolderURL = destinationURLProvider.makeSubFolderURLForArchive(folderName: (filename as NSString).deletingPathExtension)
         let paths = try? FileManager.default.contentsOfDirectory(
             at: subFolderURL,
             includingPropertiesForKeys: nil,

--- a/Scripts/download-portal-item-data.swift
+++ b/Scripts/download-portal-item-data.swift
@@ -33,15 +33,15 @@ struct DestinationURLProvider: URLProvider {
     let downloadDirectory: URL
     let fileTypes: [String: [String]]
     
-    /// Make a full path for a file based on the mapping between its filename and file type.
+    /// Make a full path for a file based on the mapping between its filename
+    /// and file type.
     ///
     /// - Parameter filename: The filename of the file.
     /// - Returns: A URL to the file.
     func makeURL(filename: String) -> URL {
         var url = downloadDirectory
-        if let subdirectory = fileTypes.first(
-            where: { $0.value.contains((filename as NSString).pathExtension) }
-            )?.key {
+        if let subdirectory = fileTypes.first(where: {
+            $0.value.contains((filename as NSString).pathExtension) })?.key {
             url.appendPathComponent(subdirectory, isDirectory: true)
         }
         url.appendPathComponent(filename, isDirectory: false)
@@ -49,7 +49,8 @@ struct DestinationURLProvider: URLProvider {
     }
 }
 
-/// Creates a URL such as `{portalURL}/sharing/rest/content/items/{itemIdentifier}/data`
+/// Creates a URL such as
+/// `{portalURL}/sharing/rest/content/items/{itemIdentifier}/data`
 /// for the given item in the given portal.
 ///
 /// - Parameters:
@@ -126,7 +127,7 @@ func uncompressArchive(at sourceURL: URL, to destinationURL: URL) throws {
 ///
 /// - Parameters:
 ///   - sourceURL: The portal URL to the resource.
-///   - destinationURLProvider: A helper struct to make destination path URL with filename.
+///   - destinationURLProvider: A helper struct to make destination URL with filename.
 ///   - completion: A closure to handle the results.
 func downloadFile(at sourceURL: URL, destinationURLProvider: URLProvider, completion: @escaping (Result<URL, Error>) -> Void) {
     let downloadTask = URLSession.shared.downloadTask(with: sourceURL) { (temporaryURL, response, error) in
@@ -190,7 +191,7 @@ struct PortalItem: Decodable {
     var filename: String
 }
 
-// MARK: Enters the script from here.
+// MARK: Script Entry
 
 let arguments = CommandLine.arguments
 
@@ -261,16 +262,10 @@ portalItems.forEach { (portalURLString, portalItems) in
         // Have we already downloaded the item?
         let filename = downloadedItems[portalItem.identifier] ?? portalItem.filename
         let tempURL = destinationURLProvider.makeURL(filename: filename)
-        let pathURL = tempURL.pathExtension == "zip" ? tempURL.deletingPathExtension() : tempURL
+        let fileURL = tempURL.pathExtension == "zip" ? tempURL.deletingPathExtension() : tempURL
         
-        // Check if a single file or a folder exists.
-        var isDirectory = ObjCBool(false)
-        let isFileExist = FileManager.default.fileExists(atPath: pathURL.path, isDirectory: &isDirectory)
-        
-        if isFileExist && isDirectory.boolValue {
-            print("Item \(portalItem.identifier) has already been downloaded, and is extracted to an folder")
-            downloadedItems[portalItem.identifier] = filename
-        } else if isFileExist {
+        // Check if a single file or a directory exists.
+        if FileManager.default.fileExists(atPath: fileURL.path) {
             print("Item \(portalItem.identifier) has already been downloaded")
             // This is a temporary measure for users who currently don't have a downloaded items file.
             downloadedItems[portalItem.identifier] = filename

--- a/Scripts/download-portal-item-data.swift
+++ b/Scripts/download-portal-item-data.swift
@@ -102,7 +102,7 @@ func numberOfFilesInArchive(at url: URL) throws -> Int {
     // "240 files, 29461066 bytes uncompressed, 28292775 bytes compressed:  4.0%"
     // To extract the count, cut the string when first space char is met.
     let totalsInfo = outputPipe.fileHandleForReading.readDataToEndOfFile()
-    let totalsCount = String(data: totalsInfo.prefix(while: { $0 != 32 }), encoding: .utf8)!
+    let totalsCount = String(data: totalsInfo.prefix { $0 != 32 }, encoding: .utf8)!
     return Int(totalsCount)!
 }
 

--- a/Scripts/download-portal-item-data.swift
+++ b/Scripts/download-portal-item-data.swift
@@ -199,7 +199,6 @@ guard arguments.count == 4 else {
     exit(1)
 }
 
-
 let portalItemsURL = URL(fileURLWithPath: arguments[1], isDirectory: false)
 let fileTypesURL = URL(fileURLWithPath: arguments[2], isDirectory: false)
 let downloadDirectoryURL = URL(fileURLWithPath: arguments[3], isDirectory: true)
@@ -232,7 +231,11 @@ let fileTypes: [String: [String]] = {
         exit(1)
     }
 }()
-let destinationURLProvider = DestinationURLProvider(downloadDirectory: downloadDirectoryURL, fileTypes: fileTypes)
+
+let destinationURLProvider = DestinationURLProvider(
+    downloadDirectory: downloadDirectoryURL,
+    fileTypes: fileTypes
+)
 
 typealias Identifier = String
 typealias Filename = String


### PR DESCRIPTION
This PR updates the `download-portal-item-data.swift` script which currently handles the offline data on-demand download for the app. It
- Improves support for ZIP archived portal items.
- Added logics to detect if a file already exists.

A few concerns below.

---

- [x] 1. The script still relies on the filename in `PortalItems.plist`, which run against what being proposed in update #729.

- [x] 2. ~~The script **WILL** create an enclosing folder for the archive to extract to, so that it can ensure all the files from an archive stay in the same folder, rather than scattering under sub-root. See below.~~

**Edit**: With "-j" argument, no enclosing folder will be created.

`enclosing`
```
.
|---enclosing_folder
      |---1.png
      |---2.png
      | ...
```
`flat`
```
.
|---1.png
|---2.png
| ...
```

One downside is that if the files in archive are already wrapped by an enclosing folder, this method will create an effect such as below.
```
.
|---created_enclosing_folder
      |---original_enclosing_folder
            |---1.png
            |---2.png
            | ...
```
Unless the script can handle the case that subfolder is only created for a "flat" archive.

- [x] 3. ~~Some unused functions stays in the file in case they are needed in the future.~~

**Edit**: Removed unused functions.

- [x] 4. ~~Currently the extracted files are not recorded in `.downloaded_items` dictionary. Instead, the zip archive itself is kept track of.~~

**Edit**: There are two cases. First, if the downloaded item is a single file or an archive containing a single file, then the filename of that single file will be recorded. Second, if the downloaded item is an archive, then the `{archive_name}.zip` will be recorded.

Before download, the script will check if the filename-identifier mapping exists, and get the existing file's name. The file will only be downloaded when it doesn't exist on disk.

- [x] ~~5. In this script, both the .zip archive and the extracted files are kept in the storage, which wastes some disk space. Because the sample relies on the `on-demand resource tag`, and the tag is given to the zip archive rather than the extracted folder.~~

  This doesn't apply anymore.

- [x] 6. The extracted files will need to be add to the project file's folder reference, so that it can be retrieved by the sample.