### PR TITLE
Hotfix: wrong category in metadata

### DIFF
--- a/arcgis-ios-sdk-samples/Route & Directions/Find closest facility to an incident (interactive)/README.metadata.json
+++ b/arcgis-ios-sdk-samples/Route & Directions/Find closest facility to an incident (interactive)/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Routing and Directions",
+    "category": "Route and Directions",
     "description": "Find a route to the closest facility from a location.",
     "ignore": false,
     "images": [


### PR DESCRIPTION
An issue causing the site not to render correctly. See image below

![image](https://user-images.githubusercontent.com/9660181/88321367-e62b8900-ccd3-11ea-8d09-8a654ffd59e2.png)
