### PR TITLE
CI: Add GitHub Actions workflow and style checking tools

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,60 @@
+# The name of the job, which will be displayed for the status check in PR.
+name: README and metadata formatting
+
+# Controls when the action will run.
+# Below triggers the workflow on pull requests to `master` or `v.next` branch.
+on:
+  pull_request:
+    branches:
+      - master
+      - v.next
+
+# A workflow run is made up of one or more jobs that can run sequentially or
+# in parallel.
+jobs:
+  # This workflow contains a single job called "changes"
+  changes:
+    name: Check README and metadata format for changed files
+    
+    # Comment out the line below if the job is only running for certain labels.
+    # i.e. only run the job on PRs with label "new-sample"
+
+    # if: contains(github.event.pull_request.labels.*.name, 'new-sample')
+    
+    # The type of runner that the job will run on
+    # supported VMs are here: https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that got executed as part of the job.
+    steps:
+
+      # This step gets the paths to all changed files and returns an array
+      # such as ['xxx/README.md', 'xxx/README.metadata.json', 'xxx/1.png']
+      # https://github.com/trilom/file-changes-action
+      - id: file_changes
+        name: Detect changed file paths
+        uses: trilom/file-changes-action@master
+
+      # Checks-out your repository under $GITHUB_WORKSPACE, so the workflow can 
+      # access the files.
+      # https://github.com/actions/checkout
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      
+      # Print out changed file paths for debugging purposes.
+      - name: Print changed file paths
+        run: |
+          echo 'Below shows a list of changed file paths'
+          echo '${{ steps.file_changes.outputs.files}}'
+      #    echo '${{ steps.file_changes.outputs.files_modified}}'
+      #    echo '${{ steps.file_changes.outputs.files_added}}'
+      #    echo '${{ steps.file_changes.outputs.files_removed}}'
+
+      - name: Run style checks
+        uses: ./Scripts/CI/README_Metadata_StyleCheck
+        with:
+          FILE_PATHS: ${{ steps.file_changes.outputs.files }}
+      
+      # Runs a single command using the runners shell
+      # - name: Run a script with Python
+      #   run: python ./Scripts/README-formatter.py

--- a/Scripts/CI/README_Metadata_StyleCheck/Dockerfile
+++ b/Scripts/CI/README_Metadata_StyleCheck/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:3.12
+MAINTAINER Ting Chen <tchen@esri.com>
+ENV PYTHONUNBUFFERED=1
+# Add scripts for the check.
+ADD entry.py /entry.py
+ADD style.rb /style.rb
+ADD description_differ.py /description_differ.py
+ADD metadata_style_checker.py /metadata_style_checker.py
+ADD README_style_checker.py /README_style_checker.py
+ADD title_differ.py /title_differ.py
+# Install dependencies.
+RUN echo "**** Install Ruby and mdl ****" && \
+    apk add --update --no-cache ruby-full && \
+    gem install mdl --no-document && \
+    echo "**** Install Python ****" && \
+    apk add --no-cache python3 && \
+    if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi
+ENTRYPOINT ["python3", "/entry.py"]

