### PR TITLE
Hotfix: wrong category and duplicate entry on developer site

### DIFF
--- a/arcgis-ios-sdk-samples/Edit data/Offline edit and sync/README.metadata.json
+++ b/arcgis-ios-sdk-samples/Edit data/Offline edit and sync/README.metadata.json
@@ -49,5 +49,5 @@
         "FeatureLayersViewController.swift",
         "OfflineEditingViewController.swift"
     ],
-    "title": "Edit and sync features"
+    "title": "Offline edit and sync"
 }

--- a/arcgis-ios-sdk-samples/Route & Directions/Find closest facility to an incident (interactive)/README.metadata.json
+++ b/arcgis-ios-sdk-samples/Route & Directions/Find closest facility to an incident (interactive)/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Routing & Directions",
+    "category": "Routing and Directions",
     "description": "Find a route to the closest facility from a location.",
     "ignore": false,
     "images": [


### PR DESCRIPTION
ref: /runtime/common-samples/issues/2006

These 2 issues have been fixed in #888 on `philium/readme-updates` branch. However, in today's mtg, Mike suggested that they should be fixed ASAP as a hotfix on master branch, to avoid keeping looking bad until we merge the whole update.

Therefore, I made this hotfix to mitigate the issues in metadata, so that they can be fixed on developer site during the weekly build.