### PR TITLE
Bugfix: Create save KML file deleted too early

### DIFF
--- a/arcgis-ios-sdk-samples/Edit data/Create and save KML file/CreateAndSaveKMLViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Create and save KML file/CreateAndSaveKMLViewController.swift
@@ -61,8 +61,12 @@ class CreateAndSaveKMLViewController: UIViewController {
         let activityViewController = UIActivityViewController(activityItems: [kmzProvider], applicationActivities: nil)
         activityViewController.popoverPresentationController?.barButtonItem = sender
         present(activityViewController, animated: true)
-        activityViewController.completionWithItemsHandler = { (_, _, _, _) in
-            kmzProvider.deleteKMZ()
+        activityViewController.completionWithItemsHandler = { activityType, completed, returnedItems, activityError in
+            if completed {
+                kmzProvider.deleteKMZ()
+            } else if let error = activityError {
+                self.presentAlert(error: error)
+            }
         }
     }
 

--- a/arcgis-ios-sdk-samples/Edit data/Create and save KML file/CreateAndSaveKMLViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Create and save KML file/CreateAndSaveKMLViewController.swift
@@ -61,7 +61,7 @@ class CreateAndSaveKMLViewController: UIViewController {
         let activityViewController = UIActivityViewController(activityItems: [kmzProvider], applicationActivities: nil)
         activityViewController.popoverPresentationController?.barButtonItem = sender
         present(activityViewController, animated: true)
-        activityViewController.completionWithItemsHandler = { activityType, completed, returnedItems, activityError in
+        activityViewController.completionWithItemsHandler = { _, completed, _, activityError in
             if completed {
                 kmzProvider.deleteKMZ()
             } else if let error = activityError {


### PR DESCRIPTION
This PR fixes the issue in `/runtime/common-samples/issues/2150`.

In the original implementation, when the save file `UIActivityViewController` is dismissed or completed, the KML file get deleted, without considering the case where user could cancel the process. This will cause the activity VC keep popping up when tapping on save files button again, as it cannot find the file with provided path.