### PR TITLE
Fix: remove redundant tags

### DIFF
--- a/arcgis-ios-sdk-samples/Analysis/Viewshed (location)/README.md
+++ b/arcgis-ios-sdk-samples/Analysis/Viewshed (location)/README.md
@@ -31,4 +31,4 @@ The scene shows a [buildings layer in Brest, France](https://tiles.arcgis.com/ti
 
 ## Tags
 
-3D, frustum, LocationViewshed, Scene, viewshed, visibility analysis
+3D, frustum, scene, viewshed, visibility analysis

--- a/arcgis-ios-sdk-samples/Analysis/Viewshed (location)/README.metadata.json
+++ b/arcgis-ios-sdk-samples/Analysis/Viewshed (location)/README.metadata.json
@@ -7,9 +7,8 @@
     ],
     "keywords": [
         "3D",
-        "LocationViewshed",
-        "Scene",
         "frustum",
+        "scene",
         "viewshed",
         "visibility analysis",
         "AGSAnalysisOverlay",

--- a/arcgis-ios-sdk-samples/Display information/Simple marker symbol/README.md
+++ b/arcgis-ios-sdk-samples/Display information/Simple marker symbol/README.md
@@ -27,4 +27,4 @@ The sample loads with a predefined simple marker symbol, set as a red circle.
 
 ## Tags
 
-AGSSimpleMarkerSymbol, symbol
+symbol

--- a/arcgis-ios-sdk-samples/Layers/Dictionary renderer with feature layer/README.md
+++ b/arcgis-ios-sdk-samples/Layers/Dictionary renderer with feature layer/README.md
@@ -34,4 +34,4 @@ This sample uses the [Mil2525d Stylx File](https://www.arcgis.com/home/item.html
 
 ## Tags
 
-DictionaryRenderer, DictionarySymbolStyle, military, symbol
+military, symbol

--- a/arcgis-ios-sdk-samples/Layers/Dictionary renderer with feature layer/README.metadata.json
+++ b/arcgis-ios-sdk-samples/Layers/Dictionary renderer with feature layer/README.metadata.json
@@ -6,8 +6,6 @@
         "dictionary-renderer-with-feature-layer.png"
     ],
     "keywords": [
-        "DictionaryRenderer",
-        "DictionarySymbolStyle",
         "military",
         "symbol",
         "AGSDictionaryRenderer",

--- a/arcgis-ios-sdk-samples/Maps/Set map spatial reference/README.md
+++ b/arcgis-ios-sdk-samples/Maps/Set map spatial reference/README.md
@@ -33,4 +33,4 @@ Operational layers will automatically project to this spatial reference when pos
 
 ## Tags
 
-project, SpatialReference, WKID
+project, WKID

--- a/arcgis-ios-sdk-samples/Maps/Set map spatial reference/README.metadata.json
+++ b/arcgis-ios-sdk-samples/Maps/Set map spatial reference/README.metadata.json
@@ -6,7 +6,6 @@
         "map-spatial-reference.png"
     ],
     "keywords": [
-        "SpatialReference",
         "WKID",
         "project",
         "AGSArcGISMapImageLayer",


### PR DESCRIPTION
A quick fix PR to remove redundant tags.

Discussed with our team and found out more duplicate API names that shouldn't go into tags. Removing them and running the check yields no error.