### PR TITLE
Fix: Animate images with image overlay slider color

### DIFF
--- a/arcgis-ios-sdk-samples/Scenes/Animate images with image overlay/AnimateImagesWithImageOverlay.storyboard
+++ b/arcgis-ios-sdk-samples/Scenes/Animate images with image overlay/AnimateImagesWithImageOverlay.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="GBY-aZ-JO5">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="GBY-aZ-JO5">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -24,7 +24,7 @@
                                 <rect key="frame" x="0.0" y="813" width="414" height="49"/>
                                 <items>
                                     <barButtonItem style="plain" id="ePe-Xd-XYS">
-                                        <slider key="customView" opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" id="G9L-es-5OQ">
+                                        <slider key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" id="G9L-es-5OQ">
                                             <rect key="frame" x="20" y="10" width="104" height="34"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <constraints>

--- a/arcgis-ios-sdk-samples/Scenes/Animate images with image overlay/AnimateImagesWithImageOverlayViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Animate images with image overlay/AnimateImagesWithImageOverlayViewController.swift
@@ -168,10 +168,10 @@ class AnimateImagesWithImageOverlayViewController: UIViewController {
         if !imagesIterator.elements.isEmpty {
             playButtonItem.isEnabled = true
             speedButtonItem.isEnabled = true
-            opacitySlider.isEnabled = true
             // Load the first frame into the scene.
             setImageFrame()
         } else {
+            opacitySlider.isEnabled = false
             presentAlert(title: "Error", message: "Fail to load images.")
         }
     }


### PR DESCRIPTION
Description: The opacity slider is embedded in a `UIBarButtonItem`. Current version sets slider's `isEnabled` property to false in storyboard, which dims its tint color to indicate it is not interactive. After enabling it in code, the color does not update, which might give wrong clues to the user that the slider is not operable.

This fix invert the settings: enable in storyboard, and disable in code if loading images failed.

Please see the comparison images below.
|Before|After|
|-|-|
|![before](https://user-images.githubusercontent.com/9660181/89583939-1274f880-d7f0-11ea-82bc-6c37399e50f5.png)|![after](https://user-images.githubusercontent.com/9660181/89583938-11dc6200-d7f0-11ea-9067-2d34247c8a44.png)|

ref: #857 