### PR TITLE
Fix: OptionsTableViewController cannot dismiss properly

### DIFF
--- a/arcgis-ios-sdk-samples/Scenes/Change atmosphere effect/ChangeAtmosphereEffectViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Change atmosphere effect/ChangeAtmosphereEffectViewController.swift
@@ -84,7 +84,7 @@ class ChangeAtmosphereEffectViewController: UIViewController {
         controller.modalPresentationStyle = .popover
         controller.presentationController?.delegate = self
         controller.popoverPresentationController?.barButtonItem = sender
-        controller.popoverPresentationController?.passthroughViews = [sceneView]
+        controller.popoverPresentationController?.passthroughViews?.append(sceneView)
         controller.preferredContentSize = CGSize(width: 300, height: 150)
         
         // show the options controller


### PR DESCRIPTION
Problem: Cannot dismiss the `OptionsTableViewController` by tapping on the scene.

Cause: This issue was caused by not setting the `passthroughViews` property of the popover VC properly. See the screenshots below.

Fix: Setting the `passthroughViews` properly.

Also went through the app and checked all other samples that used `OptionsTableViewController` and didn't find another problem like this.

|`Bug`|`Fixed`|
|:------:|:------:|
|<img src="https://user-images.githubusercontent.com/9660181/81754914-27015900-946c-11ea-943d-5dc7b140ff11.gif">|<img src="https://user-images.githubusercontent.com/9660181/81754909-236dd200-946c-11ea-8214-7a5feed1121c.gif">|