### PR TITLE
Update: remove -j flag from download script and fix portal item

### DIFF
--- a/Scripts/download-portal-item-data.swift
+++ b/Scripts/download-portal-item-data.swift
@@ -116,8 +116,7 @@ func uncompressArchive(at sourceURL: URL, to destinationURL: URL) throws {
     let process = Process()
     process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip", isDirectory: false)
     // Unzip the archive into a specified sub-folder and silence the output.
-    // "-j" is passed in to get rid of redundant subfolder.
-    process.arguments = ["-jq", sourceURL.path, "-d", destinationURL.path]
+    process.arguments = ["-q", sourceURL.path, "-d", destinationURL.path]
     
     try process.run()
     process.waitUntilExit()

--- a/arcgis-ios-sdk-samples.xcodeproj/project.pbxproj
+++ b/arcgis-ios-sdk-samples.xcodeproj/project.pbxproj
@@ -31,7 +31,7 @@
 		009D8BEF24F9AC8D00FD7E76 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 009D8BEE24F9AC8D00FD7E76 /* LaunchScreen.storyboard */; };
 		00ADC3BD2464D45C00A3B88D /* AnimateImagesWithImageOverlay.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 00ADC3B82464D45B00A3B88D /* AnimateImagesWithImageOverlay.storyboard */; };
 		00ADC3BF2464D45C00A3B88D /* AnimateImagesWithImageOverlayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00ADC3BA2464D45B00A3B88D /* AnimateImagesWithImageOverlayViewController.swift */; };
-		00ADC3C32464D59200A3B88D /* PacificSouthWest in Resources */ = {isa = PBXBuildFile; fileRef = 00ADC3C22464D59200A3B88D /* PacificSouthWest */; settings = {ASSET_TAGS = (PacificSouthWest, ); }; };
+		00ADC3C32464D59200A3B88D /* PacificSouthWest2 in Resources */ = {isa = PBXBuildFile; fileRef = 00ADC3C22464D59200A3B88D /* PacificSouthWest2 */; settings = {ASSET_TAGS = (PacificSouthWest, ); }; };
 		00ADC3C42464D64F00A3B88D /* AnimateImagesWithImageOverlayViewController.swift in CopyFiles */ = {isa = PBXBuildFile; fileRef = 00ADC3BA2464D45B00A3B88D /* AnimateImagesWithImageOverlayViewController.swift */; };
 		00ADC3CF2464DD2B00A3B88D /* IdentifyRasterCell.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 00ADC3CE2464DD2B00A3B88D /* IdentifyRasterCell.storyboard */; };
 		00ADC3D12464DD3600A3B88D /* IdentifyRasterCellViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00ADC3D02464DD3600A3B88D /* IdentifyRasterCellViewController.swift */; };