--- a/Scripts/CI/README_Metadata_StyleCheck/README_style_checker.py
+++ b/Scripts/CI/README_Metadata_StyleCheck/README_style_checker.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+
+"""
+Comments in PyCharm style.
+
+References
+
+- Tag sorter by Zack
+  /common-samples/blob/master/tools/net/tag_sorter/tag_sorter.py
+
+- README standard format
+  /common-samples/wiki/Standard-sample-documentation-template-%28README.md%29
+"""
+
+import os
+import re
+import typing
+import argparse
+
+# region Global sets
+# A set of words that get omitted during letter-case checks.
+exception_proper_nouns = {
+    'WmsLayer',
+    'ArcGIS Online',
+    'OAuth',
+    'Web Mercator',
+    'ArcGIS Pro',
+    'GeoPackage',
+    'loadStatus',
+    'Integrated Windows Authentication',
+    'GeoElement',
+    'Network Link',
+    'Network Link Control',
+    'Open Street Map',
+    'OpenStreetMap',
+    'Play a KML Tour'
+}
+
+# A set of category folder names in current sample viewer.
+categories = {
+    'Maps',
+    'Layers',
+    'Features',
+    'Display information',
+    'Search',
+    'Edit data',
+    'Geometry',
+    'Route and directions',
+    'Analysis',
+    'Cloud and portal',
+    'Scenes',
+    'Utility network',
+    'Augmented reality'
+}
+# endregion
+
+
+# region Static functions
+def get_folder_name_from_path(path: str, index: int = -1) -> str:
+    """
+    Get the folder name from a full path.
+
+    :param path: A string of a full/absolute path to a folder.
+    :param index: The index of path parts. Default to -1 to get the most
+    trailing folder in the path; set to certain index to get other parts.
+    :return: The folder name.
+    """
+    return os.path.normpath(path).split(os.path.sep)[index]
+
+
+def parse_head(head_string: str) -> (str, str):
+    """
+    Parse the head of README and get title and description.
+
+    :param head_string: A string containing title, description and images.
+    :return: Stripped title and description strings.
+    """
+    # Split title section and rule out empty lines.
+    parts = list(filter(bool, head_string.splitlines()))
+    if len(parts) < 3:
+        raise Exception('README should contain title, description and image.')
+    title = parts[0].lstrip('# ').rstrip()
+    description = parts[1].strip()
+    return title, description
+
+
+def check_apis(apis_string: str) -> typing.Set[str]:
+    """
+    Check the format for `Relevant API` section.
+
+    :param apis_string: A multiline string containing all APIs.
+    :return: A set of APIs. Throws if format is wrong.
+    """
+    stripped = apis_string.strip()
+    apis = list(stripped.splitlines())
+    if not apis:
+        raise Exception('Empty Relevant APIs.')
+    s = set()
+    stripped_apis = []
+    for api in apis:
+        # Bullet is checked by the linter, no need to check here.
+        a = api.lstrip('*- ').rstrip()
+        s.add(a)
+        stripped_apis.append(a)
+        if '`' in a:
+            raise Exception('API should not include backticks.')
+    if '' in s:
+        raise Exception('Empty line in APIs.')
+    if len(apis) > len(s):
+        raise Exception('Duplicate APIs.')
+    if stripped_apis != sorted(stripped_apis, key=str.casefold):
+        raise Exception('APIs are not sorted.')
+    return s
+
+
+def check_tags(tags_string: str) -> typing.Set[str]:
+    """
+    Check the format for `Tags` section.
+
+    :param tags_string: A string containing all tags, with comma as delimiter.
+    :return: A set of tags. Throws if format is wrong.
+    """
+    tags = tags_string.split(',')
+    if not tags:
+        raise Exception('Empty tags.')
+    s = set()
+    stripped_tags = []
+    for tag in tags:
+        t = tag.strip()
+        s.add(t)
+        stripped_tags.append(t)
+        if t.lower() != t and t.upper() != t and t.capitalize() != t \
+                and t not in exception_proper_nouns:
+            raise Exception(f'Wrong letter case for tag: "{t}".')
+    if '' in s:
+        raise Exception('Empty char in tags.')
+    if ', '.join(stripped_tags) != tags_string.strip():
+        raise Exception('Extra whitespaces in tags.')
+    if len(tags) > len(s):
+        raise Exception('Duplicate tags.')
+    if stripped_tags != sorted(stripped_tags, key=str.casefold):
+        raise Exception('Tags are not sorted.')
+    return s
+
+
+def check_sentence_case(string: str) -> None:
+    """
+    Check if a sentence follows 'sentence case'. A few examples below.
+
+    Hello world! -> YES
+    I'm a good guy. -> YES
+    a man and a gun. -> NO
+    A WMS layer -> YES, as it's allowed to include proper nouns
+
+    :param string: Input sentence, typically the title string.
+    :return: None. Throws if is not sentence case.
+    """
+    # Check empty string.
+    if not string:
+        raise Exception('Empty title string.')
+    # The whole sentence get excepted.
+    if string in exception_proper_nouns:
+        return
+    # Split sentence into words.
+    words = string.split()
+    # First word should either be Title-cased or a proper noun (UPPERCASE).
+    if words[0][0].upper() != words[0][0] and words[0].upper() != words[0] \
+            and words[0] not in exception_proper_nouns:
+        raise Exception('Wrong letter case for the first word in title.')
+    # If a word is neither lowercase nor UPPERCASE then it is not great.
+    for word in words[1:]:
+        word = word.strip('()')
+        if word.lower() != word and word.upper() != word \
+                and word not in exception_proper_nouns:
+            raise Exception(f'Wrong letter case for word: "{word}" in title.')
+
+
+def check_is_subsequence(list_a: typing.List[str],
+                         list_b: typing.List[str]) -> int:
+    """
+    Check if list A is a subsequence of list B.
+    E.g.
+    list_a = ['a', 'b', 'c']
+    list_b = ['a', 'h', 'b', 'g', 'd', 'c']
+    -> returns 0, which means all elements in list_a is also in list_b
+
+    :param list_a: A list of strings, presumably the section titles of a README.
+    :param list_b: A list of strings, presumably all valid titles in order.
+    :return: 0 if list_a is subsequence of list_b.
+    """
+    # Empty list is always a subsequence of other lists.
+    if not list_a:
+        return True
+    pa = len(list_a)
+    for pb in range(len(list_b), 0, -1):
+        pa -= 1 if list_b[pb-1] == list_a[pa-1] else 0
+    return pa
+# endregion
+
+
+class ReadmeStyleChecker:
+
+    essential_headers = {
+        'Use case',
+        'How to use the sample',
+        'How it works',
+        'Relevant API',
+        'Tags'
+    }
+
+    possible_headers = [
+        'Use case',
+        'How to use the sample',
+        'How it works',
+        'Relevant API',
+        'Offline data',
+        'About the data',
+        'Additional information',
+        'Tags'
+    ]
+
+    def __init__(self, folder_path: str):
+        self.folder_path = folder_path
+        self.folder_name = get_folder_name_from_path(folder_path)
+        self.readme_path = os.path.join(folder_path, 'README.md')
+        self.readme_contents = None
+        self.readme_parts = None
+        self.readme_headers = None
+
+    def populate_from_readme(self) -> None:
+        """
+        Read and parse the sections from README.
+
+        :return: None. Throws if exception occurs.
+        """
+        try:
+            readme_file = open(self.readme_path, 'r')
+            # read the readme content into a string
+            contents = readme_file.read()
+            # A regular expression that matches exactly 2 pound marks, and
+            # capture the trailing string.
+            pattern = re.compile(r'^#{2}(?!#)\s(.*)', re.MULTILINE)
+            self.readme_contents = contents
+            # Use regex to split the README by section headers, so that they are
+            # separated into paragraphs.
+            self.readme_parts = re.split(pattern, contents)
+            # Capture the section headers.
+            self.readme_headers = re.findall(pattern, contents)
+        except Exception as err:
+            raise Exception(f'Error loading file - {self.readme_path} - {err}.')
+        else:
+            readme_file.close()
+
+    def check_format_heading(self) -> None:
+        """
+        Check if
+        1. essential section headers present.
+        2. all sections are valid.
+        3. section headers are in correct order.
+
+        :return: None. Throws if exception occurs.
+        """
+        header_set = set(self.readme_headers)
+        possible_header_set = set(self.possible_headers)
+        # Check if all sections are valid.
+        sets_diff = header_set - possible_header_set
+        if sets_diff:
+            raise Exception(
+                f'Error header - Unexpected header or extra whitespace'
+                f' - "{sets_diff}".')
+        # Check if all essential section headers present.
+        sets_diff = self.essential_headers - header_set
+        if sets_diff:
+            raise Exception(
+                f'Error header - Missing essential header(s) - "{sets_diff}".')
+        # Check if all sections are in correct order.
+        index = check_is_subsequence(self.readme_headers, self.possible_headers)
+        if index:
+            raise Exception(
+                f'Error header - Wrong order at - '
+                f'"{self.readme_headers[index-1]}".')
+
+    def check_format_title_section(self) -> None:
+        """
+        Check if
+        1. the head has at least 3 parts (title, description and image URLs).
+        2. the title string uses sentence case.
+
+        :return: None. Throws if exception occurs.
+        """
+        try:
+            title, _ = parse_head(self.readme_parts[0])
+            check_sentence_case(title)
+        except Exception as err:
+            raise Exception(f'Error title - {err}')
+
+    def check_format_apis(self) -> None:
+        """
+        Check if APIs
+        1. do not have backticks.
+        2. are sorted.
+        3. do not have duplicate entries.
+
+        :return: None. Throws if exception occurs.
+        """
+        try:
+            api_section_index = self.readme_parts.index('Relevant API') + 1
+            check_apis(self.readme_parts[api_section_index])
+        except Exception as err:
+            raise Exception(f'Error APIs - {err}')
+
+    def check_format_tags(self) -> None:
+        """
+        Check if tags
+        1. are in correct case.
+        2. are sorted.
+        3. do not have duplicate entries.
+
+        :return: None. Throws if exception occurs.
+        """
+        try:
+            tags_section_index = self.readme_parts.index('Tags') + 1
+            check_tags(self.readme_parts[tags_section_index])
+        except Exception as err:
+            raise Exception(f'Error tags - {err}')
+
+    def check_redundant_apis_in_tags(self) -> None:
+        """
+        Check if APIs and tags intersect.
+
+        :return: None. Throws if exception occurs.
+        """
+        try:
+            tags_section_index = self.readme_parts.index('Tags') + 1
+            api_section_index = self.readme_parts.index('Relevant API') + 1
+            api_set = check_apis(self.readme_parts[api_section_index])
+            tag_set = check_tags(self.readme_parts[tags_section_index])
+            if not api_set.isdisjoint(tag_set):
+                raise Exception(f'Error tags - API should not be in tags')
+        except Exception as err:
+            raise Exception(f'Error checking extra tags due to previous error')
+
+
+# region Main wrapper functions
+def run_check(path: str, count: int) -> int:
+    checker = ReadmeStyleChecker(path)
+    # 1. Populate from README.
+    try:
+        checker.populate_from_readme()
+    except Exception as err:
+        count += 1
+        print(f'{count}. {checker.folder_path} - {err}')
+    # 2. Check format of headings, e.g. 'Use case', 'How it works', etc.
+    try:
+        checker.check_format_heading()
+    except Exception as err:
+        count += 1
+        print(f'{count}. {checker.folder_path} - {err}')
+    # 3. Check format of title section, i.e. title, description and image URLs.
+    try:
+        checker.check_format_title_section()
+    except Exception as err:
+        count += 1
+        print(f'{count}. {checker.folder_path} - {err}')
+    # 4. Check format of relevant APIs.
+    try:
+        checker.check_format_apis()
+    except Exception as err:
+        count += 1
+        print(f'{count}. {checker.folder_path} - {err}')
+    # 5. Check format of tags.
+    try:
+        checker.check_format_tags()
+    except Exception as err:
+        count += 1
+        print(f'{count}. {checker.folder_path} - {err}')
+    # 6. Check if redundant APIs in tags
+    try:
+        checker.check_redundant_apis_in_tags()
+    except Exception as err:
+        count += 1
+        print(f'{count}. {checker.folder_path} - {err}')
+    return count
+
+
+def single(path: str):
+    exception_count = run_check(path, 0)
+    # Throw once if there are exceptions.
+    if exception_count > 0:
+        raise Exception('Error(s) occurred during checking a single design.')
+
+
+def all_designs(path: str):
+    exception_count = 0
+    for root, dirs, files in os.walk(path):
+        # Get parent folder name.
+        parent_folder_name = get_folder_name_from_path(root)
+        # If parent folder name is a valid category name.
+        if parent_folder_name in categories:
+            for dir_name in dirs:
+                sample_path = os.path.join(root, dir_name)
+                # Omit empty folders - they are omitted by Git.
+                if len([f for f in os.listdir(sample_path)
+                        if not f.startswith('.DS_Store')]) == 0:
+                    continue
+                exception_count = run_check(sample_path, exception_count)
+
+    # Throw once if there are exceptions.
+    if exception_count > 0:
+        raise Exception('Error(s) occurred during checking all samples.')
+
+
+def main():
+
+    msg = 'README checker script. Run it against the /arcgis-ios-sdk-samples ' \
+          'folder or a single sample folder. ' \
+          'On success: Script will exit with zero. ' \
+          'On failure: Style violations will print to console and the script ' \
+          'will exit with non-zero code.'
+    parser = argparse.ArgumentParser(description=msg)
+    parser.add_argument('-a', '--all', help='path to project root folder')
+    parser.add_argument('-s', '--single', help='path to a sample folder')
+    args = parser.parse_args()
+    if args.all:
+        try:
+            all_designs(args.all)
+        except Exception as err:
+            raise err
+    elif args.single:
+        try:
+            single(args.single)
+        except Exception as err:
+            raise err
+    else:
+        raise Exception('Invalid arguments, abort.')
+# endregion
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception as error:
+        print(f'{error}')
+        # Abort with failure if any exception occurs.
+        exit(1)

