### PR TITLE
Fix selection in OptionsTableViewController

### DIFF
--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/OptionsTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/OptionsTableViewController.swift
@@ -50,7 +50,7 @@ class OptionsTableViewController: UITableViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        tableView.register(OptionCell.self, forCellReuseIdentifier: "OptionCell")
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "OptionCell")
     }
     
     // UITableViewDataSource
@@ -61,26 +61,20 @@ class OptionsTableViewController: UITableViewController {
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "OptionCell", for: indexPath)
-        cell.selectionStyle = .none
         let option = options[indexPath.row]
         cell.textLabel?.text = option.label
         cell.imageView?.image = option.image
-        if selectedIndex == indexPath.row {
-            tableView.selectRow(at: indexPath, animated: false, scrollPosition: .none)
-        }
+        cell.accessoryType = indexPath.row == selectedIndex ? .checkmark : .none
         return cell
     }
     
     // UITableViewDelegate
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let indexPathOfPreviouslySelectedRow = IndexPath(row: selectedIndex, section: indexPath.section)
+        let indexPathsToReload = [indexPathOfPreviouslySelectedRow, indexPath]
         selectedIndex = indexPath.row
+        tableView.reloadRows(at: indexPathsToReload, with: .automatic)
         onChange(indexPath.row)
-    }
-}
-
-private class OptionCell: UITableViewCell {
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        accessoryType = selected ? .checkmark : .none
     }
 }


### PR DESCRIPTION
Before | After
------ | -----
![Before](https://user-images.githubusercontent.com/2257493/91734426-c6537480-eb5f-11ea-83a7-b9173904b4ff.gif) | ![After](https://user-images.githubusercontent.com/2257493/91734442-ca7f9200-eb5f-11ea-94cc-2eb3be531725.gif)

I've never been happy with how selection was implemented in `OptionsTableViewController`. The tapped cells are not highlighted as excepted and the selection change isn't animated. This PR addresses those issues by simply reloading the previously selected row and the newly selected row. Rows are now highlighted when tapped and both the highlight and the checkmark changes are animated.