### PR TITLE
Fix: missing comma in Identify raster cell metadata json

### DIFF
--- a/arcgis-ios-sdk-samples/Layers/Identify raster cell/README.metadata.json
+++ b/arcgis-ios-sdk-samples/Layers/Identify raster cell/README.metadata.json
@@ -14,7 +14,7 @@
         "identify",
         "pixel",
         "pixel value",
-        "raster"
+        "raster",
         "AGSGeoView.identifyLayer(_:screenPoint:tolerance:returnPopupsOnly:completion:)",
         "AGSIdentifyLayerResult",
         "AGSRasterCell",


### PR DESCRIPTION
Running style check script spotted this issue, which will cause the sample not rendering on website.