### PR TITLE
do not show touches for indirect pointers

### DIFF
--- a/arcgis-ios-sdk-samples/Info.plist
+++ b/arcgis-ios-sdk-samples/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/arcgis-ios-sdk-samples/Shared resources/Libraries/DemoTouchManager/DemoTouchManager.swift
+++ b/arcgis-ios-sdk-samples/Shared resources/Libraries/DemoTouchManager/DemoTouchManager.swift
@@ -224,6 +224,15 @@ class DemoTouchManager {
     
     func handleEvent(_ event: UIEvent) {
         guard let touches = event.allTouches else { return }
+        
+        #if compiler(>=5.2)
+        // Check if touch is from indirect pointers like a mouse
+        // or a keyboard. If so, do not show touches
+        if #available(iOS 13.4, *) {
+            if let touch = touches.first, touch.type == .indirectPointer { return }
+        }
+        #endif
+        
         // Ensure our DemoTouch view is always at the front of its window.
         if let window = view.window {
             window.bringSubviewToFront(view)


### PR DESCRIPTION
Show Touches is broken in Samples app with magic mouse or trackpad. Tapping/Clicking on multiple points doesn't remove the previous touches. The pointer is already visible, so we don't need to show touches in that scenario.