### PR TITLE
Fix: Add markdownlint exception rule for trailing spaces in README

### DIFF
--- a/Scripts/CI/README_Metadata_StyleCheck/style.rb
+++ b/Scripts/CI/README_Metadata_StyleCheck/style.rb
@@ -1,7 +1,7 @@
 all  # opt-in all rules by default
 rule 'MD003', :style => :atx  # Header style written as non-closing pound marks. e.g. ## Section title
 rule 'MD004', :style => :asterisk  # Unordered list style as asterisk, rather than hyphen or plus sign
-rule 'MD009', :br_spaces => 2  # allows an exception for 2 trailing spaces used to insert an explicit line break
+rule 'MD009', :br_spaces => 2  # Allows an exception for 2 trailing spaces used to insert an explicit line break
 rule 'MD029', :style => :ordered  # Ordered list item prefix is incremental, rather than all ones
-exclude_rule 'MD013'  # not limiting line length
-exclude_rule 'MD007'  # not limiting unordered list indentation, tab, 2 or 4 spaces are all fine
+exclude_rule 'MD013'  # Not limiting line length
+exclude_rule 'MD007'  # Not limiting unordered list indentation, tab, 2 or 4 spaces are all fine

--- a/Scripts/CI/README_Metadata_StyleCheck/style.rb
+++ b/Scripts/CI/README_Metadata_StyleCheck/style.rb
@@ -1,4 +1,4 @@
-all  # opt-in all rules by default
+all  # Opt-in all rules by default
 rule 'MD003', :style => :atx  # Header style written as non-closing pound marks. e.g. ## Section title
 rule 'MD004', :style => :asterisk  # Unordered list style as asterisk, rather than hyphen or plus sign
 rule 'MD009', :br_spaces => 2  # Allows an exception for 2 trailing spaces used to insert an explicit line break

--- a/Scripts/CI/README_Metadata_StyleCheck/style.rb
+++ b/Scripts/CI/README_Metadata_StyleCheck/style.rb
@@ -1,6 +1,7 @@
 all  # opt-in all rules by default
 rule 'MD003', :style => :atx  # Header style written as non-closing pound marks. e.g. ## Section title
 rule 'MD004', :style => :asterisk  # Unordered list style as asterisk, rather than hyphen or plus sign
+rule 'MD009', :br_spaces => 2  # allows an exception for 2 trailing spaces used to insert an explicit line break
 rule 'MD029', :style => :ordered  # Ordered list item prefix is incremental, rather than all ones
 exclude_rule 'MD013'  # not limiting line length
 exclude_rule 'MD007'  # not limiting unordered list indentation, tab, 2 or 4 spaces are all fine

--- a/arcgis-ios-sdk-samples/Layers/ArcGIS vector tiled layer (custom style)/README.md
+++ b/arcgis-ios-sdk-samples/Layers/ArcGIS vector tiled layer (custom style)/README.md
@@ -16,7 +16,7 @@ Pan and zoom to explore the vector tile basemap.
 ## How it works
 
 1. Construct an `AGSArcGISVectorTiledLayer` with the URL of a custom style from AGOL.
-    * Follow these steps to create a vector tiled layer with a custom style from offline resources:  
+    * Follow these steps to create a vector tiled layer with a custom style from offline resources:   
     i. Construct an `AGSVectorTileCache` using the name of the local vector tile package.  
     ii. Create an `AGSPortalItem` using the URL of a custom style.  
     iii. Create an `AGSExportVectorTilesTask` using the portal item.  

--- a/arcgis-ios-sdk-samples/Layers/ArcGIS vector tiled layer (custom style)/README.md
+++ b/arcgis-ios-sdk-samples/Layers/ArcGIS vector tiled layer (custom style)/README.md
@@ -16,13 +16,13 @@ Pan and zoom to explore the vector tile basemap.
 ## How it works
 
 1. Construct an `AGSArcGISVectorTiledLayer` with the URL of a custom style from AGOL.