--- a/Scripts/CI/README_Metadata_StyleCheck/action.yml
+++ b/Scripts/CI/README_Metadata_StyleCheck/action.yml
@@ -1,0 +1,20 @@
+# The name of the stepm just as a reference.
+name: "mdl and Python style checks"
+description: "This check will run several scripts to ensure the formatting."
+author: "tchen@esri.com"
+
+inputs:
+  FILE_PATHS:
+    description: "Files to run the checks on."
+    required: true
+
+runs:
+  using: "docker"
+  image: "Dockerfile"
+  args:
+    - "-s"
+    - ${{ inputs.FILE_PATHS }}
+
+branding:
+  icon: "mic"
+  color: "purple"

--- a/Scripts/CI/README_Metadata_StyleCheck/action.yml
+++ b/Scripts/CI/README_Metadata_StyleCheck/action.yml
@@ -14,7 +14,3 @@ runs:
   args:
     - "-s"
     - ${{ inputs.FILE_PATHS }}
-
-branding:
-  icon: "mic"
-  color: "purple"

--- a/Scripts/CI/README_Metadata_StyleCheck/action.yml
+++ b/Scripts/CI/README_Metadata_StyleCheck/action.yml
@@ -12,5 +12,5 @@ runs:
   using: "docker"
   image: "Dockerfile"
   args:
-    - "-s"
+    - "--string"
     - ${{ inputs.FILE_PATHS }}

