### PR TITLE
Fix: deprecation warnings

### DIFF
--- a/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/NavigateARNavigatorViewController.swift
+++ b/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/NavigateARNavigatorViewController.swift
@@ -157,7 +157,7 @@ class NavigateARNavigatorViewController: UIViewController {
     // MARK: Actions
     
     @IBAction func startTurnByTurn(_ sender: UIBarButtonItem) {
-        routeTracker = AGSRouteTracker(routeResult: routeResult, routeIndex: 0)
+        routeTracker = AGSRouteTracker(routeResult: routeResult, routeIndex: 0, skipCoincidentStops: true)
         if routeTask.routeTaskInfo().supportsRerouting {
             routeTracker?.enableRerouting(with: routeTask, routeParameters: routeParameters, strategy: .toNextStop, visitFirstStopOnStart: true ) { [weak self] (error: Error?) in
                 if let error = error {

--- a/arcgis-ios-sdk-samples/Route & Directions/Navigate route/NavigateRouteViewController.swift
+++ b/arcgis-ios-sdk-samples/Route & Directions/Navigate route/NavigateRouteViewController.swift
@@ -120,7 +120,7 @@ class NavigateRouteViewController: UIViewController {
     /// - Parameter result: An `AGSRouteResult` object used to configure the route tracker.
     /// - Returns: An `AGSRouteTracker` object.
     func makeRouteTracker(result: AGSRouteResult) -> AGSRouteTracker {
-        let tracker = AGSRouteTracker(routeResult: result, routeIndex: 0)!
+        let tracker = AGSRouteTracker(routeResult: result, routeIndex: 0, skipCoincidentStops: true)!
         tracker.delegate = self
         return tracker
     }


### PR DESCRIPTION
From the latest build of the SDK, a deprecation warning pops up:

```
'init(routeResult:routeIndex:)' is deprecated: Use 'initWithRouteResult:routeIndex:skipCoincidentStops:' instead
```

After reading the doc, I set `skipCoincidentStops` to true to fix this warning, as YES was the default value for this parameter.