-    * Follow these steps to create a vector tiled layer with a custom style from offline resources:  
-    i. Construct an `AGSVectorTileCache` using the name of the local vector tile package.  
-    ii. Create an `AGSPortalItem` using the URL of a custom style.  
-    iii. Create an `AGSExportVectorTilesTask` using the portal item.  
-    iv. Get the `AGSExportVectorTilesJob` using `AGSExportVectorTilesTask.exportStyleResourceCacheJob(withDownloadDirectory:)`.  
-    v. Start the job using  `AGSExportVectorTilesJob.start(statusHandler:completion:)`.  
-    vi. Once the job is complete, construct an `AGSArcGISVectorTiledLayer` using the vector tile cache and the `AGSItemResourceCache` from the job's result.  
+    * Follow these steps to create a vector tiled layer with a custom style from offline resources:
+    i. Construct an `AGSVectorTileCache` using the name of the local vector tile package.
+    ii. Create an `AGSPortalItem` using the URL of a custom style.
+    iii. Create an `AGSExportVectorTilesTask` using the portal item.
+    iv. Get the `AGSExportVectorTilesJob` using `AGSExportVectorTilesTask.exportStyleResourceCacheJob(withDownloadDirectory:)`.
+    v. Start the job using  `AGSExportVectorTilesJob.start(statusHandler:completion:)`.
+    vi. Once the job is complete, construct an `AGSArcGISVectorTiledLayer` using the vector tile cache and the `AGSItemResourceCache` from the job's result.
 2. Create an `AGSBasemap` from the `AGSArcGISVectorTiledLayer`.
 3. Assign the `AGSBasemap` to the map's `basemap`.
 

--- a/arcgis-ios-sdk-samples/Layers/ArcGIS vector tiled layer (custom style)/README.md
+++ b/arcgis-ios-sdk-samples/Layers/ArcGIS vector tiled layer (custom style)/README.md
@@ -16,7 +16,7 @@ Pan and zoom to explore the vector tile basemap.
 ## How it works
 
 1. Construct an `AGSArcGISVectorTiledLayer` with the URL of a custom style from AGOL.
-    * Follow these steps to create a vector tiled layer with a custom style from offline resources:   
+    * Follow these steps to create a vector tiled layer with a custom style from offline resources:  
     i. Construct an `AGSVectorTileCache` using the name of the local vector tile package.  
     ii. Create an `AGSPortalItem` using the URL of a custom style.  
     iii. Create an `AGSExportVectorTilesTask` using the portal item.  

--- a/arcgis-ios-sdk-samples/Layers/ArcGIS vector tiled layer (custom style)/README.md
+++ b/arcgis-ios-sdk-samples/Layers/ArcGIS vector tiled layer (custom style)/README.md
@@ -16,12 +16,12 @@ Pan and zoom to explore the vector tile basemap.
 ## How it works
 
 1. Construct an `AGSArcGISVectorTiledLayer` with the URL of a custom style from AGOL.
-    * Follow these steps to create a vector tiled layer with a custom style from offline resources:\
-    i. Construct an `AGSVectorTileCache` using the name of the local vector tile package.\
-    ii. Create an `AGSPortalItem` using the URL of a custom style.\
-    iii. Create an `AGSExportVectorTilesTask` using the portal item.\
-    iv. Get the `AGSExportVectorTilesJob` using `AGSExportVectorTilesTask.exportStyleResourceCacheJob(withDownloadDirectory:)`.\
-    v. Start the job using  `AGSExportVectorTilesJob.start(statusHandler:completion:)`.\
+    * Follow these steps to create a vector tiled layer with a custom style from offline resources:<br/>
+    i. Construct an `AGSVectorTileCache` using the name of the local vector tile package.<br/>
+    ii. Create an `AGSPortalItem` using the URL of a custom style.<br/>
+    iii. Create an `AGSExportVectorTilesTask` using the portal item.<br/>
+    iv. Get the `AGSExportVectorTilesJob` using `AGSExportVectorTilesTask.exportStyleResourceCacheJob(withDownloadDirectory:)`.<br/>
+    v. Start the job using  `AGSExportVectorTilesJob.start(statusHandler:completion:)`.<br/>
     vi. Once the job is complete, construct an `AGSArcGISVectorTiledLayer` using the vector tile cache and the `AGSItemResourceCache` from the job's result.
 2. Create an `AGSBasemap` from the `AGSArcGISVectorTiledLayer`.
 3. Assign the `AGSBasemap` to the map's `basemap`.

