### PR TITLE
Fix: reorder section headers

### DIFF
--- a/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/README.md
+++ b/arcgis-ios-sdk-samples/Analysis/Statistical query (group and sort)/README.md
@@ -22,10 +22,6 @@ Select a combination of fields and statistic types to include in the query. Choo
 5. To execute the query, call `AGSFeatureTable.queryStatistics(with:completion:)`.
 6. Get the `AGSStatisticQueryResult`. From this, you can use `AGSStatisticsQueryResult.statisticRecordEnumerator()` to loop through and display.
 
-## About the data
-
-This sample uses a [Diabetes, Obesity, and Inactivity by US County](https://www.arcgis.com/home/item.html?id=392420848e634079bc7d0648586e818f) feature layer hosted on ArcGIS Online.
-
 ## Relevant API
 
 * AGSField
@@ -37,6 +33,10 @@ This sample uses a [Diabetes, Obesity, and Inactivity by US County](https://www.
 * AGSStatisticsQueryParameters
 * AGSStatisticsQueryResult
 * AGSStatisticType
+
+## About the data
+
+This sample uses a [Diabetes, Obesity, and Inactivity by US County](https://www.arcgis.com/home/item.html?id=392420848e634079bc7d0648586e818f) feature layer hosted on ArcGIS Online.
 
 ## Tags
 

--- a/arcgis-ios-sdk-samples/Analysis/Viewshed (GeoElement)/README.md
+++ b/arcgis-ios-sdk-samples/Analysis/Viewshed (GeoElement)/README.md
@@ -21,14 +21,6 @@ Tap to set a destination for the vehicle (an `AGSGeoElement`). The vehicle will 
 4. Add the viewshed to an `AGSAnalysisOverlay` and add the overlay to the scene.
 5. Configure the SceneView `AGSCameraController` to orbit the vehicle.
 
-## Offline data
-
-[Model Marker Symbol Data](https://www.arcgis.com/home/item.html?id=07d62a792ab6496d9b772a24efea45d0) will be downloaded by the sample viewer automatically.
-
-## About the data
-
-This sample shows a [Johannesburg, South Africa Scene](https://www.arcgis.com/home/item.html?id=eb4dab9e61b24fe2919a0e6f7905321e) from ArcGIS Online. The sample uses a [Tank model scene symbol](https://www.arcgis.com/home/item.html?id=07d62a792ab6496d9b772a24efea45d0) hosted as an item on ArcGIS Online.
-
 ## Relevant API
 
 * AGSAnalysisOverlay
@@ -37,6 +29,14 @@ This sample shows a [Johannesburg, South Africa Scene](https://www.arcgis.com/ho
 * AGSGeometryEngine
 * AGSModelSceneSymbol
 * AGSOrbitGeoElementCameraController
+
+## Offline data
+
+[Model Marker Symbol Data](https://www.arcgis.com/home/item.html?id=07d62a792ab6496d9b772a24efea45d0) will be downloaded by the sample viewer automatically.
+
+## About the data
+
+This sample shows a [Johannesburg, South Africa Scene](https://www.arcgis.com/home/item.html?id=eb4dab9e61b24fe2919a0e6f7905321e) from ArcGIS Online. The sample uses a [Tank model scene symbol](https://www.arcgis.com/home/item.html?id=07d62a792ab6496d9b772a24efea45d0) hosted as an item on ArcGIS Online.
 
 ## Tags
 

--- a/arcgis-ios-sdk-samples/Edit data/Edit feature attachments/README.md
+++ b/arcgis-ios-sdk-samples/Edit data/Edit feature attachments/README.md
@@ -23,10 +23,6 @@ Tap a feature on the map to open a callout displaying the number of attachments.
 6. To delete an attachment from the selected `AGSArcGISFeature`, use the `AGSArcGISFeature.delete(_:completion:)`.
 7. After a change, apply the changes to the server using `AGSServiceFeatureTable.applyEdits(completion:)`.
 
-## Additional information
-
-Attachments can only be added to and accessed on a service feature table when its `hasAttachments` property is true.
-
 ## Relevant API
 
 * AGSArcGISFeature.delete(_:completion:)
@@ -34,6 +30,10 @@ Attachments can only be added to and accessed on a service feature table when it
 * AGSFeatureLayer
 * AGSServiceFeatureTable
 * AGSServiceFeatureTable.applyEdits(completion:)
+
+## Additional information
+
+Attachments can only be added to and accessed on a service feature table when its `hasAttachments` property is true.
 
 ## Tags
 

--- a/arcgis-ios-sdk-samples/Features/Feature layer query/README.md
+++ b/arcgis-ios-sdk-samples/Features/Feature layer query/README.md
@@ -20,16 +20,16 @@ Input the name of a U.S. state into the text field. A query is performed and the
 3. Perform the query using `AGSFeatureTable.queryFeatures(with:completion:)` on the service feature table.
 4. When complete, the query will return an `AGSFeatureQueryResult` which can be iterated over to get the matching features.
 
-## About the data
-
-This sample uses U.S. State polygon features from the [USA 2016 Daytime Population](https://www.arcgis.com/home/item.html?id=f01f0eda766344e29f42031e7bfb7d04) feature service.
-
 ## Relevant API
 
 * AGSFeatureLayer
 * AGSFeatureQueryResult
 * AGSQueryParameters
 * AGSServiceFeatureTable
+
+## About the data
+
+This sample uses U.S. State polygon features from the [USA 2016 Daytime Population](https://www.arcgis.com/home/item.html?id=f01f0eda766344e29f42031e7bfb7d04) feature service.
 
 ## Tags
 

--- a/arcgis-ios-sdk-samples/Features/Feature layer selection/README.md
+++ b/arcgis-ios-sdk-samples/Features/Feature layer selection/README.md
@@ -20,15 +20,15 @@ Tap on a feature in the map. All features within a given tolerance (in pixels) o
 3. Identify nearby features at the tapped location by specifying the `AGSGeometry` for the `AGSQueryParameters`.
 4. Select all identified features in the feature layer with `AGSFeatureLayer.selectFeatures(withQuery:mode:completion:)`.
 
-## About the data
-
-This sample uses the [Gross Domestic Product, 1960-2016](https://www.arcgis.com/home/item.html?id=0c4b6b70a56b40b08c5b0420c570a6ac) feature service. Only the 2016 GDP values are shown.
-
 ## Relevant API
 
 * AGSFeature
 * AGSFeatureLayer
 * AGSServiceFeatureTable
+
+## About the data
+
+This sample uses the [Gross Domestic Product, 1960-2016](https://www.arcgis.com/home/item.html?id=0c4b6b70a56b40b08c5b0420c570a6ac) feature service. Only the 2016 GDP values are shown.
 
 ## Tags
 

--- a/arcgis-ios-sdk-samples/Geometry/List transformations/README.md
+++ b/arcgis-ios-sdk-samples/Geometry/List transformations/README.md
@@ -30,6 +30,10 @@ If the selected transformation is not usable (has missing grid files) then an er
 * AGSTransformationCatalog
 * class AGSGeometryEngine.projectGeometry(_:to:datumTransformation:)
 
+## About the data
+
+The map starts out zoomed into the grounds of the Royal Observatory, Greenwich. The initial point is in the [British National Grid](https://epsg.io/27700) spatial reference, which was created by the United Kingdom Ordnance Survey. The spatial reference after projection is in [Web Mercator](https://epsg.io/3857).
+
 ## Additional information
 
 Some transformations aren't available until transformation data is provided.
@@ -43,10 +47,6 @@ To download projection engine data to your device:
 3. Click the download button next to `Projection Engine Data` to download projection engine data to your computer.
 4. Unzip the downloaded data on your computer.
 5. Copy the `PEDataRuntime` folder to your application's Documents folder.
-
-## About the data
-
-The map starts out zoomed into the grounds of the Royal Observatory, Greenwich. The initial point is in the [British National Grid](https://epsg.io/27700) spatial reference, which was created by the United Kingdom Ordnance Survey. The spatial reference after projection is in [Web Mercator](https://epsg.io/3857).
 
 ## Tags
 

--- a/arcgis-ios-sdk-samples/Layers/Query a map image sublayer/README.md
+++ b/arcgis-ios-sdk-samples/Layers/Query a map image sublayer/README.md
@@ -20,17 +20,17 @@ Specify a minimum population in the input field (values under 1810000 will produ
 4. Create `AGSQueryParameters` and define its `whereClause` and `geometry`.
 5. Use `AGSFeatureTable.queryFeatures(with:completion:)` to get an `AGSFeatureQueryResult` with features matching the query. The result is an enumerator of features.
 
-## About the data
-
-The `AGSArcGISMapImageLayer` in the map uses the "USA" map service as its data source. This service is hosted by ArcGIS Online, and is composed of four sublayers: "states", "counties", "cities", and "highways".
-Since the `cities`, `counties`, and `states` tables all have a `POP2000` field, they can all execute a query against that attribute and a map extent.
-
 ## Relevant API
 
 * AGSArcGISMapImageLayer
 * AGSArcGISMapImageSublayer
 * AGSFeatureTable
 * AGSQueryParameters
+
+## About the data
+
+The `AGSArcGISMapImageLayer` in the map uses the "USA" map service as its data source. This service is hosted by ArcGIS Online, and is composed of four sublayers: "states", "counties", "cities", and "highways".
+Since the `cities`, `counties`, and `states` tables all have a `POP2000` field, they can all execute a query against that attribute and a map extent.
 
 ## Tags
 

--- a/arcgis-ios-sdk-samples/Layers/Raster layer (service)/README.md
+++ b/arcgis-ios-sdk-samples/Layers/Raster layer (service)/README.md
@@ -18,14 +18,14 @@ Simply launch the sample to see a raster from an image service being used on a m
 2. Create an `AGSRasterLayer` from the image service raster.
 3. Add the raster layer the the map.
 
-## About the data
-
-This sample uses a [NOAA raster image service](https://gis.ngdc.noaa.gov/arcgis/rest/services/bag_hillshades/ImageServer). The service computes a hillshade image from the depth (in meters) of U.S. coastal waters.
-
 ## Relevant API
 
 * AGSmageServiceRaster
 * AGSRasterLayer
+
+## About the data
+
+This sample uses a [NOAA raster image service](https://gis.ngdc.noaa.gov/arcgis/rest/services/bag_hillshades/ImageServer). The service computes a hillshade image from the depth (in meters) of U.S. coastal waters.
 
 ## Tags
 

--- a/arcgis-ios-sdk-samples/Layers/WMS layer (URL)/README.md
+++ b/arcgis-ios-sdk-samples/Layers/WMS layer (URL)/README.md
@@ -18,15 +18,15 @@ The map will load automatically when the sample is opened. Pan and zoom to explo
     **Note**: The name comes from the `Name` property, not the `Title` property. On many services, the title is human-readable while the name is a numeric identifier.
 2. After the `AGSWMSLayer` loads, add it to the map's `operationalLayers` array.
 
-## About the data
-
-This sample uses a [U.S. National Weather Service radar map](https://nowcoast.noaa.gov/arcgis/services/nowcoast/radar_meteo_imagery_nexrad_time/MapServer/WMSServer?request=GetCapabilities&service=WMS). Because WMS services generate map images on-the-fly, this layer is always up-to-date with the latest [NOAA NEXRAD radar](https://www.ncdc.noaa.gov/data-access/radar-data/nexrad) observations.
-
 ## Relevant API
 
 * AGSMap
 * AGSMapView
 * AGSWMSLayer
+
+## About the data
+
+This sample uses a [U.S. National Weather Service radar map](https://nowcoast.noaa.gov/arcgis/services/nowcoast/radar_meteo_imagery_nexrad_time/MapServer/WMSServer?request=GetCapabilities&service=WMS). Because WMS services generate map images on-the-fly, this layer is always up-to-date with the latest [NOAA NEXRAD radar](https://www.ncdc.noaa.gov/data-access/radar-data/nexrad) observations.
 
 ## Tags
 

--- a/arcgis-ios-sdk-samples/Route & Directions/Offline routing/README.md
+++ b/arcgis-ios-sdk-samples/Route & Directions/Offline routing/README.md
@@ -22,14 +22,6 @@ Tap near a road to start adding a stop to the route, tap again to place it on th
 5. Solve the route using `AGSRouteTask.solveRoute(with:completion:)` to get an `AGSRouteResult`.
 6. Create a graphic with the route's geometry and a `AGSSimpleLineSymbol` and display it on another `AGSGraphicsOverlay`.
 
-## Offline data
-
-The data used by this sample is available on [ArcGIS Online](https://arcgisruntime.maps.arcgis.com/home/item.html?id=567e14f3420d40c5a206e5c0284cf8fc).
-
-## About the data
-
-This sample uses a pre-packaged sample dataset consisting of a geodatabase with a San Diego road network and a tile package with a streets basemap.
-
 ## Relevant API
 
 * AGSRouteParameters
@@ -37,6 +29,14 @@ This sample uses a pre-packaged sample dataset consisting of a geodatabase with 
 * AGSRouteTask
 * AGSStop
 * AGSTravelMode
+
+## Offline data
+
+The data used by this sample is available on [ArcGIS Online](https://arcgisruntime.maps.arcgis.com/home/item.html?id=567e14f3420d40c5a206e5c0284cf8fc).
+
+## About the data
+
+This sample uses a pre-packaged sample dataset consisting of a geodatabase with a San Diego road network and a tile package with a streets basemap.
 
 ## Tags
 

--- a/arcgis-ios-sdk-samples/Scenes/Scene layer (URL)/README.md
+++ b/arcgis-ios-sdk-samples/Scenes/Scene layer (URL)/README.md
@@ -20,15 +20,15 @@ Pan and zoom to explore the scene.
 4. Apply the surface to the scene.
 5. Create an `AGSArcGISSceneLayer` with a URL and add it to the scene's `operationalLayers` array.
 
-## About the data
-
-This sample shows a [Brest, France Scene](https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0) hosted on ArcGIS Online.
-
 ## Relevant API
 
 * AGSArcGISSceneLayer
 * AGSScene
 * AGSSceneView
+
+## About the data
+
+This sample shows a [Brest, France Scene](https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0) hosted on ArcGIS Online.
 
 ## Tags
 

--- a/arcgis-ios-sdk-samples/Search/Find place/README.md
+++ b/arcgis-ios-sdk-samples/Search/Find place/README.md
@@ -32,10 +32,6 @@ Choose a type of place in the first field and an area to search within in the se
     * Call `AGSLocatorTask.geocode(withSearchText:parameters:completion:)` to get a list of `AGSGeocodeResult`s.
     * Display the places of interest using the results' `AGSGeocodeResult.displayLocation`s.
 
-## About the data
-
-This sample uses the [world locator service](https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer).
-
 ## Relevant API
 
 * AGSGeocodeParameters
@@ -43,6 +39,10 @@ This sample uses the [world locator service](https://geocode.arcgis.com/arcgis/r
 * AGSLocatorTask
 * AGSSuggestParameters
 * AGSSuggestResult
+
+## About the data
+
+This sample uses the [world locator service](https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer).
 
 ## Tags
 


### PR DESCRIPTION
According to README style wiki, the section headers/sections should follow a certain order.
This PR fixes all the sections that are not in correct order in READMEs.
Reordering the sections and running the check yields no error.
