### PR TITLE
[Dark Mode] Update: Content Display Logic

### DIFF
--- a/arcgis-ios-sdk-samples.xcodeproj/project.pbxproj
+++ b/arcgis-ios-sdk-samples.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		00686FD02480889900EDA705 /* NavigateARNavigatorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00686FCF2480889900EDA705 /* NavigateARNavigatorViewController.swift */; };
 		00686FD52481CF4D00EDA705 /* NavigateARRoutePlannerViewController.swift in CopyFiles */ = {isa = PBXBuildFile; fileRef = 00C024E42475E4AB00E1DA8D /* NavigateARRoutePlannerViewController.swift */; };
 		00686FD62481CF4D00EDA705 /* NavigateARNavigatorViewController.swift in CopyFiles */ = {isa = PBXBuildFile; fileRef = 00686FCF2480889900EDA705 /* NavigateARNavigatorViewController.swift */; };
+		007FC9482534E8AE00D8D9A1 /* darkmode.css in Resources */ = {isa = PBXBuildFile; fileRef = 007FC9452534E8AE00D8D9A1 /* darkmode.css */; };
+		007FC9492534E8AE00D8D9A1 /* solarized-dark.css in Resources */ = {isa = PBXBuildFile; fileRef = 007FC9472534E8AE00D8D9A1 /* solarized-dark.css */; };
 		008D175224EEEEBD0001BB8F /* loudoun_anno.geodatabase in Resources */ = {isa = PBXBuildFile; fileRef = 008D175124EEEEBD0001BB8F /* loudoun_anno.geodatabase */; settings = {ASSET_TAGS = (loudoun_anno, ); }; };
 		008D175724EEF3FE0001BB8F /* EditWithBranchVersioningViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008D175624EEF3FE0001BB8F /* EditWithBranchVersioningViewController.swift */; };
 		008D175924EEF4390001BB8F /* EditWithBranchVersioning.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 008D175824EEF4390001BB8F /* EditWithBranchVersioning.storyboard */; };
@@ -1185,6 +1187,8 @@
 		003D25612513D833007527C2 /* ApplyRasterRenderingRule.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ApplyRasterRenderingRule.storyboard; sourceTree = "<group>"; };
 		003D25632513D844007527C2 /* ApplyRasterRenderingRuleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplyRasterRenderingRuleViewController.swift; sourceTree = "<group>"; };
 		00686FCF2480889900EDA705 /* NavigateARNavigatorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigateARNavigatorViewController.swift; sourceTree = "<group>"; };
+		007FC9452534E8AE00D8D9A1 /* darkmode.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = darkmode.css; sourceTree = "<group>"; };
+		007FC9472534E8AE00D8D9A1 /* solarized-dark.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = "solarized-dark.css"; sourceTree = "<group>"; };
 		008D175124EEEEBD0001BB8F /* loudoun_anno.geodatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = loudoun_anno.geodatabase; sourceTree = "<group>"; };
 		008D175624EEF3FE0001BB8F /* EditWithBranchVersioningViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditWithBranchVersioningViewController.swift; sourceTree = "<group>"; };
 		008D175824EEF4390001BB8F /* EditWithBranchVersioning.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = EditWithBranchVersioning.storyboard; sourceTree = "<group>"; };
@@ -2148,6 +2152,8 @@
 		3E03F0971B056F9C0078EB36 /* Js */ = {
 			isa = PBXGroup;
 			children = (
+				007FC9452534E8AE00D8D9A1 /* darkmode.css */,
+				007FC9472534E8AE00D8D9A1 /* solarized-dark.css */,
 				3E03F0981B056F9C0078EB36 /* highlight.pack.js */,
 				97DD84661B2B869300184B41 /* xcode.css */,
 				3E03F09A1B05714A0078EB36 /* default.css */,
@@ -4684,6 +4690,7 @@
 				3ED0286C1B8E3A8500ACA70D /* DisplayLocation.storyboard in Resources */,
 				D97B7E671FD9BFE700E1239D /* Subdivisions.dbf in Resources */,
 				3E03F09B1B05714A0078EB36 /* default.css in Resources */,
+				007FC9482534E8AE00D8D9A1 /* darkmode.css in Resources */,
 				3E5E094D1EF850BA00FF3454 /* ManageSublayers.storyboard in Resources */,
 				3ED028F71B8E3AA500ACA70D /* ManualCache.storyboard in Resources */,
 				21EBBBFD1FE07B0500567F14 /* StatisticalQueryGroupAndSort.storyboard in Resources */,
@@ -4705,6 +4712,7 @@
 				10859BAB1FE0AAE400F6E552 /* FeatureLayerExtrusion.storyboard in Resources */,
 				D98CC09222E25EC400618682 /* TraceUtilityNetwork.storyboard in Resources */,
 				3EABC7C41DB191BC00C161C6 /* Shasta_Elevation.tif.ovr in Resources */,
+				007FC9492534E8AE00D8D9A1 /* solarized-dark.css in Resources */,
 				C734B1F521C2DDE500E1BE76 /* ClipGeometry.storyboard in Resources */,
 				3E4BF47C1C5BDDCA00D85919 /* san-diego-locator.loc in Resources */,
 				4CB506D7224C3975006A3471 /* sandiego-north-balboa-pointcloud.slpk in Resources */,

--- a/arcgis-ios-sdk-samples/AppDelegate.swift
+++ b/arcgis-ios-sdk-samples/AppDelegate.swift
@@ -177,4 +177,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
 extension UIColor {
     // Also used as global tint/accent color.
     class var accentColor: UIColor { return UIColor(named: "AccentColor")! }
+    // The translucent background color for status labels.
+    class var statusLabelBackgroundColor: UIColor { return UIColor(named: "statusLabelBackgroundColor")! }
 }

--- a/arcgis-ios-sdk-samples/Assets.xcassets/Colors/AccentColor.colorset/Contents.json
+++ b/arcgis-ios-sdk-samples/Assets.xcassets/Colors/AccentColor.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.812",
-          "green" : "0.310",
-          "red" : "0.514"
+          "blue" : "1.000",
+          "green" : "0.222",
+          "red" : "0.666"
         }
       },
       "idiom" : "universal"