@@ -1191,7 +1191,7 @@
 		009D8BEE24F9AC8D00FD7E76 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		00ADC3B82464D45B00A3B88D /* AnimateImagesWithImageOverlay.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = AnimateImagesWithImageOverlay.storyboard; sourceTree = "<group>"; };
 		00ADC3BA2464D45B00A3B88D /* AnimateImagesWithImageOverlayViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimateImagesWithImageOverlayViewController.swift; sourceTree = "<group>"; };
-		00ADC3C22464D59200A3B88D /* PacificSouthWest */ = {isa = PBXFileReference; lastKnownFileType = folder; path = PacificSouthWest; sourceTree = "<group>"; };
+		00ADC3C22464D59200A3B88D /* PacificSouthWest2 */ = {isa = PBXFileReference; lastKnownFileType = folder; path = PacificSouthWest2; sourceTree = "<group>"; };
 		00ADC3CE2464DD2B00A3B88D /* IdentifyRasterCell.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = IdentifyRasterCell.storyboard; sourceTree = "<group>"; };
 		00ADC3D02464DD3600A3B88D /* IdentifyRasterCellViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifyRasterCellViewController.swift; sourceTree = "<group>"; };
 		00C024E42475E4AB00E1DA8D /* NavigateARRoutePlannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigateARRoutePlannerViewController.swift; sourceTree = "<group>"; };
@@ -1865,7 +1865,7 @@
 		00C6D328246CA8FC00C63EAF /* Archives */ = {
 			isa = PBXGroup;
 			children = (
-				00ADC3C22464D59200A3B88D /* PacificSouthWest */,
+				00ADC3C22464D59200A3B88D /* PacificSouthWest2 */,
 				00C6D329246CA8FC00C63EAF /* SA_EVI_8Day_03May20 */,
 			);
 			path = Archives;
@@ -4900,7 +4900,7 @@
 				3EABC7B51DB181DD00C161C6 /* ShastaBW.tif in Resources */,
 				D9E2E76120EEB8FF001D0AE0 /* Public_Art.cpg in Resources */,
 				3EABC7C91DB1947500C161C6 /* BlendRenderer.storyboard in Resources */,
-				00ADC3C32464D59200A3B88D /* PacificSouthWest in Resources */,
+				00ADC3C32464D59200A3B88D /* PacificSouthWest2 in Resources */,
 				3EFCE1C81CF38A9C00E02F67 /* SanFrancisco.mmpk in Resources */,
 				4C9912382245534100CCBC2A /* PlayKMLTour.storyboard in Resources */,
 				D9E2E76520EEB8FF001D0AE0 /* Public_Art.shx in Resources */,

--- a/arcgis-ios-sdk-samples/Content Display Logic/PortalItems.plist
+++ b/arcgis-ios-sdk-samples/Content Display Logic/PortalItems.plist
@@ -6,12 +6,6 @@
 	<array>
 		<dict>
 			<key>identifier</key>
-			<string>74c0c9fa80f4498c9739cc42531e9948</string>
-			<key>filename</key>
-			<string>loudoun_anno.geodatabase</string>
-		</dict>
-		<dict>
-			<key>identifier</key>
 			<string>c78b149a1d52414682c86a5feeb13d30</string>
 			<key>filename</key>
 			<string>mil2525d.stylx</string>
@@ -69,6 +63,12 @@
 			<string>9465e8c02b294c69bdb42de056a23ab1</string>
 			<key>filename</key>
 			<string>PacificSouthWest.zip</string>
+		</dict>
+		<dict>
+			<key>identifier</key>
+			<string>74c0c9fa80f4498c9739cc42531e9948</string>
+			<key>filename</key>
+			<string>loudoun_anno.geodatabase</string>
 		</dict>
 		<dict>
 			<key>identifier</key>

--- a/arcgis-ios-sdk-samples/Content Display Logic/PortalItems.plist
+++ b/arcgis-ios-sdk-samples/Content Display Logic/PortalItems.plist
@@ -60,9 +60,9 @@
 		</dict>
 		<dict>
 			<key>identifier</key>
-			<string>9465e8c02b294c69bdb42de056a23ab1</string>
+			<string>d1453556d91e46dea191c20c398b82cd</string>
 			<key>filename</key>
-			<string>PacificSouthWest.zip</string>
+			<string>PacificSouthWest2.zip</string>
 		</dict>
 		<dict>
 			<key>identifier</key>

--- a/arcgis-ios-sdk-samples/Scenes/Animate images with image overlay/AnimateImagesWithImageOverlayViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Animate images with image overlay/AnimateImagesWithImageOverlayViewController.swift
@@ -57,7 +57,7 @@ class AnimateImagesWithImageOverlayViewController: UIViewController {
     /// An iterator to hold and loop through the overlay images.
     private lazy var imagesIterator: CircularIterator<UIImage> = {
         // Get the URLs to images added to the project's folder reference.
-        let imageURLs = Bundle.main.urls(forResourcesWithExtension: "png", subdirectory: "PacificSouthWest") ?? []
+        let imageURLs = Bundle.main.urls(forResourcesWithExtension: "png", subdirectory: "PacificSouthWest2") ?? []
         let images = imageURLs
             .sorted { $0.lastPathComponent < $1.lastPathComponent }
             .map { UIImage(contentsOfFile: $0.path)! }

--- a/arcgis-ios-sdk-samples/Scenes/Animate images with image overlay/README.md
+++ b/arcgis-ios-sdk-samples/Scenes/Animate images with image overlay/README.md
@@ -26,7 +26,7 @@ The sample loads a map of the Southwestern United States. Tap the play or pause 
 
 ## About the data
 
-These radar images were captured by the US National Weather Service (NWS). They highlight the Pacific Southwest sector which is made up of part the western United States and Mexico. For more information visit the [National Weather Service](https://www.weather.gov/jetstream/gis) website. The archive for radar images can be downloaded from [ArcGIS Online](https://runtime.maps.arcgis.com/home/item.html?id=9465e8c02b294c69bdb42de056a23ab1).
+These radar images were captured by the US National Weather Service (NWS). They highlight the Pacific Southwest sector which is made up of part the western United States and Mexico. For more information visit the [National Weather Service](https://www.weather.gov/jetstream/gis) website. The archive for radar images can be downloaded from [ArcGIS Online](https://runtime.maps.arcgis.com/home/item.html?id=d1453556d91e46dea191c20c398b82cd).
 
 ## Additional information
 


### PR DESCRIPTION
This PR fixes the issue in #857 (Animate images with image overlay) and #865 , where we decided to add "-j" flag to call `unzip` so that it omits all enclosing folders and extract files to a flattened directory. It also replaced the item that caused trouble.

Removing the flag means now extracting zip archive will preserve their folder structure, and we need to

- Add the folder tree as-is when introducing new item to the `Portal Data` folder
- (Negotiate with sample designer to) ensure future zip archives do not contain irrelevant hidden files or redundant folders

