### PR TITLE
Fix: Nearest vertex wraparound

### DIFF
--- a/arcgis-ios-sdk-samples/Geometry/Nearest vertex/NearestVertexViewController.swift
+++ b/arcgis-ios-sdk-samples/Geometry/Nearest vertex/NearestVertexViewController.swift
@@ -138,9 +138,6 @@ extension NearestVertexViewController: AGSGeoViewTouchDelegate {
                     rotateOffsetWithMap: false,
                     animated: true
                 )
-            } else {
-                // Display the error as an alert if there is a problem with `AGSGeometryEngine` operations.
-                presentAlert(title: "Error", message: "Geometry Engine Failed!")
             }
         } else {
             // Dismiss the callout and reset geometry for all simple marker graphics.


### PR DESCRIPTION
**Description**: Similar to the `Convex hull` sample, this sample also has trouble providing correct coordinates after wrapping around meridian. This bugfix normalizes the point before calling `GeometryEngine`. Also clean up formatting a bit. Refer to #882 .

**Bug**: Calculating a nearest vertex after wrapping around the meridian has incorrect behavior with points in web mercator.

**Fix**: Fixed by normalizing the map point before computing.

**Ref**: /common-samples/issues/2003

|`Before fix`|`After fix`|
|:------:|:------:|
|<img src="https://user-images.githubusercontent.com/9660181/83791298-6af01400-a64e-11ea-86fa-c165f71980f0.gif">|<img src="https://user-images.githubusercontent.com/9660181/83791252-5744ad80-a64e-11ea-9e95-bb47243daaed.gif">|