### PR TITLE
Update top level README for 100.8 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-A copy of the license is available in the repository's [license.txt](https://raw.githubusercontent.com/Esri/arcgis-runtime-samples-ios/master/LICENSE) file.
+A copy of the license is available in the repository's [LICENSE](https://raw.githubusercontent.com/Esri/arcgis-runtime-samples-ios/master/LICENSE) file.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ This repository contains Swift sample code demonstrating the capabilities of [Ar
 
 The ```master``` branch of this repository contains samples configured for the latest available version of ArcGIS Runtime SDK for iOS. For samples configured for older versions of the SDK,  look under the ```Releases``` tab for a specific version.
 
-
 ## Features
 
 * Maps - Open, create, inteact with and save maps

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains Swift sample code demonstrating the capabilities of [Ar
 
 ![](SampleApp.png)
 
-The ```master``` branch of this repository contains samples configured for the latest available version of ArcGIS Runtime SDK for iOS. For samples configured for older versions of the SDK,  look under the ```Releases``` tab for a specific version.
+The ```master``` branch of this repository contains samples configured for the latest available version of ArcGIS Runtime SDK for iOS. For samples configured for older versions of the SDK, look under the ```Releases``` tab for a specific version.
 
 ## Features
 
@@ -41,7 +41,7 @@ The *ArcGIS Runtime SDK Samples app* has a *Target SDK* version of *12.0*, meani
     > If you've already cloned the repo without the submodule, you can load the submodule using 
     >
     >`git submodule update --init`
-1. **Install** the ArcGIS Runtime SDK for iOS to a central location on your mac as described [here](https://developers.arcgis.com/ios/latest/swift/guide/install.htm#ESRI_SECTION1_D57435A2BEBC4D29AFA3A4CAA722506A)  
+1. **Install** the ArcGIS Runtime SDK for iOS to a central location on your mac as described [here](https://developers.arcgis.com/ios/latest/swift/guide/install.htm#ESRI_SECTION1_D57435A2BEBC4D29AFA3A4CAA722506A)
 1. **Open** the `arcgis-ios-sdk-samples.xcodeproj` **project** file
 1. **Run** the `arcgis-ios-sdk-samples` app target
     > If you get the error message saying _"This Copy Files build phase contains a reference to a missing file 'ArcGISToolkit.framework'"_, you probably didn't clone the repo to include it's submodule. See Step 1 above.
@@ -51,7 +51,7 @@ The *ArcGIS Runtime SDK Samples app* has a *Target SDK* version of *12.0*, meani
 1. **Fork** and then **clone** the repository
 1. **Install** the ArcGIS Runtime SDK for iOS by running the `pod install` command in the folder where you cloned this repository
 1. **Open** the `arcgis-ios-sdk-samples.xcworkspace` **workspace** file
-1. **Select** the `arcgis-ios-sdk-samples` project node, go to the `Build Phases` tab, and **delete** the phases for `Embed Frameworks` and `Strip Frameworks` (these phases conflict with cocoapods  and are only required when using the installed SDK as described in the previous section )
+1. **Select** the `arcgis-ios-sdk-samples` project node, go to the `Build Phases` tab, and **delete** the phases for `Embed Frameworks` and `Strip Frameworks` (these phases conflict with cocoapods and are only required when using the installed SDK as described in the previous section)
 1. **Select** the `ArcGISToolkit.xcodeproj` project node and **delete** it. (this project dependency conflicts with cocoapods and is only required when using the installed SDK as described in the previous section)
 1. **Run** the `arcgis-ios-sdk-samples` app target
 
@@ -67,7 +67,7 @@ Some sample data is too large to store in the repository, so it is automatically
 
 ## Issues
 
-Find a bug or want to request a new feature?  Please let us know by submitting an issue.
+Find a bug or want to request a new feature? Please let us know by submitting an issue.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ArcGIS Runtime SDK for iOS Samples [![](https://user-images.githubusercontent.com/2257493/54144188-6fe0fc00-43e8-11e9-8cf5-229af80f604a.png)](https://itunes.apple.com/us/app/arcgis-runtime-sdk-for-ios/id1180714771)
 ==========================
 
-This repository contains Swift sample code demonstrating the capabilities of [ArcGIS Runtime SDK for iOS](https://developers.arcgis.com/ios/) and how to use them in your own app. The project that can be opened in Xcode and run on a simulator or a device. Or you can [download the app from the App Store](https://itunes.apple.com/us/app/arcgis-runtime-sdk-for-ios/id1180714771) on your iOS device.
+This repository contains Swift sample code demonstrating the capabilities of [ArcGIS Runtime SDK for iOS](https://developers.arcgis.com/ios/latest/) and how to use them in your own app. The project that can be opened in Xcode and run on a simulator or a device. Or you can [download the app from the App Store](https://itunes.apple.com/us/app/arcgis-runtime-sdk-for-ios/id1180714771) on your iOS device.
 
 ![](SampleApp.png)
 
@@ -12,23 +12,28 @@ The ```master``` branch of this repository contains samples configured for the l
 
 * Maps - Open, create, inteact with and save maps
 * Layers - Layer types offered by the SDK
-* Features - Working with Feature layers
-* Edit Data - Adding, deleting and editing features
+* Features - Working with feature layers
 * Display Information - Displaying graphics, popups and callouts
 * Search - Finding an address
+* Edit Data - Adding, deleting and editing features
 * Geometry - Displaying geometries
 * Route & Directions - Find a route around barriers and get turn-by-turn directions
+* Analysis - 
+* Cloud & Portal - 
 * Scenes - Display scenes, 3D symbols, and scene layers
+* Utility Network - 
+* Augmented Reality - 
 
 ## Requirements
 
-* [ArcGIS Runtime SDK for iOS](https://developers.arcgis.com/ios/) 100.7.0 (or newer)
-* [ArcGIS Runtime Toolkit for iOS](https://github.com/Esri/arcgis-runtime-toolkit-ios) 100.7.0 (or newer)
+* [ArcGIS Runtime SDK for iOS](https://developers.arcgis.com/ios/latest/) 100.8.0 (or newer)
+* [ArcGIS Runtime Toolkit for iOS](https://github.com/Esri/arcgis-runtime-toolkit-ios) 100.8.0 (or newer)
 * Xcode 11.0 (or newer)
 
 The *ArcGIS Runtime SDK Samples app* has a *Target SDK* version of *12.0*, meaning that it can run on devices with *iOS 12.0* or newer.
 
 ## Building samples using installed SDK
+
 1. **Fork** and then **clone** the repository
     > Make sure to use the "recursive" option to ensure you get the **ArcGIS Runtime Toolkit** submodule
     >
@@ -43,13 +48,13 @@ The *ArcGIS Runtime SDK Samples app* has a *Target SDK* version of *12.0*, meani
     > If you get the error message saying _"This Copy Files build phase contains a reference to a missing file 'ArcGISToolkit.framework'"_, you probably didn't clone the repo to include it's submodule. See Step 1 above.
 
 ## Building samples with cocoapods
+
 1. **Fork** and then **clone** the repository
-1. **Install** the ArcGIS Runtime SDK for iOS by running the `pod install` command in the folder where you cloned this repository.
+1. **Install** the ArcGIS Runtime SDK for iOS by running the `pod install` command in the folder where you cloned this repository
 1. **Open** the `arcgis-ios-sdk-samples.xcworkspace` **workspace** file
 1. **Select** the `arcgis-ios-sdk-samples` project node, go to the `Build Phases` tab, and **delete** the phases for `Embed Frameworks` and `Strip Frameworks` (these phases conflict with cocoapods  and are only required when using the installed SDK as described in the previous section )
 1. **Select** the `ArcGISToolkit.xcodeproj` project node and **delete** it. (this project dependency conflicts with cocoapods and is only required when using the installed SDK as described in the previous section)
 1. **Run** the `arcgis-ios-sdk-samples` app target
-
 
 ## Sample Data
 
@@ -59,7 +64,7 @@ Some sample data is too large to store in the repository, so it is automatically
 
 * Want to start a new project? [Setup](https://developers.arcgis.com/ios/latest/swift/guide/install.htm) your dev environment
 * New to the API? Explore the documentation : [Guide](https://developers.arcgis.com/ios/latest/swift/guide/introduction.htm) | [API Reference](https://developers.arcgis.com/ios/latest/api-reference/)
-* Got a question? Ask the community on our [forum](https://geonet.esri.com/community/developers/native-app-developers/arcgis-runtime-sdk-for-ios/)
+* Got a question? Ask the community on our [forum](https://community.esri.com/community/developers/native-app-developers/arcgis-runtime-sdk-for-ios/)
 
 ## Issues
 
@@ -71,7 +76,7 @@ Esri welcomes contributions from anyone and everyone. Please see our [guidelines
 
 ## Licensing
 
-Copyright 2013 Esri
+Copyright 2020 Esri
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -85,4 +90,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-A copy of the license is available in the repository's [license.txt]( https://raw.github.com/Esri/arcgis-runtime-samples-ios/master/license.txt) file.
+A copy of the license is available in the repository's [license.txt](https://raw.githubusercontent.com/Esri/arcgis-runtime-samples-ios/master/LICENSE) file.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The ```master``` branch of this repository contains samples configured for the l
 
 ## Features
 
-* Maps - Open, create, inteact with and save maps
+* Maps - Open, create, interact with and save maps
 * Layers - Layer types offered by the SDK
 * Features - Working with feature layers
 * Display Information - Displaying graphics, popups and callouts
@@ -46,13 +46,13 @@ The *ArcGIS Runtime SDK Samples app* has a *Target SDK* version of *12.0*, meani
 1. **Run** the `arcgis-ios-sdk-samples` app target
     > If you get the error message saying _"This Copy Files build phase contains a reference to a missing file 'ArcGISToolkit.framework'"_, you probably didn't clone the repo to include it's submodule. See Step 1 above.
 
-## Building samples with cocoapods
+## Building samples with CocoaPods
 
 1. **Fork** and then **clone** the repository
 1. **Install** the ArcGIS Runtime SDK for iOS by running the `pod install` command in the folder where you cloned this repository
 1. **Open** the `arcgis-ios-sdk-samples.xcworkspace` **workspace** file
-1. **Select** the `arcgis-ios-sdk-samples` project node, go to the `Build Phases` tab, and **delete** the phases for `Embed Frameworks` and `Strip Frameworks` (these phases conflict with cocoapods and are only required when using the installed SDK as described in the previous section)
-1. **Select** the `ArcGISToolkit.xcodeproj` project node and **delete** it. (this project dependency conflicts with cocoapods and is only required when using the installed SDK as described in the previous section)
+1. **Select** the `arcgis-ios-sdk-samples` project node, go to the `Build Phases` tab, and **delete** the phases for `Embed Frameworks` and `Strip Frameworks` (these phases conflict with CocoaPods and are only required when using the installed SDK as described in the previous section)
+1. **Select** the `ArcGISToolkit.xcodeproj` project node and **delete** it. (this project dependency conflicts with CocoaPods and is only required when using the installed SDK as described in the previous section)
 1. **Run** the `arcgis-ios-sdk-samples` app target
 
 ## Sample Data

--- a/README.md
+++ b/README.md
@@ -10,18 +10,18 @@ The ```master``` branch of this repository contains samples configured for the l
 ## Features
 
 * Maps - Open, create, interact with and save maps
-* Layers - Layer types offered by the SDK
-* Features - Working with feature layers
-* Display Information - Displaying graphics, popups and callouts
-* Search - Finding an address
-* Edit Data - Adding, deleting and editing features
-* Geometry - Displaying geometries
-* Route & Directions - Find a route around barriers and get turn-by-turn directions
-* Analysis - Analyze data and display results
-* Cloud & Portal - Integrate ArcGIS Online services and tools
-* Scenes - Display scenes, 3D symbols and scene layers
-* Utility Network - Trace, analyze and display information with utility networks
-* Augmented Reality - Explore, display and utilize AR within a map
+* Layers - Display vector and raster data in maps and scenes
+* Features - Work with feature layers and geodatabases
+* Display Information - Show graphics, popups, callouts, and sketches
+* Search - Find addresses, places, and points of interest
+* Edit Data - Add, delete, and edit features and attachments
+* Geometry - Create geometries and perform geometric operations
+* Route & Directions - Calculate routes between locations and around barriers
+* Analysis - Perform spatial analysis via geoprocessing tasks and services
+* Cloud & Portal - Search for webmaps and list portal group users
+* Scenes - Visualize 3D environments and symbols
+* Utility Network - Work with utility networks, performing traces and exploring network elements
+* Augmented Reality - View data overlaid on the real world through your device's camera
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The *ArcGIS Runtime SDK Samples app* has a *Target SDK* version of *12.0*, meani
     > If you've already cloned the repo without the submodule, you can load the submodule using 
     >
     >`git submodule update --init`
-1. **Install** the ArcGIS Runtime SDK for iOS to a central location on your mac as described [here](https://developers.arcgis.com/ios/latest/swift/guide/install.htm#ESRI_SECTION1_D57435A2BEBC4D29AFA3A4CAA722506A)
+1. **Install** the ArcGIS Runtime SDK for iOS to a central location on your Mac as described [here](https://developers.arcgis.com/ios/latest/swift/guide/install.htm#ESRI_SECTION1_D57435A2BEBC4D29AFA3A4CAA722506A)
 1. **Open** the `arcgis-ios-sdk-samples.xcodeproj` **project** file
 1. **Run** the `arcgis-ios-sdk-samples` app target
     > If you get the error message saying _"This Copy Files build phase contains a reference to a missing file 'ArcGISToolkit.framework'"_, you probably didn't clone the repo to include it's submodule. See Step 1 above.
@@ -89,4 +89,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-A copy of the license is available in the repository's [LICENSE](https://raw.githubusercontent.com/Esri/arcgis-runtime-samples-ios/master/LICENSE) file.
+A copy of the license is available in the repository's [LICENSE](https://github.com/Esri/arcgis-runtime-samples-ios/blob/master/LICENSE) file.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The ```master``` branch of this repository contains samples configured for the l
 * Route & Directions - Find a route around barriers and get turn-by-turn directions
 * Analysis - Analyze data and display results
 * Cloud & Portal - Integrate ArcGIS Online services and tools
-* Scenes - Display scenes, 3D symbols, and scene layers
+* Scenes - Display scenes, 3D symbols and scene layers
 * Utility Network - Trace, analyze and display information with utility networks
 * Augmented Reality - Explore, display and utilize AR within a map
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ The ```master``` branch of this repository contains samples configured for the l
 * Edit Data - Adding, deleting and editing features
 * Geometry - Displaying geometries
 * Route & Directions - Find a route around barriers and get turn-by-turn directions
-* Analysis - 
-* Cloud & Portal - 
+* Analysis - Analyze data and display results
+* Cloud & Portal - Integrate ArcGIS Online services and tools
 * Scenes - Display scenes, 3D symbols, and scene layers
-* Utility Network - 
-* Augmented Reality - 
+* Utility Network - Trace, analyze and display information with utility networks
+* Augmented Reality - Explore, display and utilize AR within a map
 
 ## Requirements
 


### PR DESCRIPTION
A few updates to the top level README to reflect changes in 100.8 release: #871.

- [x] Update version number in `Requirements` section
- [x] Update URLs to the latest doc
- [x] Fix not working URL in `Licensing` section
- [x] Update year in `Licensing` section
- [x] Update top URL

Also,  the URL atop the repo should be updated to https://developers.arcgis.com/ios/latest/. See below

![](https://user-images.githubusercontent.com/9660181/80522171-fdf7a900-8940-11ea-86b2-73b516c11261.png)