### PR TITLE
Fix alert controller tint color on iOS 14

### DIFF
--- a/arcgis-ios-sdk-samples/AppDelegate.swift
+++ b/arcgis-ios-sdk-samples/AppDelegate.swift
@@ -118,6 +118,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
         }
         UISwitch.appearance().onTintColor = .accentColor
         navigationBarAppearanceProxy.tintColor = .white
+        UIView.appearance(whenContainedInInstancesOf: [UIAlertController.self]).tintColor = .accentColor
         if #available(iOS 14.0, *) {
             // Nothing to do! iOS 14 handles global tint with accent color.
         } else {
@@ -126,7 +127,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
             UISlider.appearance().tintColor = .accentColor
             UITableViewCell.appearance().tintColor = .accentColor
             UIProgressView.appearance().tintColor = .accentColor
-            UIView.appearance(whenContainedInInstancesOf: [UIAlertController.self]).tintColor = .accentColor
             UIButton.appearance(whenContainedInInstancesOf: [AGSCallout.self]).tintColor = .accentColor
         }
     }


### PR DESCRIPTION
This fixes an issue where interactive elements in an alert controller (buttons, etc.) had the wrong tint color on iOS 14.