--- a/Scripts/CI/README_Metadata_StyleCheck/description_differ.py
+++ b/Scripts/CI/README_Metadata_StyleCheck/description_differ.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import json
+import plistlib
+import argparse
+from typing import List
+
+
+# region Global sets
+# A set of category folder names in current sample viewer.
+categories = {
+    'Maps',
+    'Layers',
+    'Features',
+    'Display information',
+    'Search',
+    'Edit data',
+    'Geometry',
+    'Route and directions',
+    'Analysis',
+    'Cloud and portal',
+    'Scenes',
+    'Utility network',
+    'Augmented reality'
+}
+
+excluded_samples = {
+    'Map loaded',
+    'Animate 3D graphic',
+    'Densify and generalize',
+    'Add graphics with renderer'
+}
+# endregion
+
+
+# region Static functions
+def sub_special_char(string: str) -> str:
+    """
+    Check and substitute if a string contains special characters.
+
+    :param string: The input string.
+    :return: A new string without special characters.
+    """
+    # regex = re.compile('[@_!#$%^&*()<>?/\\|}{~:]')
+    regex = re.compile('[@_!#$%^&*<>?|/\\}{~:]')
+    return re.sub(regex, '', string)
+
+
+def get_plist_cat_mapping(plist_category: str) -> str:
+    """
+    Get the mapping between plist categories and the ones on website.
+
+    :param plist_category: The category in `ContentPlist.plist`.
+    :return: The category in `README.metadata.json` files, which also defines
+             the online categories on
+             https://developers.arcgis.com/ios/latest/swift/sample-code/
+    """
+    plist_json_categories_mapping = {
+        'Maps': 'Maps',
+        'Layers': 'Layers',
+        'Features': 'Features',
+        'Display Information': 'Display information',
+        'Search': 'Search',
+        'Edit Data': 'Edit data',
+        'Geometry': 'Geometry',
+        'Route & Directions': 'Route and directions',
+        'Analysis': 'Analysis',
+        'Cloud & Portal': 'Cloud and portal',
+        'Scenes': 'Scenes',
+        'Utility Network': 'Utility network',
+        'Augmented Reality': 'Augmented reality'
+    }
+    return plist_json_categories_mapping.get(plist_category)
+
+
+def load_plist(plist_path: str) -> List[dict]:
+    """
+    Open a plist file.
+
+    :param plist_path: The path to plist file.
+    :return: The plist dictionary. In our particular case is a list of dicts.
+    """
+    with open(plist_path, 'rb') as fp:
+        plist = plistlib.load(fp)
+        return plist
+
+
+def get_plist_categories(plist: List[dict]) -> List[str]:
+    """
+    A helper function to get all categories in our plist.
+
+    :param plist: The plist dictionary.
+    :return: A list of categories.
+    """
+    plist_categories = [cat.get('displayName') for cat in plist]
+    return plist_categories
+
+
+def get_folder_name_from_path(path: str, index: int = -1) -> str:
+    """
+    Get the folder name from a full path.
+
+    :param path: A string of a full/absolute path to a folder.
+    :param index: The index of path parts. Default to -1 to get the most
+    trailing folder in the path; set to certain index to get other parts.
+    :return: The folder name.
+    """
+    return os.path.normpath(path).split(os.path.sep)[index]
+
+
+def get_readme_description(head_string: str) -> str:
+    """
+    Parse the head of README and get description.
+
+    :param head_string: A string containing title, description and images.
+    :return: Stripped description string.
+    """
+    # Split title section and rule out empty lines.
+    parts = list(filter(bool, head_string.splitlines()))
+    if len(parts) < 3:
+        raise Exception('README should contain title, description and image.')
+    description = parts[1].strip()
+    return description
+
+
+def get_first_sentence(s: str) -> str:
+    """
+    Return the first sentence separated by period in a string.
+
+    :param s: A string.
+    :return: A sentence.
+    """
+    return sub_special_char(s.split('.')[0] + '.')
+# endregion
+
+
+class Sample:
+    def __init__(self, folder_path: str):
+        """
+        Given a folder path of a sample, get everything we need to compare.
+        - Descriptions
+          - sample’s plist description
+          - sample’s `README.md` description
+          - `README.metadata.json` description
+
+        :param folder_path: The path to a sample's folder.
+        """
+        self.folder_path = folder_path
+        self.folder_name = get_folder_name_from_path(folder_path)
+        self.folder_category = get_folder_name_from_path(folder_path, -2)
+
+        self.json_description = self.get_json_description()
+        self.readme_description = self.get_readme_description()
+
+    def get_json_description(self) -> str:
+        json_path = os.path.join(self.folder_path, 'README.metadata.json')
+        try:
+            json_file = open(json_path, 'r')
+            json_data = json.load(json_file)
+        except Exception as err:
+            print(f'Error reading JSON - {self.folder_name} - {err}')
+            raise err
+        else:
+            json_file.close()
+        return json_data['description']
+
+    def get_readme_description(self):
+        readme_path = os.path.join(self.folder_path, 'README.md')
+        try:
+            readme_file = open(readme_path, 'r')
+            # read the readme content into a string
+            readme_contents = readme_file.read()
+        except Exception as err:
+            print(f'Error reading README - {self.folder_name} - {err}.')
+            raise err
+        else:
+            readme_file.close()
+        pattern = re.compile(r'^#{2}(?!#)\s(.*)', re.MULTILINE)
+        readme_parts = re.split(pattern, readme_contents)
+        return get_readme_description(readme_parts[0])
+
+
+# region Main wrapper functions
+def single_sample_check_diff(folder_path: str, plist: List[dict]):
+    sample = Sample(folder_path)
+    if sample.folder_name in excluded_samples:
+        # Deliberately omit a few samples.
+        return
+    # Get category for a sample
+    plist_cats = list(
+        filter(lambda d: get_plist_cat_mapping(d.get('displayName')) ==
+               sample.folder_category, plist))
+    # Get the children, a list of sample dicts.
+    plist_children: List[dict] = plist_cats[0].get('children')
+    # Get sample item dictionary.
+    plist_names = list(
+        filter(lambda d: d.get('displayName') == sample.folder_name,
+               plist_children))
+    plist_description = plist_names[0].get('descriptionText')
+
+    err_count = 0
+    p = plist_description
+    # Check if plist description matches sample README description.
+    r = sample.readme_description
+    if p != r and p != get_first_sentence(r):
+        err_count += 1
+        print(f'  {err_count}. plist "{p}" does not match'
+              f' README description "{r}".')
+    # Check if plist description matches sample json.description.
+    j = sample.json_description
+    if p != j and p != get_first_sentence(j):
+        err_count += 1
+        print(f'  {err_count}. plist "{p}" does not match'
+              f' json.description "{j}".')
+
+    if err_count > 0:
+        raise Exception(f'{err_count} error(s) occurred during checking '
+                        f'/{sample.folder_category} - {sample.folder_name}.')
+
+
+def all_samples(path: str, plist: List[dict]):
+    """
+    Run the check on all samples.
+
+    :param path: The path to 'arcgis-ios-sdk-samples' folder.
+    :param plist: The plist dictionary. In our case is a list of dicts.
+    :return: None. Throws if exception occurs.
+    """
+    exception_count = 0
+    for root, dirs, files in os.walk(path):
+        # Get parent folder name.
+        parent_folder_name = get_folder_name_from_path(root)
+        # If parent folder name is a valid category name.
+        if parent_folder_name in categories:
+            for dir_name in dirs:
+                sample_path = os.path.join(root, dir_name)
+                # Omit empty folders - they are omitted by Git.
+                if len([f for f in os.listdir(sample_path)
+                        if not f.startswith('.DS_Store')]) == 0:
+                    continue
+                try:
+                    single_sample(sample_path, plist)
+                except Exception as err:
+                    exception_count += 1
+                    print(f'{exception_count}. {err}')
+
+    # Throw once if there are exceptions.
+    if exception_count > 0:
+        raise Exception('Error(s) occurred during checking all samples.')
+
+
+def single_sample(path: str, plist: List[dict]):
+    """
+    Run the check on a single sample.
+
+    :param path: The path to a sample's folder.
+    :param plist: The plist dictionary. In our case is a list of dicts.
+    :return: None. Throws if exception occurs.
+    """
+    try:
+        single_sample_check_diff(path, plist)
+    except Exception as err:
+        raise err
+
+
+def main():
+    msg = 'Description checker script. Run it against the ' \
+          '/arcgis-ios-sdk-samples folder or a single sample folder. ' \
+          'On success: Script will exit with zero. ' \
+          'On failure: Title inconsistency will print to console and the ' \
+          'script will exit with non-zero code.'
+    parser = argparse.ArgumentParser(description=msg)
+    parser.add_argument('-a', '--all', help='path to arcgis-ios-sdk-samples '
+                                            'folder')
+    parser.add_argument('-s', '--single', help='path to single sample folder.')
+    args = parser.parse_args()
+
+    if args.all:
+        # Load ContentPList.plist.
+        plist_path = os.path.normpath(
+            args.all + '/Content Display Logic/ContentPList.plist')
+        plist = load_plist(plist_path)
+        if not plist:
+            raise Exception('Error loading plist.')
+
+        try:
+            all_samples(args.all, plist)
+        except Exception as err:
+            raise err
+    elif args.single:
+        # Load ContentPList.plist.
+        plist_path = os.path.normpath(
+            args.single + '/../../Content Display Logic/ContentPList.plist')
+        plist = load_plist(plist_path)
+        if not plist:
+            raise Exception('Error loading plist.')
+
+        try:
+            single_sample(args.single, plist)
+        except Exception as err:
+            raise err
+    else:
+        raise Exception('Invalid arguments, abort.')
+# endregion
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception as error:
+        print(f'{error}')
+        exit(1)

--- a/Scripts/CI/README_Metadata_StyleCheck/description_differ.py
+++ b/Scripts/CI/README_Metadata_StyleCheck/description_differ.py
@@ -269,8 +269,8 @@ def main():
     msg = 'Description checker script. Run it against the ' \
           '/arcgis-ios-sdk-samples folder or a single sample folder. ' \
           'On success: Script will exit with zero. ' \
