### PR TITLE
Fix: Not to change the title of GenerateOfflineMap samples

### DIFF
--- a/arcgis-ios-sdk-samples/Maps/Generate offline map (overrides)/GenerateOfflineMapOverridesViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map (overrides)/GenerateOfflineMapOverridesViewController.swift
@@ -91,7 +91,6 @@ class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthentica
                 return
             }
             
-            self.title = self.mapView.map?.item?.title
             self.generateButtonItem.isEnabled = true
         }
         

--- a/arcgis-ios-sdk-samples/Maps/Generate offline map/GenerateOfflineMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map/GenerateOfflineMapViewController.swift
@@ -83,7 +83,6 @@ class GenerateOfflineMapViewController: UIViewController, AGSAuthenticationManag
                 return
             }
             
-            self.title = self.mapView.map?.item?.title
             self.barButtonItem.isEnabled = true
         }
         


### PR DESCRIPTION
This PR removes the lines that change the title of the sample's main view controller.