### PR TITLE
Fix: Change info.plist to fix compliance warning

### DIFF
--- a/arcgis-ios-sdk-samples/Info.plist
+++ b/arcgis-ios-sdk-samples/Info.plist
@@ -45,6 +45,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>
@@ -124,8 +126,6 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>

--- a/arcgis-ios-sdk-samples/Info.plist
+++ b/arcgis-ios-sdk-samples/Info.plist
@@ -124,6 +124,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>


### PR DESCRIPTION
This PR fixes the Compliance warning on AppStore Connect so that next time the app is uploaded, it will automatically go into internal testing after processing is done.

|1|2|
|-|-|
|<img width="619" alt="compliance-1" src="https://user-images.githubusercontent.com/9660181/98273031-a9179980-1f46-11eb-8078-1a14b508a749.png">|<img width="817" alt="compliance-2" src="https://user-images.githubusercontent.com/9660181/98273024-a6b53f80-1f46-11eb-92ab-d676774d242b.png">|

When the app is uploaded to AppStore Connect, it won't immediately go into internal testing, but get stuck by the compliance warning. Since we are not using encrypted communication in our app, simply setting it to false will solve the problem. Read more at

- https://developer.apple.com/documentation/bundleresources/information_property_list/itsappusesnonexemptencryption
- https://stackoverflow.com/questions/35841117