-          'On failure: Title inconsistency will print to console and the ' \
-          'script will exit with non-zero code.'
+          'On failure: Description inconsistency will print to console and ' \
+          'the script will exit with non-zero code.'
     parser = argparse.ArgumentParser(description=msg)
     parser.add_argument('-a', '--all', help='path to arcgis-ios-sdk-samples '
                                             'folder')

--- a/Scripts/CI/README_Metadata_StyleCheck/entry.py
+++ b/Scripts/CI/README_Metadata_StyleCheck/entry.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+
+import os
+import json
+import argparse
+import subprocess as sp
+
+# A set of category folder names in current sample viewer.
+# Only run the checks when a file path is within one of these category folders.
+categories = {
+    'Maps',
+    'Layers',
+    'Features',
+    'Display information',
+    'Search',
+    'Edit data',
+    'Geometry',
+    'Route and directions',
+    'Analysis',
+    'Cloud and portal',
+    'Scenes',
+    'Utility network',
+    'Augmented reality'
+}
+
+
+def run_mdl(readme_path: str):
+    print("**** mdl ****")
+    code = sp.call(f'mdl --style /style.rb "{readme_path}"', shell=True)
+    return code
+
+
+def run_style_check(dirname: str):
+    print("**** README_style_checker ****")
+    code1 = sp.call(f'python3 /README_style_checker.py -s "{dirname}"', shell=True)
+    print("**** title_differ ****")
+    code2 = sp.call(f'python3 /title_differ.py -s "{dirname}"', shell=True)
+    print("**** description_differ ****")
+    code3 = sp.call(f'python3 /description_differ.py -s "{dirname}"', shell=True)
+    print("**** metadata_style_checker ****")
+    code4 = sp.call(f'python3 /metadata_style_checker.py -s "{dirname}"', shell=True)
+    return code1 + code2 + code3 + code4
+
+
+def read_json(filenames_json_data):
+    return [filename for filename in filenames_json_data]
+
+
+def load_json_file(path: str):
+    try:
+        json_file = open(path, 'r')
+        json_data = json.load(json_file)
+    except Exception as err:
+        print(f'Error reading JSON - {path} - {err}')
+        raise err
+    else:
+        json_file.close()
+    return json_data
+
+
+def main():
+    msg = 'Entry point of the docker to run mdl and style check scripts.'
+    parser = argparse.ArgumentParser(description=msg)
+    parser.add_argument('-s', '--string', help='A JSON array of file paths.')
+    args = parser.parse_args()
+    files = None
+
+    print("** Starting checks **")
+    if args.string:
+        files = read_json(json.loads(args.string))
+        if not files:
+            print('Invalid input file paths string, abort.')
+            exit(1)
+    else:
+        print('Invalid arguments, abort.')
+        exit(1)
+
+    return_code = 0
+    # A set of dirname strings to avoid duplicate checks on the same sample.
+    samples_set = set()
+
+    for f in files:
+        if not os.path.exists(f):
+            # The changed file is deleted, no need to style check.
+            continue
+
+        path_parts = os.path.normpath(f).split(os.path.sep)
+
+        if len(path_parts) < 3:
+            # A file not in samples folder, omit.
+            # E.g. might be in the root folder or other unrelated folders.
+            continue
+
+        # Only run checks on folders that is within a category.
+        if path_parts[-3] not in categories:
+            # Folder name is not a category, omit.
+            continue
+
+        # Get filename and folder name of the changed sample.
+        filename = os.path.basename(f)
+        dir_path = os.path.dirname(f)
+        l_name = filename.lower()
+
+        # Changed file is not a README or metadata file, omit.
+        if l_name != 'readme.md' and l_name != 'readme.metadata.json':
+            continue
+
+        # Print debug information for current sample.
+        if dir_path not in samples_set:
+            print(f'*** Checking {dir_path} ***')
+
+        # Check if the capitalization of doc filenames are correct.
+        if l_name == 'readme.md' and filename != 'README.md':
+            print(f'Error: {dir_path} filename has wrong capitalization')
+            return_code += 1
+
+        if l_name == 'readme.metadata.json' and filename != 'README.metadata.json':
+            print(f'Error: {dir_path} filename has wrong capitalization')
+            return_code += 1
+
+        # Run the markdownlint linter on README file.
+        if filename == 'README.md':
+            # Run the linter on markdown file.
+            return_code += run_mdl(f)
+
+        # Run the other Python checks on the whole sample folder.
+        if dir_path not in samples_set:
+            samples_set.add(dir_path)
+            return_code += run_style_check(dir_path)
+
+    if return_code != 0:
+        # Non-zero code occurred during the process.
+        exit(return_code)
+    else:
+        exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/Scripts/CI/README_Metadata_StyleCheck/metadata_style_checker.py
+++ b/Scripts/CI/README_Metadata_StyleCheck/metadata_style_checker.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import json
+import typing
+import argparse
+
+
+# region Global sets
+# A set of category folder names in current sample viewer.
+categories = {
+    'Maps',
+    'Layers',
+    'Features',
+    'Display information',
+    'Search',
+    'Edit data',
+    'Geometry',
+    'Route and directions',
+    'Analysis',
+    'Cloud and portal',
+    'Scenes',
+    'Utility network',
+    'Augmented reality'
+}
+# endregion
+
+
+# region Static functions
+def sub_special_char(string: str) -> str:
+    """
+    Check and substitute if a string contains special characters.
+
+    :param string: The input string.
+    :return: A new string without special characters.
+    """
+    # regex = re.compile('[@_!#$%^&*()<>?/\\|}{~:]')
+    regex = re.compile(r'[@_!#$%^&*<>?|/\\}{~:]')
+    return re.sub(regex, '', string)
+
+
+def parse_head(head_string: str) -> (str, str):
+    """
+    Parse the `Title` section of README file and get the title and description.
+
+    :param head_string: A string containing title, description and images.
+    :return: Stripped title and description strings.
+    """
+    parts = list(filter(bool, head_string.splitlines()))
+    if len(parts) < 3:
+        raise Exception('README description parse failure!')
+    title = parts[0].lstrip('# ').rstrip()
+    description = parts[1].strip()
+    return title, description
+
+
+def parse_apis(apis_string: str) -> typing.List[str]:
+    """
+    Parse the `Relevant API` section and get a list of APIs.
+
+    :param apis_string: A string containing all APIs.
+    :return: A sorted list of stripped API names.
+    """
+    apis = list(filter(bool, apis_string.splitlines()))
+    if not apis:
+        raise Exception('README Relevant API parse failure!')
+    return sorted([api.lstrip('*- ').rstrip() for api in apis])
+
+
+def parse_tags(tags_string: str) -> typing.List[str]:
+    """
+    Parse the `Tags` section and get a list of tags.
+
+    :param tags_string: A string containing all tags, with comma as delimiter.
+    :return: A sorted list of stripped tags.
+    """
+    tags = tags_string.split(',')
+    if not tags:
+        raise Exception('README Tags parse failure!')
+    return sorted([tag.strip() for tag in tags])
+
+
+def get_folder_name_from_path(path: str, index: int = -1) -> str:
+    """
+    Get the folder name from a full path.
+
+    :param path: A string of a full/absolute path to a folder.
+    :param index: The index of path parts. Default to -1 to get the most
+    trailing folder in the path; set to certain index to get other parts.
+    :return: The folder name.
+    """
+    return os.path.normpath(path).split(os.path.sep)[index]
+# endregion
+
+
+class MetadataCreator:
+
+    def __init__(self, folder_path: str):
+        """
+        The standard format of metadata.json for iOS platform. Read more at:
+        https://devtopia.esri.com/runtime/common-samples/wiki/README.metadata.json
+        """
+        self.category = ''          # Populate from path.
+        self.description = ''       # Populate from README.
+        self.ignore = False         # Default to False.
+        self.images = []            # Populate from paths.
+        self.keywords = []          # Populate from README.
+        self.redirect_from = []     # Default to empty list.
+        self.relevant_apis = []     # Populate from README.
+        self.snippets = []          # Populate from paths.
+        self.title = ''             # Populate from README.
+
+        self.folder_path = folder_path
+        self.folder_name = get_folder_name_from_path(folder_path)
+        self.readme_path = os.path.join(folder_path, 'README.md')
+        self.json_path = os.path.join(folder_path, 'README.metadata.json')
+
+    def get_source_code_paths(self) -> typing.List[str]:
+        """
+        Traverse the directory and get all filenames for source code.
+
+        :return: A list of swift source code filenames.
+        """
+        results = []
+        for file in os.listdir(self.folder_path):
+            if os.path.splitext(file)[1] in ['.swift']:
+                results.append(file)
+        if not results:
+            raise Exception('Unable to get swift source code paths.')
+        return sorted(results)
+
+    def get_images_paths(self):
+        """
+        Traverse the directory and get all filenames for images.
+
+        :return: A list of image filenames.
+        """
+        results = []
+        for file in os.listdir(self.folder_path):
+            if os.path.splitext(file)[1].lower() in ['.png']:
+                results.append(file)
+        if not results:
+            raise Exception('Unable to get images paths.')
+        return sorted(results)
+
+    def populate_from_readme(self) -> None:
+        """
+        Read and parse the sections from README, and fill in the 'title',
+        'description', 'relevant_apis' and 'keywords' fields in the dictionary
+        for output json.
+        """
+        try:
+            readme_file = open(self.readme_path, 'r')
+            # read the readme content into a string
+            readme_contents = readme_file.read()
+        except Exception as err:
+            print(f"Error reading README - {self.readme_path} - {err}.")
+            raise err
+        else:
+            readme_file.close()
+
+        # Use regex to split the README by exactly 2 pound marks, so that they
+        # are separated into paragraphs.
+        pattern = re.compile(r'^#{2}(?!#)\s(.*)', re.MULTILINE)
+        readme_parts = re.split(pattern, readme_contents)
+        try:
+            api_section_index = readme_parts.index('Relevant API') + 1
+            tags_section_index = readme_parts.index('Tags') + 1
+            self.title, self.description = parse_head(readme_parts[0])
+            self.relevant_apis = parse_apis(readme_parts[api_section_index])
+            keywords = parse_tags(readme_parts[tags_section_index])
+            # De-duplicate API names in README's Tags section.
+            self.keywords = [w for w in keywords if w not in self.relevant_apis]
+
+            # "It combines the Tags and the Relevant APIs in the README."
+            # See /runtime/common-samples/wiki/README.metadata.json#keywords
+            self.keywords += self.relevant_apis
+            # self.keywords.sort(key=str.casefold)
+        except Exception as err:
+            print(f'Error parsing README - {self.readme_path} - {err}.')
+            raise err
+
+    def populate_from_paths(self) -> None:
+        """
+        Populate category name, source code and image filenames from a sample's
+        folder.
+        """
+        self.category = get_folder_name_from_path(self.folder_path, -2)
+        try:
+            self.images = self.get_images_paths()
+            self.snippets = self.get_source_code_paths()
+        except Exception as err:
+            print(f"Error parsing paths - {self.folder_name} - {err}.")
+            raise err
+
+    def flush_to_json_string(self) -> str:
+        """
+        Write the metadata to a json string.
+        """
+        data = dict()
+
+        data["category"] = self.category
+        data["description"] = self.description
+        data["ignore"] = self.ignore
+        data["images"] = self.images
+        data["keywords"] = self.keywords
+        data["redirect_from"] = self.redirect_from
+        data["relevant_apis"] = self.relevant_apis
+        data["snippets"] = self.snippets
+        data["title"] = self.title
+
+        return json.dumps(data, indent=4, sort_keys=True)
+
+
+def compare_one_metadata(folder_path: str):
+    """
+    A handy helper function to create 1 sample's metadata by running the script
+    without passing in arguments, and write to a separate json for comparison.
+
+    The path may look like
+    '~/arcgis-runtime-samples-ios/arcgis-ios-sdk-samples/Maps/Display a map'
+    """
+    single_updater = MetadataCreator(folder_path)
+    try:
+        single_updater.populate_from_readme()
+        single_updater.populate_from_paths()
+    except Exception as err:
+        print(f'Error populate failed for - {single_updater.folder_name}.')
+        raise err
+
+    json_path = os.path.join(folder_path, 'README.metadata.json')
+
+    try:
+        json_file = open(json_path, 'r')
+        json_data = json.load(json_file)
+    except Exception as err:
+        print(f'Error reading JSON - {folder_path} - {err}')
+        raise err
+    else:
+        json_file.close()
+    # The special rule not to compare the redirect_from.
+    single_updater.redirect_from = json_data['redirect_from']
+
+    # The special rule to be lenient on shortened description.
+    # If the original json has a shortened/special char purged description,
+    # then no need to raise an error.
+    if json_data['description'] in sub_special_char(single_updater.description):
+        single_updater.description = json_data['description']
+    # The special rule to ignore the order of src filenames.
+    # If the original json has all the filenames, then it is good.
+    if sorted(json_data['snippets']) == single_updater.snippets:
+        single_updater.snippets = json_data['snippets']
+
+    new = single_updater.flush_to_json_string()
+    original = json.dumps(json_data, indent=4, sort_keys=True)
+    if new != original:
+        raise Exception(f'Error inconsistent metadata - {folder_path}')
+
+
+def all_samples(path: str):
+    """
+    Run the check on all samples.
+
+    :param path: The path to 'arcgis-ios-sdk-samples' folder.
+    :return: None. Throws if exception occurs.
+    """
+    exception_count = 0
+    for root, dirs, files in os.walk(path):
+        # Get parent folder name.
+        parent_folder_name = get_folder_name_from_path(root)
+        # If parent folder name is a valid category name.
+        if parent_folder_name in categories:
+            for dir_name in dirs:
+                sample_path = os.path.join(root, dir_name)
+                # Omit empty folders - they are omitted by Git.
+                if len([f for f in os.listdir(sample_path)
+                        if not f.startswith('.DS_Store')]) == 0:
+                    continue
+                try:
+                    compare_one_metadata(sample_path)
+                except Exception as err:
+                    exception_count += 1
+                    print(f'{exception_count}. {err}')
+
+    # Throw once if there are exceptions.
+    if exception_count > 0:
+        raise Exception('Error(s) occurred during checking all samples.')
+
+
+def main():
+    # Initialize parser.
+    msg = 'Check metadata style. Run it against the /arcgis-ios-sdk-samples ' \
+          'folder or a single sample folder. ' \
+          'On success: Script will exit with zero. ' \
+          'On failure: Title inconsistency will print to console and the ' \
+          'script will exit with non-zero code.'
+    parser = argparse.ArgumentParser(description=msg)
+    parser.add_argument('-a', '--all', help='path to arcgis-ios-sdk-samples '
+                                            'folder')
+    parser.add_argument('-s', '--single', help='path to a single sample')
+    args = parser.parse_args()
+
+    if args.all:
+        try:
+            all_samples(args.all)
+        except Exception as err:
+            raise err
+    elif args.single:
+        try:
+            compare_one_metadata(args.single)
+        except Exception as err:
+            raise err
+    else:
+        raise Exception('Invalid arguments, abort.')
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception as error:
+        print(f'{error}')
+        exit(1)