--- a/arcgis-ios-sdk-samples/Assets.xcassets/Colors/statusLabelBackgroudColor.colorset/Contents.json
+++ b/arcgis-ios-sdk-samples/Assets.xcassets/Colors/statusLabelBackgroudColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.600",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.600",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/arcgis-ios-sdk-samples/Cloud and portal/Search for webmap by keyword/SearchForWebmapByKeywordViewController.swift
+++ b/arcgis-ios-sdk-samples/Cloud and portal/Search for webmap by keyword/SearchForWebmapByKeywordViewController.swift
@@ -68,7 +68,7 @@ class SearchForWebmapByKeywordViewController: UICollectionViewController {
         
         if #available(iOS 13, *) {
             // Change the backgroundColor to differentiate from nav bar color.
-            searchBar.searchTextField.backgroundColor = .systemBackground
+            searchBar.searchTextField.backgroundColor = .tertiarySystemBackground
             // Set the color of the insertion cursor as well as the text. The text is default to black color whereas the cursor is white.
             searchBar.searchTextField.tintColor = .label
         } else {

--- a/arcgis-ios-sdk-samples/Cloud and portal/Search for webmap by keyword/SearchForWebmapByKeywordViewController.swift
+++ b/arcgis-ios-sdk-samples/Cloud and portal/Search for webmap by keyword/SearchForWebmapByKeywordViewController.swift
@@ -68,18 +68,16 @@ class SearchForWebmapByKeywordViewController: UICollectionViewController {
         
         if #available(iOS 13, *) {
             // Change the backgroundColor to differentiate from nav bar color.
-            searchBar.searchTextField.backgroundColor = .white
-            // Set the color of "Cancel" text, to mimic the settings on iOS 12. On iOS 13 it is default to white.
-            searchBar.tintColor = .white
+            searchBar.searchTextField.backgroundColor = .systemBackground
             // Set the color of the insertion cursor as well as the text. The text is default to black color whereas the cursor is white.
-            searchBar.searchTextField.tintColor = .darkText
+            searchBar.searchTextField.tintColor = .label
         } else {
             // This code is required to make the search bar look decent on iOS 12
             // This does not work on iOS 13, where the search bar looks different.
             // Different meaning - not as good as iOS 12 looks like with this fix,
             // but at least acceptable and a bit better than what it would look like
             // on 12 without this fix.
-            // set the color of "Cancel" text
+            // Set the color of "Cancel" text, to mimic the settings on iOS 12. On iOS 13 it is default to white.
             searchBar.tintColor = .white
             
             // find the text field to customize its appearance

--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/Color Picker/ColorPicker.storyboard
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/Color Picker/ColorPicker.storyboard
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="WKq-Wo-x9z">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="WKq-Wo-x9z">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -16,19 +15,19 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="0CM-vF-q8p">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <sections>
                             <tableViewSection id="oyW-a0-Njj">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="x0t-Ui-vFs">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="28" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="x0t-Ui-vFs" id="jOo-N7-oCq">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Hue" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gDm-BC-Hek">
-                                                    <rect key="frame" x="16" y="12" width="31.5" height="9"/>
+                                                    <rect key="frame" x="16" y="12" width="31" height="9"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -60,10 +59,10 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="heC-tV-mXW">
-                                        <rect key="frame" x="0.0" y="44" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="72" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="heC-tV-mXW" id="SnP-CO-BV8">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Saturation" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QdS-Kb-OB8">
@@ -99,10 +98,10 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="MpW-jO-m6P">
-                                        <rect key="frame" x="0.0" y="88" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="116" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="MpW-jO-m6P" id="NPL-Pf-2Uf">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Brightness" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aJb-2D-rB7">
@@ -138,10 +137,10 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="X8W-cO-tPJ">
-                                        <rect key="frame" x="0.0" y="132" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="160" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="X8W-cO-tPJ" id="bub-Y5-2DS">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Alpha" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WQO-tg-7s4">
@@ -200,4 +199,9 @@
             <point key="canvasLocation" x="-15.199999999999999" y="107.49625187406298"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ContentCollectionViewController.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ContentCollectionViewController.swift
@@ -46,7 +46,7 @@ class ContentCollectionViewController: UICollectionViewController, UICollectionV
         
         if #available(iOS 13, *) {
             // Change the backgroundColor to differentiate from nav bar color.
-            searchBar.searchTextField.backgroundColor = .systemBackground
+            searchBar.searchTextField.backgroundColor = .tertiarySystemBackground
             // Set the color of the insertion cursor as well as the text. The text is default to black color whereas the cursor is white.
             searchBar.searchTextField.tintColor = .label
         } else {

--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ContentCollectionViewController.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ContentCollectionViewController.swift
@@ -43,8 +43,6 @@ class ContentCollectionViewController: UICollectionViewController, UICollectionV
         
         let searchBar = searchController.searchBar
         searchBar.autocapitalizationType = .none
-        // Set the color of "Cancel" text, to mimic the settings on iOS 12. On iOS 13 it is default to white.
-        searchBar.tintColor = .white
         
         if #available(iOS 13, *) {
             // Change the backgroundColor to differentiate from nav bar color.
@@ -57,6 +55,8 @@ class ContentCollectionViewController: UICollectionViewController, UICollectionV
             // Different meaning - not as good as iOS 12 looks like with this fix,
             // but at least acceptable and a bit better than what it would look like
             // on 12 without this fix.
+            // Set the color of "Cancel" text, to mimic the settings on iOS 12. On iOS 13 it is default to white.
+            searchBar.tintColor = .white
             
             // find the text field to customize its appearance
             if let textfield = searchBar.value(forKey: "searchField") as? UITextField {

--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ContentCollectionViewController.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ContentCollectionViewController.swift
@@ -43,23 +43,20 @@ class ContentCollectionViewController: UICollectionViewController, UICollectionV
         
         let searchBar = searchController.searchBar
         searchBar.autocapitalizationType = .none
+        // Set the color of "Cancel" text, to mimic the settings on iOS 12. On iOS 13 it is default to white.
+        searchBar.tintColor = .white
         
         if #available(iOS 13, *) {
             // Change the backgroundColor to differentiate from nav bar color.
-            searchBar.searchTextField.backgroundColor = .white
-            // Set the color of "Cancel" text, to mimic the settings on iOS 12. On iOS 13 it is default to white.
-            searchBar.tintColor = .white
+            searchBar.searchTextField.backgroundColor = .systemBackground
             // Set the color of the insertion cursor as well as the text. The text is default to black color whereas the cursor is white.
-            searchBar.searchTextField.tintColor = .darkText
+            searchBar.searchTextField.tintColor = .label
         } else {
             // This code is required to make the search bar look decent on iOS 12
             // This does not work on iOS 13, where the search bar looks different.
             // Different meaning - not as good as iOS 12 looks like with this fix,
             // but at least acceptable and a bit better than what it would look like
             // on 12 without this fix.
-            
-            // set the color of "Cancel" text
-            searchBar.tintColor = .white
             
             // find the text field to customize its appearance
             if let textfield = searchBar.value(forKey: "searchField") as? UITextField {

--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ListViewController.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ListViewController.swift
@@ -39,7 +39,6 @@ class ListViewController: UITableViewController {
         let cell = tableView.dequeueReusableCell(withIdentifier: "ListCell", for: indexPath)
         
         cell.textLabel?.text = list[indexPath.row]
-        cell.backgroundColor = .clear
         return cell
     }
     

--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/SampleInfoViewController.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/SampleInfoViewController.swift
@@ -17,21 +17,16 @@ import WebKit
 
 class SampleInfoViewController: UIViewController {
     /// The web view that displays the readme.
-    @IBOutlet private weak var webView: WKWebView!
+    @IBOutlet var webView: WKWebView! {
+        didSet {
+            webView.navigationDelegate = self
+        }
+    }
     
     var readmeURL: URL?
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        // We must construct the web view in code as long as we support iOS 10.
-        // Prior to iOS 11, there was a bug in WKWebView.init(coder:) that
-        // caused a crash.
-        let webView = WKWebView(frame: view.bounds)
-        webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        webView.navigationDelegate = self
-        view.addSubview(webView)
-        self.webView = webView
         
         if let readmeURL = readmeURL,
             let html = markdownTextFromFile(at: readmeURL) {
@@ -53,7 +48,8 @@ class SampleInfoViewController: UIViewController {
     }
     
     func displayHTML(_ readmeContent: String) {
-        let cssPath = Bundle.main.path(forResource: "style", ofType: "css") ?? ""
+        let cssPath = Bundle.main.path(forResource: "style", ofType: "css")!
+        let darkmodePath = Bundle.main.path(forResource: "darkmode", ofType: "css")!
         let string = """
             <!doctype html>
             <html>
@@ -61,6 +57,7 @@ class SampleInfoViewController: UIViewController {
                 <link rel="stylesheet" href="\(cssPath)">
                 <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/foundation/5.5.2/css/foundation.min.css">
                 <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
+                <link rel="stylesheet" href="\(darkmodePath)">
                 <meta name="viewport" content="initial-scale=1, width=device-width, height=device-height">
             </head>
             <body>

--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/SourceCodeViewController.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/SourceCodeViewController.swift
@@ -102,7 +102,12 @@ class SourceCodeViewController: UIViewController, UIAdaptivePresentationControll
         if filenames.count > 1 {
             titleString = String(format: "%@ %@", (arrowPointingDown ? "▶︎" : " \u{25B4}"), filename)
         } else {
-            toolbarTitleButton.setTitleTextAttributes([.foregroundColor: UIColor.black], for: .normal)
+            if #available(iOS 13.0, *) {
+                toolbarTitleButton.setTitleTextAttributes([.foregroundColor: UIColor.label], for: .normal)
+            } else {
+                // Fallback on earlier versions
+                toolbarTitleButton.setTitleTextAttributes([.foregroundColor: UIColor.black], for: .normal)
+            }
         }
         toolbarTitleButton.title = titleString
     }

--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/SourceCodeViewController.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/SourceCodeViewController.swift
@@ -17,10 +17,21 @@ import WebKit
 
 class SourceCodeViewController: UIViewController, UIAdaptivePresentationControllerDelegate {
     /// The view to which the web view is added.
-    @IBOutlet private weak var contentView: UIView!
+    @IBOutlet var contentView: UIView!
     /// The web view that displays the source code.
-    @IBOutlet private weak var webView: WKWebView!
-    @IBOutlet private weak var toolbarTitleButton: UIBarButtonItem!
+    @IBOutlet var webView: WKWebView!
+    @IBOutlet var toolbarTitleButton: UIBarButtonItem! {
+        didSet {
+            if filenames.count <= 1 {
+                if #available(iOS 13.0, *) {
+                    toolbarTitleButton.tintColor = UIColor.label
+                } else {
+                    toolbarTitleButton.tintColor = UIColor.black
+                }
+            }
+            toolbarTitleButton.possibleTitles = Set(filenames)
+        }
+    }
     
     private var listViewController: ListViewController!
     private var selectedFilenameIndex = 0
@@ -29,15 +40,6 @@ class SourceCodeViewController: UIViewController, UIAdaptivePresentationControll
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        // We must construct the web view in code as long as we support iOS 10.
-        // Prior to iOS 11, there was a bug in WKWebView.init(coder:) that
-        // caused a crash.
-        let webView = WKWebView(frame: contentView.bounds)
-        webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        webView.scrollView.alwaysBounceHorizontal = true
-        contentView.addSubview(webView)
-        self.webView = webView
         
         if let filename = currentFilename {
             loadHTMLPage(filename: filename)
@@ -80,11 +82,10 @@ class SourceCodeViewController: UIViewController, UIAdaptivePresentationControll
             cssPath = Bundle.main.path(forResource: "xcode", ofType: "css")!
         }
         let jsPath = Bundle.main.path(forResource: "highlight.pack", ofType: "js")!
-        let scale = UIDevice.current.userInterfaceIdiom == .phone ? "0.5" : "1.0"
         let stringForHTML = """
             <html>
             <head>
-                <meta name='viewport' content='width=device-width, initial-scale='\(scale)'/>
+                <meta name="viewport" content="initial-scale=1, width=device-width, height=device-height">
                 <link rel="stylesheet" href="\(cssPath)">
                 <script src="\(jsPath)"></script>
                 <script>hljs.initHighlightingOnLoad();</script>
@@ -98,16 +99,11 @@ class SourceCodeViewController: UIViewController, UIAdaptivePresentationControll
     }
     
     func setupToolbarTitle(_ filename: String, arrowPointingDown: Bool) {
-        var titleString = filename
+        let titleString: String
         if filenames.count > 1 {
             titleString = String(format: "%@ %@", (arrowPointingDown ? "▶︎" : " \u{25B4}"), filename)
         } else {
-            if #available(iOS 13.0, *) {
-                toolbarTitleButton.setTitleTextAttributes([.foregroundColor: UIColor.label], for: .normal)
-            } else {
-                // Fallback on earlier versions
-                toolbarTitleButton.setTitleTextAttributes([.foregroundColor: UIColor.black], for: .normal)
-            }
+            titleString = filename
         }
         toolbarTitleButton.title = titleString
     }
@@ -138,6 +134,6 @@ class SourceCodeViewController: UIViewController, UIAdaptivePresentationControll
     // MARK: - UIAdaptivePresentationControllerDelegate
     
     func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
-        return UIModalPresentationStyle.none
+        return .none
     }
 }

--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/SourceCodeViewController.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/SourceCodeViewController.swift
@@ -25,6 +25,7 @@ class SourceCodeViewController: UIViewController, UIAdaptivePresentationControll
     private var listViewController: ListViewController!
     private var selectedFilenameIndex = 0
     var filenames = [String]()
+    private var currentFilename: String!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -38,16 +39,25 @@ class SourceCodeViewController: UIViewController, UIAdaptivePresentationControll
         contentView.addSubview(webView)
         self.webView = webView
         
-        if let filename = filenames.first {
+        if let filename = currentFilename {
+            loadHTMLPage(filename: filename)
+        } else if let filename = filenames.first {
+            currentFilename = filename
             loadHTMLPage(filename: filename)
         }
     }
     
+    // Change the highlight.js rendered HTML when switch between modes.
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        loadHTMLPage(filename: currentFilename)
+    }
+    
     func loadHTMLPage(filename: String) {
-        if let content = self.contentOfFile(filename) {
-            self.setupToolbarTitle(filename, arrowPointingDown: true)
-            let htmlString = self.htmlStringForContent(content)
-            self.webView.loadHTMLString(htmlString, baseURL: URL(fileURLWithPath: Bundle.main.bundlePath))
+        if let content = contentOfFile(filename) {
+            setupToolbarTitle(filename, arrowPointingDown: true)
+            let htmlString = htmlStringForContent(content)
+            webView.loadHTMLString(htmlString, baseURL: URL(fileURLWithPath: Bundle.main.bundlePath))
         }
     }
     
@@ -63,8 +73,13 @@ class SourceCodeViewController: UIViewController, UIAdaptivePresentationControll
     }
     
     func htmlStringForContent(_ content: String) -> String {
-        let cssPath = Bundle.main.path(forResource: "xcode", ofType: "css") ?? ""
-        let jsPath = Bundle.main.path(forResource: "highlight.pack", ofType: "js") ?? ""
+        let cssPath: String
+        if traitCollection.userInterfaceStyle == .dark {
+            cssPath = Bundle.main.path(forResource: "solarized-dark", ofType: "css")!
+        } else {
+            cssPath = Bundle.main.path(forResource: "xcode", ofType: "css")!
+        }
+        let jsPath = Bundle.main.path(forResource: "highlight.pack", ofType: "js")!
         let scale = UIDevice.current.userInterfaceIdiom == .phone ? "0.5" : "1.0"
         let stringForHTML = """
             <html>
@@ -87,9 +102,9 @@ class SourceCodeViewController: UIViewController, UIAdaptivePresentationControll
         if filenames.count > 1 {
             titleString = String(format: "%@ %@", (arrowPointingDown ? "▶︎" : " \u{25B4}"), filename)
         } else {
-            self.toolbarTitleButton.setTitleTextAttributes([.foregroundColor: UIColor.black], for: .normal)
+            toolbarTitleButton.setTitleTextAttributes([.foregroundColor: UIColor.black], for: .normal)
         }
-        self.toolbarTitleButton.title = titleString
+        toolbarTitleButton.title = titleString
     }
     
     // MARK: - Navigation

--- a/arcgis-ios-sdk-samples/Content Display Logic/Js/darkmode.css
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Js/darkmode.css
@@ -1,0 +1,15 @@
+@media (prefers-color-scheme: dark) {
+    h1, h2, h3, h4, h5, h6 {
+        color: #f2f2f7;
+    }
+    body {
+        background-color: #1c1c1e;
+        color: #f2f2f7;
+    }
+    a:link {
+        color: #0096e2;
+    }
+    a:visited {
+        color: #9d57df;
+    }
+}

--- a/arcgis-ios-sdk-samples/Content Display Logic/Js/darkmode.css
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Js/darkmode.css
@@ -3,7 +3,7 @@
         color: #f2f2f7;
     }
     body {
-        background-color: #000000;
+        background-color: #000;
         color: #f2f2f7;
     }
     a:link {

--- a/arcgis-ios-sdk-samples/Content Display Logic/Js/darkmode.css
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Js/darkmode.css
@@ -3,7 +3,7 @@
         color: #f2f2f7;
     }
     body {
-        background-color: #000;
+        background-color: #2C2C2E;
         color: #f2f2f7;
     }
     a:link {

--- a/arcgis-ios-sdk-samples/Content Display Logic/Js/darkmode.css
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Js/darkmode.css
@@ -3,7 +3,7 @@
         color: #f2f2f7;
     }
     body {
-        background-color: #1c1c1e;
+        background-color: #000000;
         color: #f2f2f7;
     }
     a:link {

--- a/arcgis-ios-sdk-samples/Content Display Logic/Js/solarized-dark.css
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Js/solarized-dark.css
@@ -3,14 +3,14 @@ Orginal Style from ethanschoonover.com/solarized (c) Jeremy Hull <sourdrums@gmai
 */
 
 body {
-  background-color: #002b36;
+  background-color: #000;
 }
 
 .hljs {
   display: block;
   overflow-x: auto;
   padding: 0.5em;
-  background: #002b36;
+  background: #000;
   color: #839496;
 }
 

--- a/arcgis-ios-sdk-samples/Content Display Logic/Js/solarized-dark.css
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Js/solarized-dark.css
@@ -3,14 +3,14 @@ Orginal Style from ethanschoonover.com/solarized (c) Jeremy Hull <sourdrums@gmai
 */
 
 body {
-  background-color: #000;
+  background-color: #2C2C2E;
 }
 
 .hljs {
   display: block;
   overflow-x: auto;
   padding: 0.5em;
-  background: #000;
+  background: #2C2C2E;
   color: #839496;
 }
 

--- a/arcgis-ios-sdk-samples/Content Display Logic/Js/solarized-dark.css
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Js/solarized-dark.css
@@ -1,0 +1,86 @@
+/*
+Orginal Style from ethanschoonover.com/solarized (c) Jeremy Hull <sourdrums@gmail.com>
+*/
+
+body {
+  background-color: #002b36;
+}
+
+.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  background: #002b36;
+  color: #839496;
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: #586e75;
+}
+
+/* Solarized Green */
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-addition {
+  color: #859900;
+}
+
+/* Solarized Cyan */
+.hljs-number,
+.hljs-string,
+.hljs-meta .hljs-meta-string,
+.hljs-literal,
+.hljs-doctag,
+.hljs-regexp {
+  color: #2aa198;
+}
+
+/* Solarized Blue */
+.hljs-title,
+.hljs-section,
+.hljs-name,
+.hljs-selector-id,
+.hljs-selector-class {
+  color: #268bd2;
+}
+
+/* Solarized Yellow */
+.hljs-attribute,
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-class .hljs-title,
+.hljs-type {
+  color: #b58900;
+}
+
+/* Solarized Orange */
+.hljs-symbol,
+.hljs-bullet,
+.hljs-subst,
+.hljs-meta,
+.hljs-meta .hljs-keyword,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-link {
+  color: #cb4b16;
+}
+
+/* Solarized Red */
+.hljs-built_in,
+.hljs-deletion {
+  color: #dc322f;
+}
+
+.hljs-formula {
+  background: #073642;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}

--- a/arcgis-ios-sdk-samples/Content Display Logic/Storyboard/LaunchScreen.storyboard
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Storyboard/LaunchScreen.storyboard
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qW7-PQ-38T">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qW7-PQ-38T">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -16,8 +17,8 @@
                     <view key="view" contentMode="scaleToFill" id="0uM-W7-T9F">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="6P1-Di-HoJ"/>
+                        <color key="backgroundColor" systemColor="tertiarySystemBackgroundColor"/>
                     </view>
                     <navigationItem key="navigationItem" id="rKA-Rs-lqa"/>
                 </viewController>
@@ -49,7 +50,7 @@
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="1eS-UY-a1r">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <color key="backgroundColor" systemColor="tertiarySystemBackgroundColor"/>
                         <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="aZE-5w-4GU">
                             <size key="itemSize" width="128" height="128"/>
                             <size key="headerReferenceSize" width="0.0" height="0.0"/>
@@ -105,5 +106,8 @@
         <namedColor name="AccentColor">
             <color red="0.51399999856948853" green="0.18400000035762787" blue="0.7369999885559082" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <systemColor name="tertiarySystemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/arcgis-ios-sdk-samples/Content Display Logic/Storyboard/Main.storyboard
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Storyboard/Main.storyboard
@@ -505,6 +505,7 @@
                             <outlet property="delegate" destination="ZtT-NE-hWv" id="96r-hq-Oe5"/>
                         </connections>
                     </tableView>
+                    <navigationItem key="navigationItem" id="ouG-F7-0hZ"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Yhe-8p-BRS" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/arcgis-ios-sdk-samples/Content Display Logic/Storyboard/Main.storyboard
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Storyboard/Main.storyboard
@@ -50,17 +50,14 @@
                                             <constraint firstAttribute="height" constant="30" id="a6E-Hi-XhU"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
-                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Built with ArcGIS Runtime SDK for iOS 100.0.0 (1218)" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r26-1c-eoY">
                                         <rect key="frame" x="8" y="136" width="294" height="56"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstItem="sgZ-Nk-kH7" firstAttribute="top" secondItem="rjI-Fj-tXd" secondAttribute="bottom" constant="8" id="6bI-up-J1K"/>
                                     <constraint firstAttribute="trailing" secondItem="r26-1c-eoY" secondAttribute="trailing" constant="8" id="9Ye-0W-1af"/>
@@ -83,7 +80,7 @@
                             </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="a6h-ca-33f"/>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="Op6-nR-s0N" firstAttribute="centerX" secondItem="a6h-ca-33f" secondAttribute="centerX" id="7Te-o6-LfY"/>
                             <constraint firstItem="54t-nf-ZK2" firstAttribute="centerX" secondItem="a6h-ca-33f" secondAttribute="centerX" id="LwH-pF-D4X"/>
@@ -107,7 +104,7 @@
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" contentInsetAdjustmentBehavior="always" dataMode="prototypes" id="yuT-nZ-Wrk">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" sectionInsetReference="safeArea" id="VF4-1P-JDR">
                             <size key="itemSize" width="140" height="140"/>
                             <size key="headerReferenceSize" width="0.0" height="0.0"/>
@@ -139,7 +136,7 @@
                                         </view>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Nna-yf-p13">
                                             <rect key="frame" x="55" y="55" width="30" height="30"/>
-                                            <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="30" id="IAC-Fh-2xM"/>
                                                 <constraint firstAttribute="width" constant="30" id="OFv-wc-4LN"/>
@@ -148,12 +145,11 @@
                                         <label opaque="NO" userInteractionEnabled="NO" tag="11" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="DISPLAY INFORMATION" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qg1-az-h5v">
                                             <rect key="frame" x="2" y="100" width="136" height="33.5"/>
                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
-                                            <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
                                 </view>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstItem="CNK-Sn-V8R" firstAttribute="centerX" secondItem="4sS-h8-bm3" secondAttribute="centerX" id="5ne-2r-1Bg"/>
                                     <constraint firstItem="Nna-yf-p13" firstAttribute="centerY" secondItem="4sS-h8-bm3" secondAttribute="centerY" id="9YT-hF-WdD"/>
@@ -206,7 +202,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="22" sectionFooterHeight="22" id="5VG-Pu-2XV">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="detailDisclosureButton" indentationWidth="10" reuseIdentifier="ContentTableCell" id="UHI-3v-SDe" customClass="ContentTableCell" customModule="ArcGIS_Runtime_SDK_Samples" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="28" width="414" height="81"/>
@@ -240,7 +236,6 @@
                                         <constraint firstItem="pVi-Nv-PRP" firstAttribute="leading" secondItem="hjB-p9-kF0" secondAttribute="leadingMargin" id="loI-Zf-Lb3"/>
                                     </constraints>
                                 </tableViewCellContentView>
-                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <connections>
                                     <outlet property="detailLabel" destination="WF4-gk-Tcu" id="vk5-go-uAq"/>
                                     <outlet property="stackView" destination="pVi-Nv-PRP" id="Ab9-oe-EmG"/>
@@ -267,18 +262,18 @@
             <objects>
                 <viewController title="Detail" id="xTO-iT-Uqg" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="OWg-y6-Kjp">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select a sample from the list" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="99s-uK-gYc">
-                                <rect key="frame" x="100" y="410" width="215" height="21"/>
+                                <rect key="frame" x="100" y="437" width="215" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="textColor" systemColor="systemGrayColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Mtd-3h-Dnj"/>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="Mtd-3h-Dnj" firstAttribute="centerX" secondItem="99s-uK-gYc" secondAttribute="centerX" constant="-0.5" id="XZY-cT-gcg"/>
                             <constraint firstAttribute="centerY" secondItem="99s-uK-gYc" secondAttribute="centerY" constant="0.5" id="Ytu-54-YW5"/>
@@ -313,7 +308,7 @@
                             </containerView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Asf-ux-BYr"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="MfE-3m-v2G" firstAttribute="top" secondItem="Asf-ux-BYr" secondAttribute="top" id="CwL-cC-IdS"/>
                             <constraint firstItem="z5R-Ku-rtU" firstAttribute="trailing" secondItem="rXs-h5-bEr" secondAttribute="trailing" id="Io8-c8-jLg"/>
@@ -349,7 +344,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="rKQ-JU-Gkt" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2022" y="-630"/>
+            <point key="canvasLocation" x="2230" y="-631"/>
         </scene>
         <!--Sample Info View Controller-->
         <scene sceneID="Afj-lC-jQ2">
@@ -383,7 +378,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="BNK-Yk-cxh" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2022" y="238"/>
+            <point key="canvasLocation" x="3145" y="-970"/>
         </scene>
         <!--Source Code View Controller-->
         <scene sceneID="Ib1-Dw-wps">
@@ -395,14 +390,9 @@
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rA3-JQ-Mdx" userLabel="Content View">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="764"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <toolbar opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cZS-cc-Di0">
                                 <rect key="frame" x="0.0" y="764" width="414" height="44"/>
-                                <color key="backgroundColor" red="0.97647720575332642" green="0.9764588475227356" blue="0.97647124528884888" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="44" id="Kff-Ig-9pK"/>
-                                </constraints>
                                 <items>
                                     <barButtonItem style="plain" systemItem="flexibleSpace" id="RgF-M3-ILn"/>
                                     <barButtonItem id="zbn-kS-wmE">
@@ -417,7 +407,7 @@
                             </toolbar>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="63H-yR-XyK"/>
-                        <color key="backgroundColor" red="0.97647720579999997" green="0.9764588475" blue="0.97647124529999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="rA3-JQ-Mdx" secondAttribute="trailing" id="Gxz-aI-6b0"/>
                             <constraint firstItem="cZS-cc-Di0" firstAttribute="leading" secondItem="63H-yR-XyK" secondAttribute="leading" id="HbP-pv-Z3e"/>
@@ -435,7 +425,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="eWR-U8-1d5" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1325" y="97"/>
+            <point key="canvasLocation" x="3145" y="-287"/>
         </scene>
         <!--Split View Controller-->
         <scene sceneID="jfl-Ru-DY2">
@@ -456,7 +446,7 @@
             <objects>
                 <navigationController storyboardIdentifier="DetailNavigationController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="6mK-5c-4sN" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" id="V9q-Qo-B83">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="56"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </navigationBar>
@@ -475,7 +465,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="iNp-vT-fBs">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="754"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="ListCell" textLabel="hPX-p8-mBC" style="IBUITableViewCellStyleDefault" id="ZUl-1v-KYM">
                                 <rect key="frame" x="0.0" y="28" width="414" height="43.5"/>
@@ -488,13 +478,11 @@
                                             <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
-                                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 </tableViewCellContentView>
-                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             </tableViewCell>
                         </prototypes>
                         <connections>
@@ -505,11 +493,11 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Yhe-8p-BRS" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1326" y="758"/>
+            <point key="canvasLocation" x="3993" y="-287"/>
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="XFi-4R-2mc"/>
+        <segue reference="Cnq-oa-z7G"/>
     </inferredMetricsTieBreakers>
     <color key="tintColor" name="AccentColor"/>
     <resources>
@@ -520,6 +508,9 @@
         </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGrayColor">
+            <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/arcgis-ios-sdk-samples/Content Display Logic/Storyboard/Main.storyboard
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Storyboard/Main.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Dro-WJ-0ka">
-    <device id="retina5_9" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Dro-WJ-0ka">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -13,7 +14,7 @@
             <objects>
                 <navigationController title="Samples" id="yRd-en-sGR" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" largeTitles="YES" id="GpO-dt-EG2">
-                        <rect key="frame" x="0.0" y="44" width="375" height="96"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="96"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </navigationBar>
@@ -30,11 +31,11 @@
             <objects>
                 <viewController id="HRz-Eg-7ly" customClass="AppInfoViewController" customModule="ArcGIS_Runtime_SDK_Samples" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="AWt-rk-bdu">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="758"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="54t-nf-ZK2">
-                                <rect key="frame" x="32.666666666666657" y="279" width="310" height="200"/>
+                                <rect key="frame" x="52" y="321" width="310" height="200"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="AppIcon2" translatesAutoresizingMaskIntoConstraints="NO" id="rjI-Fj-tXd">
                                         <rect key="frame" x="115" y="8" width="80" height="80"/>
@@ -73,14 +74,15 @@
                                     <constraint firstAttribute="bottom" secondItem="r26-1c-eoY" secondAttribute="bottom" constant="8" id="qAU-fQ-LD2"/>
                                 </constraints>
                             </view>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Op6-nR-s0N">
-                                <rect key="frame" x="168" y="674" width="39" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Op6-nR-s0N">
+                                <rect key="frame" x="187.5" y="758" width="39" height="30"/>
                                 <state key="normal" title="Close"/>
                                 <connections>
                                     <action selector="closeAction" destination="HRz-Eg-7ly" eventType="touchUpInside" id="JSz-9v-XS9"/>
                                 </connections>
                             </button>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="a6h-ca-33f"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="Op6-nR-s0N" firstAttribute="centerX" secondItem="a6h-ca-33f" secondAttribute="centerX" id="7Te-o6-LfY"/>
@@ -88,7 +90,6 @@
                             <constraint firstItem="54t-nf-ZK2" firstAttribute="centerY" secondItem="AWt-rk-bdu" secondAttribute="centerY" id="biI-md-HHl"/>
                             <constraint firstItem="a6h-ca-33f" firstAttribute="bottom" secondItem="Op6-nR-s0N" secondAttribute="bottom" constant="20" id="qig-cv-gQO"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="a6h-ca-33f"/>
                     </view>
                     <connections>
                         <outlet property="appNameLabel" destination="sgZ-Nk-kH7" id="WRm-0Q-H4P"/>
@@ -104,7 +105,7 @@
             <objects>
                 <collectionViewController definesPresentationContext="YES" id="onD-yF-9Eu" customClass="ContentCollectionViewController" customModule="ArcGIS_Runtime_SDK_Samples" customModuleProvider="target" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" contentInsetAdjustmentBehavior="always" dataMode="prototypes" id="yuT-nZ-Wrk">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" sectionInsetReference="safeArea" id="VF4-1P-JDR">
@@ -145,7 +146,7 @@
                                             </constraints>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" tag="11" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="DISPLAY INFORMATION" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qg1-az-h5v">
-                                            <rect key="frame" x="2" y="100" width="136" height="33.666666666666657"/>
+                                            <rect key="frame" x="2" y="100" width="136" height="33.5"/>
                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
                                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
@@ -203,28 +204,28 @@
             <objects>
                 <tableViewController storyboardIdentifier="ContentTableViewController" id="qbY-kB-MCT" customClass="ContentTableViewController" customModule="ArcGIS_Runtime_SDK_Samples" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="22" sectionFooterHeight="22" id="5VG-Pu-2XV">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="detailDisclosureButton" indentationWidth="10" reuseIdentifier="ContentTableCell" id="UHI-3v-SDe" customClass="ContentTableCell" customModule="ArcGIS_Runtime_SDK_Samples" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="375" height="80.333335876464844"/>
+                                <rect key="frame" x="0.0" y="28" width="414" height="81"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="UHI-3v-SDe" id="hjB-p9-kF0">
-                                    <rect key="frame" x="0.0" y="0.0" width="316" height="80.333335876464844"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="351" height="81"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="pVi-Nv-PRP">
-                                            <rect key="frame" x="16" y="19.000000000000004" width="292" height="42.333333333333343"/>
+                                            <rect key="frame" x="20" y="19" width="323" height="43"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Open an existing map" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="t7O-tm-Q24">
-                                                    <rect key="frame" x="0.0" y="0.0" width="165.66666666666666" height="20.333333333333332"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="165" height="20.5"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="749" text="AGSMap, AGSMapView" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WF4-gk-Tcu">
-                                                    <rect key="frame" x="0.0" y="26.333333333333336" width="140.66666666666666" height="16"/>
+                                                    <rect key="frame" x="0.0" y="26.5" width="140.5" height="16.5"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                     <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
@@ -266,22 +267,22 @@
             <objects>
                 <viewController title="Detail" id="xTO-iT-Uqg" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="OWg-y6-Kjp">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="758"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select a sample from the list" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="99s-uK-gYc">
-                                <rect key="frame" x="79.666666666666686" y="368" width="217" height="21"/>
+                                <rect key="frame" x="100" y="410" width="215" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="Mtd-3h-Dnj"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="Mtd-3h-Dnj" firstAttribute="centerX" secondItem="99s-uK-gYc" secondAttribute="centerX" constant="-0.5" id="XZY-cT-gcg"/>
                             <constraint firstAttribute="centerY" secondItem="99s-uK-gYc" secondAttribute="centerY" constant="0.5" id="Ytu-54-YW5"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="Mtd-3h-Dnj"/>
                     </view>
                     <toolbarItems/>
                     <navigationItem key="navigationItem" id="uhc-ru-ALH"/>
@@ -295,22 +296,23 @@
             <objects>
                 <viewController storyboardIdentifier="SegmentedViewController" automaticallyAdjustsScrollViewInsets="NO" id="aBz-1T-a42" customClass="SegmentedViewController" customModule="ArcGIS_Runtime_SDK_Samples" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="rXs-h5-bEr">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="z5R-Ku-rtU" userLabel="Code Container View">
-                                <rect key="frame" x="0.0" y="88" width="375" height="724"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="808"/>
                                 <connections>
                                     <segue destination="qe9-PB-Pzq" kind="embed" identifier="SourceCodeSegue" id="nmt-TZ-5x3"/>
                                 </connections>
                             </containerView>
                             <containerView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MfE-3m-v2G" userLabel="Info Container View">
-                                <rect key="frame" x="0.0" y="88" width="375" height="724"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="808"/>
                                 <connections>
                                     <segue destination="NMd-B8-rJ5" kind="embed" identifier="SampleInfoSegue" id="c6m-uQ-Kz4"/>
                                 </connections>
                             </containerView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="Asf-ux-BYr"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="MfE-3m-v2G" firstAttribute="top" secondItem="Asf-ux-BYr" secondAttribute="top" id="CwL-cC-IdS"/>
@@ -322,18 +324,17 @@
                             <constraint firstItem="z5R-Ku-rtU" firstAttribute="top" secondItem="Asf-ux-BYr" secondAttribute="top" id="pQz-jW-tbe"/>
                             <constraint firstItem="MfE-3m-v2G" firstAttribute="leading" secondItem="rXs-h5-bEr" secondAttribute="leading" id="yqF-bG-HDh"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="Asf-ux-BYr"/>
                     </view>
                     <navigationItem key="navigationItem" id="Xla-oL-Hlb">
                         <nil key="title"/>
                         <segmentedControl key="titleView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="bar" selectedSegmentIndex="0" id="2NF-7S-DQ2">
-                            <rect key="frame" x="37.666666666666657" y="6" width="300" height="32"/>
+                            <rect key="frame" x="57" y="6" width="300" height="32"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <segments>
                                 <segment title="Info"/>
                                 <segment title="Code"/>
                             </segments>
-                            <color key="tintColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                            <color key="tintColor" systemColor="systemBackgroundColor"/>
                             <connections>
                                 <action selector="valueChanged:" destination="aBz-1T-a42" eventType="valueChanged" id="F3E-aq-YII"/>
                             </connections>
@@ -355,11 +356,30 @@
             <objects>
                 <viewController id="NMd-B8-rJ5" customClass="SampleInfoViewController" customModule="ArcGIS_Runtime_SDK_Samples" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="p2z-Do-b04">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="724"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <subviews>
+                            <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="e32-Rc-zGM">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
+                                <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <wkWebViewConfiguration key="configuration">
+                                    <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
+                                    <wkPreferences key="preferences"/>
+                                </wkWebViewConfiguration>
+                            </wkWebView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="RfT-xO-g6f"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="e32-Rc-zGM" firstAttribute="leading" secondItem="p2z-Do-b04" secondAttribute="leading" id="Jld-qf-du7"/>
+                            <constraint firstAttribute="trailing" secondItem="e32-Rc-zGM" secondAttribute="trailing" id="Jsm-fH-yTv"/>
+                            <constraint firstItem="e32-Rc-zGM" firstAttribute="top" secondItem="p2z-Do-b04" secondAttribute="top" id="d0p-PM-5Q6"/>
+                            <constraint firstAttribute="bottom" secondItem="e32-Rc-zGM" secondAttribute="bottom" id="i4r-eb-pkx"/>
+                        </constraints>
                     </view>
+                    <connections>
+                        <outlet property="webView" destination="e32-Rc-zGM" id="iys-KD-7nI"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="BNK-Yk-cxh" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -370,15 +390,15 @@
             <objects>
                 <viewController storyboardIdentifier="SourceCodeViewController" id="qe9-PB-Pzq" customClass="SourceCodeViewController" customModule="ArcGIS_Runtime_SDK_Samples" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="PsA-Cm-EhI">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="724"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rA3-JQ-Mdx" userLabel="Content View">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="680"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="764"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <toolbar opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cZS-cc-Di0">
-                                <rect key="frame" x="0.0" y="680" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="764" width="414" height="44"/>
                                 <color key="backgroundColor" red="0.97647720575332642" green="0.9764588475227356" blue="0.97647124528884888" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="Kff-Ig-9pK"/>
@@ -396,6 +416,7 @@
                                 </items>
                             </toolbar>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="63H-yR-XyK"/>
                         <color key="backgroundColor" red="0.97647720579999997" green="0.9764588475" blue="0.97647124529999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="rA3-JQ-Mdx" secondAttribute="trailing" id="Gxz-aI-6b0"/>
@@ -406,7 +427,6 @@
                             <constraint firstItem="cZS-cc-Di0" firstAttribute="trailing" secondItem="63H-yR-XyK" secondAttribute="trailing" id="wAh-N1-Zqp"/>
                             <constraint firstItem="cZS-cc-Di0" firstAttribute="top" secondItem="rA3-JQ-Mdx" secondAttribute="bottom" id="xgj-Pi-jqq"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="63H-yR-XyK"/>
                     </view>
                     <connections>
                         <outlet property="contentView" destination="rA3-JQ-Mdx" id="CSj-eW-KXG"/>
@@ -436,7 +456,7 @@
             <objects>
                 <navigationController storyboardIdentifier="DetailNavigationController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="6mK-5c-4sN" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" id="V9q-Qo-B83">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="56"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </navigationBar>
@@ -453,19 +473,19 @@
             <objects>
                 <tableViewController id="ZtT-NE-hWv" customClass="ListViewController" customModule="ArcGIS_Runtime_SDK_Samples" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="iNp-vT-fBs">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="670"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="754"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <prototypes>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="ListCell" textLabel="hPX-p8-mBC" style="IBUITableViewCellStyleDefault" id="ZUl-1v-KYM">
-                                <rect key="frame" x="0.0" y="28" width="375" height="43.666667938232422"/>
+                                <rect key="frame" x="0.0" y="28" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ZUl-1v-KYM" id="4hb-ou-79v">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.666667938232422"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="hPX-p8-mBC">
-                                            <rect key="frame" x="16" y="0.0" width="343" height="43.666667938232422"/>
+                                            <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -498,5 +518,8 @@
         <namedColor name="AccentColor">
             <color red="0.51399999856948853" green="0.18400000035762787" blue="0.7369999885559082" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/arcgis-ios-sdk-samples/Content Display Logic/Storyboard/Main.storyboard
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Storyboard/Main.storyboard
@@ -128,7 +128,7 @@
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CNK-Sn-V8R">
                                             <rect key="frame" x="45" y="45" width="50" height="50"/>
-                                            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.69533653846153842" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.69999999999999996" colorSpace="custom" customColorSpace="sRGB"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="50" id="GZk-MD-Oea"/>
                                                 <constraint firstAttribute="height" constant="50" id="mIH-VU-z34"/>
@@ -223,7 +223,7 @@
                                                 <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="749" text="AGSMap, AGSMapView" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WF4-gk-Tcu">
                                                     <rect key="frame" x="0.0" y="26.5" width="140.5" height="16.5"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                                    <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <color key="textColor" systemColor="secondaryLabelColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -262,13 +262,13 @@
             <objects>
                 <viewController title="Detail" id="xTO-iT-Uqg" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="OWg-y6-Kjp">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select a sample from the list" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="99s-uK-gYc">
-                                <rect key="frame" x="100" y="437" width="215" height="21"/>
+                                <rect key="frame" x="100" y="410" width="215" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" systemColor="systemGrayColor"/>
+                                <color key="textColor" systemColor="secondaryLabelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
@@ -356,7 +356,6 @@
                         <subviews>
                             <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="e32-Rc-zGM">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
-                                <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <wkWebViewConfiguration key="configuration">
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
                                     <wkPreferences key="preferences"/>
@@ -446,7 +445,7 @@
             <objects>
                 <navigationController storyboardIdentifier="DetailNavigationController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="6mK-5c-4sN" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" id="V9q-Qo-B83">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="56"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </navigationBar>
@@ -497,7 +496,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="Cnq-oa-z7G"/>
+        <segue reference="XFi-4R-2mc"/>
     </inferredMetricsTieBreakers>
     <color key="tintColor" name="AccentColor"/>
     <resources>
@@ -506,11 +505,11 @@
         <namedColor name="AccentColor">
             <color red="0.51399999856948853" green="0.18400000035762787" blue="0.7369999885559082" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="systemGrayColor">
-            <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/arcgis-ios-sdk-samples/Content Display Logic/Storyboard/Main.storyboard
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Storyboard/Main.storyboard
@@ -80,7 +80,7 @@
                             </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="a6h-ca-33f"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="tertiarySystemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="Op6-nR-s0N" firstAttribute="centerX" secondItem="a6h-ca-33f" secondAttribute="centerX" id="7Te-o6-LfY"/>
                             <constraint firstItem="54t-nf-ZK2" firstAttribute="centerX" secondItem="a6h-ca-33f" secondAttribute="centerX" id="LwH-pF-D4X"/>
@@ -104,7 +104,7 @@
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" contentInsetAdjustmentBehavior="always" dataMode="prototypes" id="yuT-nZ-Wrk">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="tertiarySystemBackgroundColor"/>
                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" sectionInsetReference="safeArea" id="VF4-1P-JDR">
                             <size key="itemSize" width="140" height="140"/>
                             <size key="headerReferenceSize" width="0.0" height="0.0"/>
@@ -273,7 +273,7 @@
                             </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Mtd-3h-Dnj"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="tertiarySystemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="Mtd-3h-Dnj" firstAttribute="centerX" secondItem="99s-uK-gYc" secondAttribute="centerX" constant="-0.5" id="XZY-cT-gcg"/>
                             <constraint firstAttribute="centerY" secondItem="99s-uK-gYc" secondAttribute="centerY" constant="0.5" id="Ytu-54-YW5"/>
@@ -308,7 +308,7 @@
                             </containerView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Asf-ux-BYr"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="tertiarySystemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="MfE-3m-v2G" firstAttribute="top" secondItem="Asf-ux-BYr" secondAttribute="top" id="CwL-cC-IdS"/>
                             <constraint firstItem="z5R-Ku-rtU" firstAttribute="trailing" secondItem="rXs-h5-bEr" secondAttribute="trailing" id="Io8-c8-jLg"/>
@@ -526,6 +526,9 @@
             <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="tertiarySystemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
     </resources>

--- a/arcgis-ios-sdk-samples/Content Display Logic/Storyboard/Main.storyboard
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Storyboard/Main.storyboard
@@ -364,7 +364,7 @@
                             </wkWebView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="RfT-xO-g6f"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="tertiarySystemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="e32-Rc-zGM" firstAttribute="leading" secondItem="p2z-Do-b04" secondAttribute="leading" id="Jld-qf-du7"/>
                             <constraint firstAttribute="trailing" secondItem="e32-Rc-zGM" secondAttribute="trailing" id="Jsm-fH-yTv"/>
@@ -422,7 +422,7 @@
                             </toolbar>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="63H-yR-XyK"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="tertiarySystemBackgroundColor"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="rA3-JQ-Mdx" secondAttribute="trailing" id="Gxz-aI-6b0"/>
                             <constraint firstItem="63H-yR-XyK" firstAttribute="bottom" secondItem="lOs-Xt-37W" secondAttribute="bottom" id="JNt-5r-Dnf"/>

--- a/arcgis-ios-sdk-samples/Content Display Logic/Storyboard/Main.storyboard
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Storyboard/Main.storyboard
@@ -3,7 +3,7 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -405,18 +405,18 @@
                                     <constraint firstItem="KE4-Ic-Gt2" firstAttribute="top" secondItem="rA3-JQ-Mdx" secondAttribute="top" id="sqb-Ou-quV"/>
                                 </constraints>
                             </view>
-                            <toolbar opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cZS-cc-Di0">
+                            <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lOs-Xt-37W">
                                 <rect key="frame" x="0.0" y="764" width="414" height="44"/>
                                 <items>
-                                    <barButtonItem style="plain" systemItem="flexibleSpace" id="RgF-M3-ILn"/>
-                                    <barButtonItem id="zbn-kS-wmE">
+                                    <barButtonItem style="plain" systemItem="flexibleSpace" id="3NS-sD-8rS"/>
+                                    <barButtonItem title="source code filenames" id="TDL-II-K65">
                                         <connections>
-                                            <segue destination="ZtT-NE-hWv" kind="popoverPresentation" identifier="FilenamesPopoverSegue" popoverAnchorBarButtonItem="zbn-kS-wmE" id="bpN-Qw-2HU">
+                                            <segue destination="ZtT-NE-hWv" kind="popoverPresentation" identifier="FilenamesPopoverSegue" popoverAnchorBarButtonItem="TDL-II-K65" id="IhC-gy-SUN">
                                                 <popoverArrowDirection key="popoverArrowDirection" up="YES" down="YES" left="YES" right="YES"/>
                                             </segue>
                                         </connections>
                                     </barButtonItem>
-                                    <barButtonItem style="plain" systemItem="flexibleSpace" id="sOx-yt-u4x"/>
+                                    <barButtonItem style="plain" systemItem="flexibleSpace" id="ajE-dW-eUU"/>
                                 </items>
                             </toolbar>
                         </subviews>
@@ -424,17 +424,17 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="rA3-JQ-Mdx" secondAttribute="trailing" id="Gxz-aI-6b0"/>
-                            <constraint firstItem="cZS-cc-Di0" firstAttribute="leading" secondItem="PsA-Cm-EhI" secondAttribute="leading" id="HbP-pv-Z3e"/>
-                            <constraint firstItem="63H-yR-XyK" firstAttribute="bottom" secondItem="cZS-cc-Di0" secondAttribute="bottom" id="UmR-sv-GZn"/>
+                            <constraint firstItem="63H-yR-XyK" firstAttribute="bottom" secondItem="lOs-Xt-37W" secondAttribute="bottom" id="JNt-5r-Dnf"/>
+                            <constraint firstItem="lOs-Xt-37W" firstAttribute="leading" secondItem="PsA-Cm-EhI" secondAttribute="leading" id="RUd-cm-VDw"/>
+                            <constraint firstItem="lOs-Xt-37W" firstAttribute="top" secondItem="rA3-JQ-Mdx" secondAttribute="bottom" id="hSY-uy-jpZ"/>
                             <constraint firstItem="rA3-JQ-Mdx" firstAttribute="top" secondItem="PsA-Cm-EhI" secondAttribute="top" id="lAi-DH-gfE"/>
                             <constraint firstItem="rA3-JQ-Mdx" firstAttribute="leading" secondItem="PsA-Cm-EhI" secondAttribute="leading" id="tTG-eT-spV"/>
-                            <constraint firstItem="cZS-cc-Di0" firstAttribute="trailing" secondItem="PsA-Cm-EhI" secondAttribute="trailing" id="wAh-N1-Zqp"/>
-                            <constraint firstItem="cZS-cc-Di0" firstAttribute="top" secondItem="rA3-JQ-Mdx" secondAttribute="bottom" id="xgj-Pi-jqq"/>
+                            <constraint firstAttribute="trailing" secondItem="lOs-Xt-37W" secondAttribute="trailing" id="uD4-DX-MX7"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="contentView" destination="rA3-JQ-Mdx" id="CSj-eW-KXG"/>
-                        <outlet property="toolbarTitleButton" destination="zbn-kS-wmE" id="reN-O0-gAK"/>
+                        <outlet property="toolbarTitleButton" destination="TDL-II-K65" id="U7Y-A9-gEW"/>
                         <outlet property="webView" destination="KE4-Ic-Gt2" id="anj-eU-nBT"/>
                     </connections>
                 </viewController>

--- a/arcgis-ios-sdk-samples/Content Display Logic/Storyboard/Main.storyboard
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Storyboard/Main.storyboard
@@ -294,14 +294,14 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="z5R-Ku-rtU" userLabel="Code Container View">
-                                <rect key="frame" x="0.0" y="88" width="414" height="808"/>
+                            <containerView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="z5R-Ku-rtU" userLabel="Code Container View">
+                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
                                 <connections>
                                     <segue destination="qe9-PB-Pzq" kind="embed" identifier="SourceCodeSegue" id="nmt-TZ-5x3"/>
                                 </connections>
                             </containerView>
-                            <containerView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MfE-3m-v2G" userLabel="Info Container View">
-                                <rect key="frame" x="0.0" y="88" width="414" height="808"/>
+                            <containerView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MfE-3m-v2G" userLabel="Info Container View">
+                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
                                 <connections>
                                     <segue destination="NMd-B8-rJ5" kind="embed" identifier="SampleInfoSegue" id="c6m-uQ-Kz4"/>
                                 </connections>
@@ -312,10 +312,10 @@
                         <constraints>
                             <constraint firstItem="MfE-3m-v2G" firstAttribute="top" secondItem="Asf-ux-BYr" secondAttribute="top" id="CwL-cC-IdS"/>
                             <constraint firstItem="z5R-Ku-rtU" firstAttribute="trailing" secondItem="rXs-h5-bEr" secondAttribute="trailing" id="Io8-c8-jLg"/>
-                            <constraint firstItem="MfE-3m-v2G" firstAttribute="bottom" secondItem="rXs-h5-bEr" secondAttribute="bottom" id="NK3-OW-3OG"/>
+                            <constraint firstItem="MfE-3m-v2G" firstAttribute="bottom" secondItem="Asf-ux-BYr" secondAttribute="bottom" id="NK3-OW-3OG"/>
                             <constraint firstItem="MfE-3m-v2G" firstAttribute="trailing" secondItem="rXs-h5-bEr" secondAttribute="trailing" id="W1c-PG-j3x"/>
                             <constraint firstItem="z5R-Ku-rtU" firstAttribute="leading" secondItem="rXs-h5-bEr" secondAttribute="leading" id="YdR-2X-v9b"/>
-                            <constraint firstItem="z5R-Ku-rtU" firstAttribute="bottom" secondItem="rXs-h5-bEr" secondAttribute="bottom" id="eYS-sS-Rlb"/>
+                            <constraint firstItem="z5R-Ku-rtU" firstAttribute="bottom" secondItem="Asf-ux-BYr" secondAttribute="bottom" id="eYS-sS-Rlb"/>
                             <constraint firstItem="z5R-Ku-rtU" firstAttribute="top" secondItem="Asf-ux-BYr" secondAttribute="top" id="pQz-jW-tbe"/>
                             <constraint firstItem="MfE-3m-v2G" firstAttribute="leading" secondItem="rXs-h5-bEr" secondAttribute="leading" id="yqF-bG-HDh"/>
                         </constraints>
@@ -351,11 +351,11 @@
             <objects>
                 <viewController id="NMd-B8-rJ5" customClass="SampleInfoViewController" customModule="ArcGIS_Runtime_SDK_Samples" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="p2z-Do-b04">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="774"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="e32-Rc-zGM">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
+                            <wkWebView contentMode="scaleToFill" allowsBackForwardNavigationGestures="YES" translatesAutoresizingMaskIntoConstraints="NO" id="e32-Rc-zGM">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="774"/>
                                 <wkWebViewConfiguration key="configuration">
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
                                     <wkPreferences key="preferences"/>
@@ -384,14 +384,29 @@
             <objects>
                 <viewController storyboardIdentifier="SourceCodeViewController" id="qe9-PB-Pzq" customClass="SourceCodeViewController" customModule="ArcGIS_Runtime_SDK_Samples" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="PsA-Cm-EhI">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="774"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rA3-JQ-Mdx" userLabel="Content View">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="764"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="730"/>
+                                <subviews>
+                                    <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KE4-Ic-Gt2">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="730"/>
+                                        <wkWebViewConfiguration key="configuration">
+                                            <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
+                                            <wkPreferences key="preferences"/>
+                                        </wkWebViewConfiguration>
+                                    </wkWebView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="KE4-Ic-Gt2" secondAttribute="bottom" id="ApL-oy-iHl"/>
+                                    <constraint firstItem="KE4-Ic-Gt2" firstAttribute="leading" secondItem="rA3-JQ-Mdx" secondAttribute="leading" id="a3B-K1-Iw3"/>
+                                    <constraint firstAttribute="trailing" secondItem="KE4-Ic-Gt2" secondAttribute="trailing" id="nxz-eX-LGE"/>
+                                    <constraint firstItem="KE4-Ic-Gt2" firstAttribute="top" secondItem="rA3-JQ-Mdx" secondAttribute="top" id="sqb-Ou-quV"/>
+                                </constraints>
                             </view>
                             <toolbar opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cZS-cc-Di0">
-                                <rect key="frame" x="0.0" y="764" width="414" height="44"/>
+                                <rect key="frame" x="0.0" y="730" width="414" height="44"/>
                                 <items>
                                     <barButtonItem style="plain" systemItem="flexibleSpace" id="RgF-M3-ILn"/>
                                     <barButtonItem id="zbn-kS-wmE">
@@ -409,17 +424,18 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="rA3-JQ-Mdx" secondAttribute="trailing" id="Gxz-aI-6b0"/>
-                            <constraint firstItem="cZS-cc-Di0" firstAttribute="leading" secondItem="63H-yR-XyK" secondAttribute="leading" id="HbP-pv-Z3e"/>
+                            <constraint firstItem="cZS-cc-Di0" firstAttribute="leading" secondItem="PsA-Cm-EhI" secondAttribute="leading" id="HbP-pv-Z3e"/>
                             <constraint firstItem="63H-yR-XyK" firstAttribute="bottom" secondItem="cZS-cc-Di0" secondAttribute="bottom" id="UmR-sv-GZn"/>
                             <constraint firstItem="rA3-JQ-Mdx" firstAttribute="top" secondItem="PsA-Cm-EhI" secondAttribute="top" id="lAi-DH-gfE"/>
                             <constraint firstItem="rA3-JQ-Mdx" firstAttribute="leading" secondItem="PsA-Cm-EhI" secondAttribute="leading" id="tTG-eT-spV"/>
-                            <constraint firstItem="cZS-cc-Di0" firstAttribute="trailing" secondItem="63H-yR-XyK" secondAttribute="trailing" id="wAh-N1-Zqp"/>
+                            <constraint firstItem="cZS-cc-Di0" firstAttribute="trailing" secondItem="PsA-Cm-EhI" secondAttribute="trailing" id="wAh-N1-Zqp"/>
                             <constraint firstItem="cZS-cc-Di0" firstAttribute="top" secondItem="rA3-JQ-Mdx" secondAttribute="bottom" id="xgj-Pi-jqq"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="contentView" destination="rA3-JQ-Mdx" id="CSj-eW-KXG"/>
                         <outlet property="toolbarTitleButton" destination="zbn-kS-wmE" id="reN-O0-gAK"/>
+                        <outlet property="webView" destination="KE4-Ic-Gt2" id="anj-eU-nBT"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="eWR-U8-1d5" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -462,7 +478,7 @@
             <objects>
                 <tableViewController id="ZtT-NE-hWv" customClass="ListViewController" customModule="ArcGIS_Runtime_SDK_Samples" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="iNp-vT-fBs">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="754"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="720"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>

--- a/arcgis-ios-sdk-samples/Content Display Logic/Storyboard/Main.storyboard
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Storyboard/Main.storyboard
@@ -295,13 +295,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="z5R-Ku-rtU" userLabel="Code Container View">
-                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="808"/>
                                 <connections>
                                     <segue destination="qe9-PB-Pzq" kind="embed" identifier="SourceCodeSegue" id="nmt-TZ-5x3"/>
                                 </connections>
                             </containerView>
                             <containerView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MfE-3m-v2G" userLabel="Info Container View">
-                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="808"/>
                                 <connections>
                                     <segue destination="NMd-B8-rJ5" kind="embed" identifier="SampleInfoSegue" id="c6m-uQ-Kz4"/>
                                 </connections>
@@ -312,10 +312,10 @@
                         <constraints>
                             <constraint firstItem="MfE-3m-v2G" firstAttribute="top" secondItem="Asf-ux-BYr" secondAttribute="top" id="CwL-cC-IdS"/>
                             <constraint firstItem="z5R-Ku-rtU" firstAttribute="trailing" secondItem="rXs-h5-bEr" secondAttribute="trailing" id="Io8-c8-jLg"/>
-                            <constraint firstItem="MfE-3m-v2G" firstAttribute="bottom" secondItem="Asf-ux-BYr" secondAttribute="bottom" id="NK3-OW-3OG"/>
+                            <constraint firstItem="MfE-3m-v2G" firstAttribute="bottom" secondItem="rXs-h5-bEr" secondAttribute="bottom" id="NK3-OW-3OG"/>
                             <constraint firstItem="MfE-3m-v2G" firstAttribute="trailing" secondItem="rXs-h5-bEr" secondAttribute="trailing" id="W1c-PG-j3x"/>
                             <constraint firstItem="z5R-Ku-rtU" firstAttribute="leading" secondItem="rXs-h5-bEr" secondAttribute="leading" id="YdR-2X-v9b"/>
-                            <constraint firstItem="z5R-Ku-rtU" firstAttribute="bottom" secondItem="Asf-ux-BYr" secondAttribute="bottom" id="eYS-sS-Rlb"/>
+                            <constraint firstItem="z5R-Ku-rtU" firstAttribute="bottom" secondItem="rXs-h5-bEr" secondAttribute="bottom" id="eYS-sS-Rlb"/>
                             <constraint firstItem="z5R-Ku-rtU" firstAttribute="top" secondItem="Asf-ux-BYr" secondAttribute="top" id="pQz-jW-tbe"/>
                             <constraint firstItem="MfE-3m-v2G" firstAttribute="leading" secondItem="rXs-h5-bEr" secondAttribute="leading" id="yqF-bG-HDh"/>
                         </constraints>
@@ -351,11 +351,11 @@
             <objects>
                 <viewController id="NMd-B8-rJ5" customClass="SampleInfoViewController" customModule="ArcGIS_Runtime_SDK_Samples" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="p2z-Do-b04">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="774"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <wkWebView contentMode="scaleToFill" allowsBackForwardNavigationGestures="YES" translatesAutoresizingMaskIntoConstraints="NO" id="e32-Rc-zGM">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="774"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
                                 <wkWebViewConfiguration key="configuration">
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
                                     <wkPreferences key="preferences"/>
@@ -384,14 +384,14 @@
             <objects>
                 <viewController storyboardIdentifier="SourceCodeViewController" id="qe9-PB-Pzq" customClass="SourceCodeViewController" customModule="ArcGIS_Runtime_SDK_Samples" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="PsA-Cm-EhI">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="774"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rA3-JQ-Mdx" userLabel="Content View">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="730"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="764"/>
                                 <subviews>
                                     <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KE4-Ic-Gt2">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="730"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="764"/>
                                         <wkWebViewConfiguration key="configuration">
                                             <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
                                             <wkPreferences key="preferences"/>
@@ -406,7 +406,7 @@
                                 </constraints>
                             </view>
                             <toolbar opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cZS-cc-Di0">
-                                <rect key="frame" x="0.0" y="730" width="414" height="44"/>
+                                <rect key="frame" x="0.0" y="764" width="414" height="44"/>
                                 <items>
                                     <barButtonItem style="plain" systemItem="flexibleSpace" id="RgF-M3-ILn"/>
                                     <barButtonItem id="zbn-kS-wmE">
@@ -478,7 +478,7 @@
             <objects>
                 <tableViewController id="ZtT-NE-hWv" customClass="ListViewController" customModule="ArcGIS_Runtime_SDK_Samples" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="iNp-vT-fBs">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="720"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="754"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>

--- a/arcgis-ios-sdk-samples/Content Display Logic/Storyboard/Main.storyboard
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Storyboard/Main.storyboard
@@ -202,7 +202,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="22" sectionFooterHeight="22" id="5VG-Pu-2XV">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="tertiarySystemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="detailDisclosureButton" indentationWidth="10" reuseIdentifier="ContentTableCell" id="UHI-3v-SDe" customClass="ContentTableCell" customModule="ArcGIS_Runtime_SDK_Samples" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="28" width="414" height="81"/>
@@ -236,6 +236,7 @@
                                         <constraint firstItem="pVi-Nv-PRP" firstAttribute="leading" secondItem="hjB-p9-kF0" secondAttribute="leadingMargin" id="loI-Zf-Lb3"/>
                                     </constraints>
                                 </tableViewCellContentView>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <connections>
                                     <outlet property="detailLabel" destination="WF4-gk-Tcu" id="vk5-go-uAq"/>
                                     <outlet property="stackView" destination="pVi-Nv-PRP" id="Ab9-oe-EmG"/>

--- a/arcgis-ios-sdk-samples/Content Display Logic/Views/DownloadProgressView.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Views/DownloadProgressView.swift
@@ -102,7 +102,7 @@ class DownloadProgressView: UIView {
         self.transparentShapeLayer.frame = CGRect(x: 0, y: 0, width: 2 * self.radius, height: 2 * self.radius)
         self.transparentShapeLayer.path = UIBezierPath(arcCenter: CGPoint(x: self.radius, y: self.radius), radius: self.radius, startAngle: 0, endAngle: 2 * CGFloat.pi, clockwise: true).cgPath
         self.transparentShapeLayer.fillColor = UIColor.clear.cgColor
-        self.transparentShapeLayer.strokeColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.3).cgColor
+        self.transparentShapeLayer.strokeColor = UIColor.lightGray.withAlphaComponent(0.6).cgColor
         self.transparentShapeLayer.lineWidth = 3
         
         self.progressLabel.layer.addSublayer(self.transparentShapeLayer)
@@ -111,7 +111,7 @@ class DownloadProgressView: UIView {
         self.shapeLayer.frame = CGRect(x: 0, y: 0, width: 2 * self.radius, height: 2 * self.radius)
         self.shapeLayer.path = self.bezierPath.cgPath
         self.shapeLayer.fillColor = UIColor.clear.cgColor
-        self.shapeLayer.strokeColor = UIColor.black.cgColor
+        self.shapeLayer.strokeColor = UIColor.darkGray.cgColor
         self.shapeLayer.lineWidth = 3
         self.shapeLayer.strokeEnd = 0
         
@@ -145,7 +145,7 @@ class DownloadProgressView: UIView {
     
     func updateProgress(progress: CGFloat, animated: Bool) {
         if progress > 1 {
-           self.progress = 1
+            self.progress = 1
         } else if progress < 0 {
             self.progress = 0
         } else {

--- a/arcgis-ios-sdk-samples/Content Display Logic/Views/DownloadProgressView.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Views/DownloadProgressView.swift
@@ -111,7 +111,7 @@ class DownloadProgressView: UIView {
         self.shapeLayer.frame = CGRect(x: 0, y: 0, width: 2 * self.radius, height: 2 * self.radius)
         self.shapeLayer.path = self.bezierPath.cgPath
         self.shapeLayer.fillColor = UIColor.clear.cgColor
-        self.shapeLayer.strokeColor = UIColor.darkGray.cgColor
+        self.shapeLayer.strokeColor = UIColor.green.cgColor
         self.shapeLayer.lineWidth = 3
         self.shapeLayer.strokeEnd = 0
         

--- a/arcgis-ios-sdk-samples/Content Display Logic/Views/DownloadProgressView.xib
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Views/DownloadProgressView.xib
@@ -3,7 +3,7 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/arcgis-ios-sdk-samples/Content Display Logic/Views/DownloadProgressView.xib
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Views/DownloadProgressView.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -17,11 +18,11 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="3Mj-KC-mCm">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FvF-Nq-g4W">
-                    <rect key="frame" x="67.5" y="237" width="240" height="193"/>
+                    <rect key="frame" x="87" y="351.5" width="240" height="193"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0%" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4ko-G4-tpJ">
                             <rect key="frame" x="98" y="40" width="44" height="21"/>
@@ -38,8 +39,8 @@
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eOX-4U-fqJ">
-                            <rect key="frame" x="91.5" y="152" width="57" height="33"/>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eOX-4U-fqJ">
+                            <rect key="frame" x="92" y="152" width="56" height="33"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                             <state key="normal" title="Cancel"/>
                             <connections>
@@ -47,7 +48,7 @@
                             </connections>
                         </button>
                     </subviews>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" systemColor="secondarySystemBackgroundColor"/>
                     <constraints>
                         <constraint firstItem="Zjh-ix-0i1" firstAttribute="leading" secondItem="FvF-Nq-g4W" secondAttribute="leading" constant="8" id="6pn-t6-i04"/>
                         <constraint firstItem="Zjh-ix-0i1" firstAttribute="top" secondItem="4ko-G4-tpJ" secondAttribute="bottom" constant="40" id="ImI-x3-AYC"/>
@@ -75,5 +76,8 @@
         <namedColor name="AccentColor">
             <color red="0.51399999856948853" green="0.18400000035762787" blue="0.7369999885559082" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <systemColor name="secondarySystemBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
     </resources>
 </document>

--- a/arcgis-ios-sdk-samples/Info.plist
+++ b/arcgis-ios-sdk-samples/Info.plist
@@ -124,8 +124,6 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>UIUserInterfaceStyle</key>
-	<string>Light</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>


### PR DESCRIPTION
## Description

This PR adapts or updates every color in Content Display Logic folder to Dark Mode. It includes

- Change colors in `Main.storyboard` for each custom color in view controllers
- Add a color to `AppDelegate.swift`
- Change color for color picker view controller
- Change colors for the search bar, which is used both in content collection view controller (the main screen card view) and in `SearchForWebmapByKeywordViewController.swift`
- Change CSS styles for README and source code panes, so that they are responsive to Dark Mode
- Update colors in download progress view - for on-demand resource dependent samples

You can use <kbd>command</kbd> + <kbd>shift</kbd> + <kbd>A</kbd> to toggle Dark Mode in Simulator.

Also, I removed the force Light Mode flag, so there is no need to edit anything when testing! Reasons [below](https://github.com/Esri/arcgis-runtime-samples-ios/pull/899#discussion_r503593806).

## Does not change

- DemoTouchManager to show touches, no color is changed in this class.
- SVProgressHUD, it is a 3rd party dependency, and the author hasn't adapted it to iOS 13 yet. We consider replacing it with our own Swift implementation in total. It is used in many samples, including Trace utility network and Perform valve isolation trace.

## References

/common-samples/issues/1507
/common-samples/issues/2037

## Demo

![201012-demo](https://user-images.githubusercontent.com/9660181/95801035-e5403d00-0cad-11eb-9e05-0d25a23085b4.gif)
