### PR TITLE
Relax trailing_closure rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -76,6 +76,8 @@ opt_in_rules: # some rules are only opt-in
 identifier_name:
   min_length:
     warning: 0 # do not flag short identifiers
+trailing_closure:
+  only_single_muted_parameter: true
 
 excluded:
 - Pods


### PR DESCRIPTION
This narrows the `trailing_closure` rule to apply only to single muted parameters (like `map(_:)`). This allows for using non-trailing closures in some cases where Xcode autocompletes them that way, like `first(where: { ... })` instead of `first { ... }`.