--- a/Scripts/CI/README_Metadata_StyleCheck/metadata_style_checker.py
+++ b/Scripts/CI/README_Metadata_StyleCheck/metadata_style_checker.py
@@ -99,7 +99,7 @@ class MetadataCreator:
     def __init__(self, folder_path: str):
         """
         The standard format of metadata.json for iOS platform. Read more at:
-        https://devtopia.esri.com/runtime/common-samples/wiki/README.metadata.json
+        /common-samples/wiki/README.metadata.json
         """
         self.category = ''          # Populate from path.
         self.description = ''       # Populate from README.

--- a/Scripts/CI/README_Metadata_StyleCheck/style.rb
+++ b/Scripts/CI/README_Metadata_StyleCheck/style.rb
@@ -1,0 +1,6 @@
+all  # opt-in all rules by default
+rule 'MD003', :style => :atx  # Header style written as non-closing pound marks. e.g. ## Section title
+rule 'MD004', :style => :asterisk  # Unordered list style as asterisk, rather than hyphen or plus sign
+rule 'MD029', :style => :ordered  # Ordered list item prefix is incremental, rather than all ones
+exclude_rule 'MD013'  # not limiting line length
+exclude_rule 'MD007'  # not limiting unordered list indentation, tab, 2 or 4 spaces are all fine