--- a/arcgis-ios-sdk-samples/Layers/ArcGIS vector tiled layer (custom style)/README.md
+++ b/arcgis-ios-sdk-samples/Layers/ArcGIS vector tiled layer (custom style)/README.md
@@ -16,12 +16,12 @@ Pan and zoom to explore the vector tile basemap.
 ## How it works
 
 1. Construct an `AGSArcGISVectorTiledLayer` with the URL of a custom style from AGOL.
-    * Follow these steps to create a vector tiled layer with a custom style from offline resources:
-    i. Construct an `AGSVectorTileCache` using the name of the local vector tile package.
-    ii. Create an `AGSPortalItem` using the URL of a custom style.
-    iii. Create an `AGSExportVectorTilesTask` using the portal item.
-    iv. Get the `AGSExportVectorTilesJob` using `AGSExportVectorTilesTask.exportStyleResourceCacheJob(withDownloadDirectory:)`.
-    v. Start the job using  `AGSExportVectorTilesJob.start(statusHandler:completion:)`.
+    * Follow these steps to create a vector tiled layer with a custom style from offline resources:\
+    i. Construct an `AGSVectorTileCache` using the name of the local vector tile package.\
+    ii. Create an `AGSPortalItem` using the URL of a custom style.\
+    iii. Create an `AGSExportVectorTilesTask` using the portal item.\
+    iv. Get the `AGSExportVectorTilesJob` using `AGSExportVectorTilesTask.exportStyleResourceCacheJob(withDownloadDirectory:)`.\
+    v. Start the job using  `AGSExportVectorTilesJob.start(statusHandler:completion:)`.\
     vi. Once the job is complete, construct an `AGSArcGISVectorTiledLayer` using the vector tile cache and the `AGSItemResourceCache` from the job's result.
 2. Create an `AGSBasemap` from the `AGSArcGISVectorTiledLayer`.
 3. Assign the `AGSBasemap` to the map's `basemap`.

--- a/arcgis-ios-sdk-samples/Layers/ArcGIS vector tiled layer (custom style)/README.md
+++ b/arcgis-ios-sdk-samples/Layers/ArcGIS vector tiled layer (custom style)/README.md
@@ -16,13 +16,13 @@ Pan and zoom to explore the vector tile basemap.
 ## How it works
 
 1. Construct an `AGSArcGISVectorTiledLayer` with the URL of a custom style from AGOL.
-    * Follow these steps to create a vector tiled layer with a custom style from offline resources:<br/>
-    i. Construct an `AGSVectorTileCache` using the name of the local vector tile package.<br/>
-    ii. Create an `AGSPortalItem` using the URL of a custom style.<br/>
-    iii. Create an `AGSExportVectorTilesTask` using the portal item.<br/>
-    iv. Get the `AGSExportVectorTilesJob` using `AGSExportVectorTilesTask.exportStyleResourceCacheJob(withDownloadDirectory:)`.<br/>
-    v. Start the job using  `AGSExportVectorTilesJob.start(statusHandler:completion:)`.<br/>
-    vi. Once the job is complete, construct an `AGSArcGISVectorTiledLayer` using the vector tile cache and the `AGSItemResourceCache` from the job's result.
+    * Follow these steps to create a vector tiled layer with a custom style from offline resources:  
+    i. Construct an `AGSVectorTileCache` using the name of the local vector tile package.  
+    ii. Create an `AGSPortalItem` using the URL of a custom style.  
+    iii. Create an `AGSExportVectorTilesTask` using the portal item.  
+    iv. Get the `AGSExportVectorTilesJob` using `AGSExportVectorTilesTask.exportStyleResourceCacheJob(withDownloadDirectory:)`.  
+    v. Start the job using  `AGSExportVectorTilesJob.start(statusHandler:completion:)`.  
+    vi. Once the job is complete, construct an `AGSArcGISVectorTiledLayer` using the vector tile cache and the `AGSItemResourceCache` from the job's result.  
 2. Create an `AGSBasemap` from the `AGSArcGISVectorTiledLayer`.
 3. Assign the `AGSBasemap` to the map's `basemap`.
 


### PR DESCRIPTION
In https://github.com/Esri/arcgis-runtime-samples-ios/pull/981#issuecomment-731330696 the PR used 2-trailing-space line break that makes the check yield error status.

This PR adds a new rule to the markdownlint rules to make an exception for such cases. Details at https://github.com/Esri/arcgis-runtime-samples-ios/pull/981#issuecomment-731397411