### PR TITLE
Fix: Convex hull wraparound across meridian

### DIFF
--- a/arcgis-ios-sdk-samples/Geometry/Convex hull/ConvexHullViewController.swift
+++ b/arcgis-ios-sdk-samples/Geometry/Convex hull/ConvexHullViewController.swift
@@ -80,10 +80,8 @@ class ConvexHullViewController: UIViewController {
             graphicsOverlay.graphics.add(convexHullGraphic!)
             creatButtonItem.isEnabled = false
         } else {
-        } else {
-            // Display the error as an alert if there is a problem with AGSGeometryEngine.convexHull operation.
-            let alertController = UIAlertController(title: nil, message: "Geometry Engine Failed!", preferredStyle: .alert)
-            alertController.addAction(UIAlertAction(title: "OK", style: .default))
+            // Present an alert if there is a problem with AGSGeometryEngine operations.
+            self.presentAlert(title: nil, message: "Geometry Engine Failed!")
         }
     }
     

--- a/arcgis-ios-sdk-samples/Geometry/Convex hull/ConvexHullViewController.swift
+++ b/arcgis-ios-sdk-samples/Geometry/Convex hull/ConvexHullViewController.swift
@@ -59,7 +59,8 @@ class ConvexHullViewController: UIViewController {
     
     /// Called in response to the Create convex hull button being tapped.
     @IBAction func createConvexHull() {
-        if let convexHullGeometry = AGSGeometryEngine.convexHull(for: AGSMultipoint(points: inputPoints)) {
+        if let normalizedPoints = AGSGeometryEngine.normalizeCentralMeridian(of: AGSMultipoint(points: inputPoints)),
+            let convexHullGeometry = AGSGeometryEngine.convexHull(for: normalizedPoints) {
             // Change the symbol depending on the returned geometry type of the convex hull.
             let symbol: AGSSymbol
             switch convexHullGeometry.geometryType {

--- a/arcgis-ios-sdk-samples/Geometry/Convex hull/ConvexHullViewController.swift
+++ b/arcgis-ios-sdk-samples/Geometry/Convex hull/ConvexHullViewController.swift
@@ -80,10 +80,10 @@ class ConvexHullViewController: UIViewController {
             graphicsOverlay.graphics.add(convexHullGraphic!)
             creatButtonItem.isEnabled = false
         } else {
+        } else {
             // Display the error as an alert if there is a problem with AGSGeometryEngine.convexHull operation.
             let alertController = UIAlertController(title: nil, message: "Geometry Engine Failed!", preferredStyle: .alert)
             alertController.addAction(UIAlertAction(title: "OK", style: .default))
-            present(alertController, animated: true)
         }
     }
     


### PR DESCRIPTION
**Bug**: Creating a convex hull after wrapping around the meridian has incorrect behavior with points in web mercator. 

**Fix**: Fixed by normalizing the multipoint geometry before computing the convex hull.

**Ref**: /common-samples/issues/1922

|`Before fix`|`After fix`|
|:------:|:------:|
|<img src="https://user-images.githubusercontent.com/9660181/82248304-bf7c5b00-98fc-11ea-89a8-39286815e5c2.gif">|<img src="https://user-images.githubusercontent.com/9660181/82248300-be4b2e00-98fc-11ea-9f77-dfcf37431437.gif">|

- [ ] Should I also update the README? If to update README, should I also fix the image name and typo?