--- a/Scripts/CI/README_Metadata_StyleCheck/title_differ.py
+++ b/Scripts/CI/README_Metadata_StyleCheck/title_differ.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import json
+import plistlib
+import argparse
+from typing import List
+
+
+# region Global sets
+# A set of category folder names in current sample viewer.
+categories = {
+    'Maps',
+    'Layers',
+    'Features',
+    'Display information',
+    'Search',
+    'Edit data',
+    'Geometry',
+    'Route and directions',
+    'Analysis',
+    'Cloud and portal',
+    'Scenes',
+    'Utility network',
+    'Augmented reality'
+}
+# endregion
+
+
+# region Static functions
+def get_plist_cat_mapping(plist_category: str) -> str:
+    """
+    Get the mapping between plist categories and the ones on website.
+
+    :param plist_category: The category in `ContentPlist.plist`.
+    :return: The category in `README.metadata.json` files, which also defines
+             the online categories on
+             https://developers.arcgis.com/ios/latest/swift/sample-code/
+    """
+    plist_json_categories_mapping = {
+        'Maps': 'Maps',
+        'Layers': 'Layers',
+        'Features': 'Features',
+        'Display Information': 'Display information',
+        'Search': 'Search',
+        'Edit Data': 'Edit data',
+        'Geometry': 'Geometry',
+        'Route & Directions': 'Route and directions',
+        'Analysis': 'Analysis',
+        'Cloud & Portal': 'Cloud and portal',
+        'Scenes': 'Scenes',
+        'Utility Network': 'Utility network',
+        'Augmented Reality': 'Augmented reality'
+    }
+    return plist_json_categories_mapping.get(plist_category)
+
+
+def load_plist(plist_path: str) -> List[dict]:
+    """
+    Open a plist file.
+
+    :param plist_path: The path to plist file.
+    :return: The plist dictionary. In our particular case is a list of dicts.
+    """
+    with open(plist_path, 'rb') as fp:
+        plist = plistlib.load(fp)
+        return plist
+
+
+def get_plist_categories(plist: List[dict]) -> List[str]:
+    """
+    A helper function to get all categories in our plist.
+
+    :param plist: The plist dictionary.
+    :return: A list of categories.
+    """
+    plist_categories = [cat.get('displayName') for cat in plist]
+    return plist_categories
+
+
+def get_folder_name_from_path(path: str, index: int = -1) -> str:
+    """
+    Get the folder name from a full path.
+
+    :param path: A string of a full/absolute path to a folder.
+    :param index: The index of path parts. Default to -1 to get the most
+    trailing folder in the path; set to certain index to get other parts.
+    :return: The folder name.
+    """
+    return os.path.normpath(path).split(os.path.sep)[index]
+
+
+def get_readme_title(head_string: str) -> str:
+    """
+    Parse the head of README and get title.
+
+    :param head_string: A string containing title, description and images.
+    :return: Stripped title string.
+    """
+    # Split title section and rule out empty lines.
+    parts = list(filter(bool, head_string.splitlines()))
+    if len(parts) < 3:
+        raise Exception('README should contain title, description and image.')
+    title = parts[0].lstrip('# ').rstrip()
+    return title
+# endregion
+
+
+class SampleNames:
+    def __init__(self, folder_path: str):
+        """
+        Given a folder path of a sample, get everything we need to compare.
+        - Titles
+          - sample’s folder name
+          - sample’s `README.md` title
+          - `README.metadata.json` title
+        - Category names
+          - sample’s enclosing category folder name
+          - `README.metadata.json` category
+
+        :param folder_path: The path to a sample's folder.
+        """
+        self.folder_path = folder_path
+
+        self.folder_name = get_folder_name_from_path(folder_path)
+        self.folder_category = get_folder_name_from_path(folder_path, -2)
+
+        self.json_title, self.json_category = self.get_json_title_category()
+        self.readme_title = self.get_readme_title()
+
+    def get_json_title_category(self) -> (str, str):
+        json_path = os.path.join(self.folder_path, 'README.metadata.json')
+        try:
+            json_file = open(json_path, 'r')
+            json_data = json.load(json_file)
+        except Exception as err:
+            print(f'Error reading JSON - {self.folder_name} - {err}')
+            raise err
+        else:
+            json_file.close()
+        return json_data['title'], json_data['category']
+
+    def get_readme_title(self):
+        readme_path = os.path.join(self.folder_path, 'README.md')
+        try:
+            readme_file = open(readme_path, 'r')
+            # read the readme content into a string
+            readme_contents = readme_file.read()
+        except Exception as err:
+            print(f'Error reading README - {self.folder_name} - {err}.')
+            raise err
+        else:
+            readme_file.close()
+        pattern = re.compile(r'^#{2}(?!#)\s(.*)', re.MULTILINE)
+        readme_parts = re.split(pattern, readme_contents)
+        return get_readme_title(readme_parts[0])
+
+
+# region Main wrapper functions
+def single_sample_check_diff(folder_path: str, plist: List[dict]):
+    sample_names = SampleNames(folder_path)
+
+    # 1. Check if plist category matches category folder name.
+    #    If they don't match, no need to go further.
+    plist_cats = list(
+        filter(lambda d: get_plist_cat_mapping(d.get('displayName')) ==
+               sample_names.folder_category, plist))
+    if len(plist_cats) != 1:
+        # Nearly impossible.
+        # This happens when the category name in plist does
+        # not match any of the category folder names.
+        # Currently there are only 13 categories and it is easy to tell.
+        raise Exception(f'Error plist category does not match category folder.')
+
+    err_count = 0
+
+    # 2. Check if plist category matches json.category.
+    plist_category = plist_cats[0].get('displayName')
+    matched_category = get_plist_cat_mapping(plist_category)
+    if matched_category != sample_names.json_category:
+        err_count += 1
+        print(f'  {err_count}. plist category {matched_category} '
+              f'does not match json.category.')
+    # Get the children, a list of sample dicts.
+    plist_children: List[dict] = plist_cats[0].get('children')
+    # 3. Check if plist title matches sample folder name.
+    plist_names = list(
+        filter(lambda d: d.get('displayName') == sample_names.folder_name,
+               plist_children))
+    if len(plist_names) != 1:
+        err_count += 1
+        print(f'  {err_count}. plist title does not match folder name.')
+    else:
+        plist_name = plist_names[0].get('displayName')
+        # 4. Check if plist title matches sample README title.
+        if plist_name != sample_names.readme_title:
+            err_count += 1
+            print(f'  {err_count}. plist title "{plist_name}" does not match '
+                  f'README title "{sample_names.readme_title}".')
+        # 5. Check if plist title matches sample json.title.
+        if plist_name != sample_names.json_title:
+            err_count += 1
+            print(f'  {err_count}. plist title "{plist_name}" does not match '
+                  f'json.title "{sample_names.json_title}".')
+
+    if err_count > 0:
+        raise Exception(f'{err_count} error(s) occurred during checking '
+                        f'/{sample_names.folder_category}'
+                        f'/{sample_names.folder_name}.')
+
+
+def all_samples(path: str, plist: List[dict]):
+    """
+    Run the check on all samples.
+
+    :param path: The path to 'arcgis-ios-sdk-samples' folder.
+    :param plist: The plist dictionary. In our case is a list of dicts.
+    :return: None. Throws if exception occurs.
+    """
+    exception_count = 0
+    for root, dirs, files in os.walk(path):
+        # Get parent folder name.
+        parent_folder_name = get_folder_name_from_path(root)
+        # If parent folder name is a valid category name.
+        if parent_folder_name in categories:
+            for dir_name in dirs:
+                sample_path = os.path.join(root, dir_name)
+                # Omit empty folders - they are omitted by Git.
+                if len([f for f in os.listdir(sample_path)
+                        if not f.startswith('.DS_Store')]) == 0:
+                    continue
+                try:
+                    single_sample(sample_path, plist)
+                except Exception as err:
+                    exception_count += 1
+                    print(f'{exception_count}. {err}')
+
+    # Throw once if there are exceptions.
+    if exception_count > 0:
+        raise Exception('Error(s) occurred during checking all samples.')
+
+
+def single_sample(path: str, plist: List[dict]):
+    """
+    Run the check on a single sample.
+
+    :param path: The path to a sample's folder.
+    :param plist: The plist dictionary. In our case is a list of dicts.
+    :return: None. Throws if exception occurs.
+    """
+    try:
+        single_sample_check_diff(path, plist)
+    except Exception as err:
+        raise err
+
+
+def main():
+    msg = 'Title checker script. Run it against the /arcgis-ios-sdk-samples ' \
+          'folder or a single sample folder. ' \
+          'On success: Script will exit with zero. ' \
+          'On failure: Title inconsistency will print to console and the ' \
+          'script will exit with non-zero code.'
+    parser = argparse.ArgumentParser(description=msg)
+    parser.add_argument('-a', '--all', help='path to arcgis-ios-sdk-samples '
+                                            'folder')
+    parser.add_argument('-s', '--single', help='path to single sample folder.')
+    args = parser.parse_args()
+
+    if args.all:
+        # Load ContentPList.plist.
+        plist_path = os.path.normpath(
+            args.all + '/Content Display Logic/ContentPList.plist')
+        plist = load_plist(plist_path)
+        if not plist:
+            raise Exception('Error loading plist.')
+
+        try:
+            all_samples(args.all, plist)
+        except Exception as err:
+            raise err
+    elif args.single:
+        # Load ContentPList.plist.
+        plist_path = os.path.normpath(
+            args.single + '/../../Content Display Logic/ContentPList.plist')
+        plist = load_plist(plist_path)
+        if not plist:
+            raise Exception('Error loading plist.')
+
+        try:
+            single_sample(args.single, plist)
+        except Exception as err:
+            raise err
+    else:
+        raise Exception('Invalid arguments, abort.')
+# endregion
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception as error:
+        print(f'{error}')
+        exit(1)

--- a/Scripts/CI/README_Metadata_StyleCheck/title_differ.py
+++ b/Scripts/CI/README_Metadata_StyleCheck/title_differ.py
@@ -115,6 +115,7 @@ class SampleNames:
           - sample’s folder name
           - sample’s `README.md` title
           - `README.metadata.json` title
+          - sample's plist title
         - Category names
           - sample’s enclosing category folder name
           - `README.metadata.json` category


### PR DESCRIPTION
This PR adds a set of scripts and 2 GitHub Actions workflow YAML files to `v.next` branch, to enforce styling for `README.md` and `README.metadata.json` files.

Steps to review:

1. (Optional) Read about the background in /common-samples/issues/2018
1. (Optional) Read about the GitHub Actions wiki in /common-samples/wiki/README-and-metadata-status-check-with-GitHub-Actions
1. Try it out to see how it works in my forked repo: https://github.com/yo1995/arcgis-runtime-samples-ios/pulls. 
    
    I've set the repo up exactly the same as this PR. When you create a PR to `v.next` in that repo, it will run the checks and give success/failure status, and print error output into the console.
1. Review the files
    - `main.yml` and `action.yml` are GitHub Actions configuration files
    - `style.rb` is a `markdownlint` configuration file, and has been reviewed by samples team
    - `Dockerfile` is a docker to setup the environment to run Python scripts and Ruby markdownlint package
    - `entry.py` is the entry point (glue code) script called by the docker, that call the other scripts
    - The other 4 Python scripts check various rules against README and metadata. There are duplicate code in them because each script is designed to be a standalone tool that can run separately

    These checkers have been used and adjusted to deliver update 9 and should work pretty well, given that the website doesn't have noticeable issue right now.

1. In #869 in this [comment](https://github.com/Esri/arcgis-runtime-samples-ios/pull/869#pullrequestreview-451994085) you can find explanation of what are being checked by the scripts.

---

In short, feel free to skim through and give approval as the scripts have been proven working well. No sample is changed so this PR won't break the build.

We can make improvements afterwards if these checker scripts run into issues in production.