### PR TITLE
Update: Basemap constructors 2

### DIFF
--- a/arcgis-ios-sdk-samples/Analysis/Statistical query/StatisticalQueryViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Statistical query/StatisticalQueryViewController.swift
@@ -37,7 +37,7 @@ class StatisticalQueryViewController: UIViewController {
         getStatisticsButton.layer.cornerRadius = 10
         
         // Initialize map and set it on map view
-        map = AGSMap(basemap: .streetsVector())
+        map = AGSMap(basemapStyle: .arcGISStreets)
         mapView.map = map
 
         // Initialize feature table, layer and add it to map

--- a/arcgis-ios-sdk-samples/Analysis/Viewshed (geoprocessing)/ViewshedGeoprocessingViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Viewshed (geoprocessing)/ViewshedGeoprocessingViewController.swift
@@ -30,7 +30,8 @@ class ViewshedGeoprocessingViewController: UIViewController, AGSGeoViewTouchDele
         //add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["ViewshedGeoprocessingViewController"]
 
-        let map = AGSMap(basemapType: .topographic, latitude: 45.3790902612337, longitude: 6.84905317262762, levelOfDetail: 12)
+        let map = AGSMap(basemapStyle: .arcGISTopographic)
+        map.initialViewpoint = AGSViewpoint(latitude: 45.3790902612337, longitude: 6.84905317262762, scale: 144447.638572)
         
         self.mapView.map = map
         

--- a/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/NavigateARRoutePlannerViewController.swift
+++ b/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/NavigateARRoutePlannerViewController.swift
@@ -29,7 +29,7 @@ class NavigateARRoutePlannerViewController: UIViewController {
     /// The map view managed by the view controller.
     @IBOutlet weak var mapView: AGSMapView! {
         didSet {
-            mapView.map = AGSMap(basemap: .imageryWithLabelsVector())
+            mapView.map = AGSMap(basemapStyle: .arcGISImagery)
             mapView.graphicsOverlays.addObjects(from: [routeGraphicsOverlay, stopGraphicsOverlay])
             mapView.locationDisplay.dataSource = locationDataSource
             mapView.locationDisplay.autoPanMode = .recenter

--- a/arcgis-ios-sdk-samples/Augmented reality/View hidden infrastructure in AR/ViewHiddenInfrastructureARPipePlacingViewController.swift
+++ b/arcgis-ios-sdk-samples/Augmented reality/View hidden infrastructure in AR/ViewHiddenInfrastructureARPipePlacingViewController.swift
@@ -34,7 +34,7 @@ class ViewHiddenInfrastructureARPipePlacingViewController: UIViewController {
     /// The map view managed by the view controller.
     @IBOutlet var mapView: AGSMapView! {
         didSet {
-            mapView.map = AGSMap(basemap: .imageryWithLabelsVector())
+            mapView.map = AGSMap(basemapStyle: .arcGISImagery)
             mapView.graphicsOverlays.add(pipeGraphicsOverlay)
             mapView.sketchEditor = AGSSketchEditor()
         }

--- a/arcgis-ios-sdk-samples/Display information/Add graphics with symbols/GraphicsWithSymbolsViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Add graphics with symbols/GraphicsWithSymbolsViewController.swift
@@ -27,7 +27,8 @@ class GraphicsWithSymbolsViewController: UIViewController {
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["GraphicsWithSymbolsViewController"]
         
         //instantiate map with basemap, initial viewpoint and level of detail
-        let map = AGSMap(basemapType: AGSBasemapType.oceans, latitude: 56.075844, longitude: -2.681572, levelOfDetail: 11)
+        let map = AGSMap(basemapStyle: .arcGISOceans)
+        map.initialViewpoint = AGSViewpoint(latitude: 56.075844, longitude: -2.681572, scale: 288895.277144)
         
         //assign the map to the map view
         self.mapView.map = map

--- a/arcgis-ios-sdk-samples/Edit data/Edit features with feature-linked annotation/EditFeaturesWithFeatureLinkedAnnotationViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit features with feature-linked annotation/EditFeaturesWithFeatureLinkedAnnotationViewController.swift
@@ -19,7 +19,9 @@ class EditFeaturesWithFeatureLinkedAnnotationViewController: UIViewController {
     @IBOutlet weak var mapView: AGSMapView! {
         didSet {
             // Create the map with a light gray canvas basemap centered on Loudoun, Virginia.
-            mapView.map = AGSMap(basemapType: .lightGrayCanvasVector, latitude: 39.0204, longitude: -77.4159, levelOfDetail: 18)
+            let map = AGSMap(basemapStyle: .arcGISStreets)
+            map.initialViewpoint = AGSViewpoint(latitude: 39.0204, longitude: -77.4159, scale: 2256.994353)
+            mapView.map = map
             // Set the touch delegate.
             mapView.touchDelegate = self
         }

--- a/arcgis-ios-sdk-samples/Edit data/Edit features with feature-linked annotation/EditFeaturesWithFeatureLinkedAnnotationViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit features with feature-linked annotation/EditFeaturesWithFeatureLinkedAnnotationViewController.swift
@@ -19,7 +19,7 @@ class EditFeaturesWithFeatureLinkedAnnotationViewController: UIViewController {
     @IBOutlet weak var mapView: AGSMapView! {
         didSet {
             // Create the map with a light gray canvas basemap centered on Loudoun, Virginia.
-            let map = AGSMap(basemapStyle: .arcGISStreets)
+            let map = AGSMap(basemapStyle: .arcGISLightGrayBase)
             map.initialViewpoint = AGSViewpoint(latitude: 39.0204, longitude: -77.4159, scale: 2256.994353)
             mapView.map = map
             // Set the touch delegate.

--- a/arcgis-ios-sdk-samples/Edit data/Edit with branch versioning/EditWithBranchVersioningViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit with branch versioning/EditWithBranchVersioningViewController.swift
@@ -28,7 +28,7 @@ class EditWithBranchVersioningViewController: UIViewController {
     /// The map view managed by the view controller.
     @IBOutlet var mapView: AGSMapView! {
         didSet {
-            mapView.map = AGSMap(basemap: .streetsVector())
+            mapView.map = AGSMap(basemapStyle: .arcGISStreets)
             mapView.touchDelegate = self
             mapView.callout.delegate = self
         }

--- a/arcgis-ios-sdk-samples/Features/Feature layer (feature service)/FeatureLayerURLViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer (feature service)/FeatureLayerURLViewController.swift
@@ -25,7 +25,7 @@ class FeatureLayerURLViewController: UIViewController {
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["FeatureLayerURLViewController"]
         
         //initialize map with basemap
-        let map = AGSMap(basemap: .terrainWithLabels())
+        let map = AGSMap(basemapStyle: .arcGISTerrain)
         
         //initial viewpoint
         map.initialViewpoint = AGSViewpoint(center: AGSPoint(x: -13176752, y: 4090404, spatialReference: .webMercator()), scale: 300000)

--- a/arcgis-ios-sdk-samples/Features/Feature layer (geopackage)/FeatureLayerGPKGViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer (geopackage)/FeatureLayerGPKGViewController.swift
@@ -26,7 +26,8 @@ class FeatureLayerGPKGViewController: UIViewController {
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["FeatureLayerGPKGViewController"]
         
         // Instantiate a map using a basemap, location, and zoom level.
-        let map = AGSMap(basemapType: .lightGrayCanvasVector, latitude: 39.7294, longitude: -104.8319, levelOfDetail: 10)
+        let map = AGSMap(basemapStyle: .arcGISLightGrayBase)
+        map.initialViewpoint = AGSViewpoint(latitude: 39.7294, longitude: -104.8319, scale: 577790.554289)
         
         // Create a geopackage from a named bundle resource.
         geoPackage = AGSGeoPackage(name: "AuroraCO")

--- a/arcgis-ios-sdk-samples/Features/Feature layer (shapefile)/FeatureLayerShapefileViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer (shapefile)/FeatureLayerShapefileViewController.swift
@@ -22,7 +22,7 @@ class FeatureLayerShapefileViewController: UIViewController {
 
     required init?(coder aDecoder: NSCoder) {
         // Instantiate a map using a basemap.
-        map = AGSMap(basemap: .streetsVector())
+        map = AGSMap(basemapStyle: .arcGISStreets)
 
         // Create a shapefile feature table from a named bundle resource.
         let shapefileTable = AGSShapefileFeatureTable(name: "Public_Art")

--- a/arcgis-ios-sdk-samples/Geometry/List transformations/ListTransformationsViewController.swift
+++ b/arcgis-ios-sdk-samples/Geometry/List transformations/ListTransformationsViewController.swift
@@ -40,7 +40,7 @@ class ListTransformationsViewController: UIViewController, UITableViewDelegate, 
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["ListTransformationsViewController"]
 
         // Get MapView from layout and set a map into this view
-        mapView.map = AGSMap(basemap: .lightGrayCanvasVector())
+        mapView.map = AGSMap(basemapStyle: .arcGISLightGrayBase)
         mapView.graphicsOverlays.add(graphicsOverlay)
         
         //add original graphic to overlay

--- a/arcgis-ios-sdk-samples/Layers/Apply mosaic rule to rasters/ApplyMosaicRuleToRastersViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Apply mosaic rule to rasters/ApplyMosaicRuleToRastersViewController.swift
@@ -82,7 +82,7 @@ class ApplyMosaicRuleToRastersViewController: UIViewController {
         }
         // Create a raster layer.
         let rasterLayer = AGSRasterLayer(raster: imageServiceRaster)
-        let map = AGSMap(basemap: .topographicVector())
+        let map = AGSMap(basemapStyle: .arcGISTopographic)
         // Add raster layer as an operational layer to the map.
         map.operationalLayers.add(rasterLayer)
         SVProgressHUD.show(withStatus: "Loading")

--- a/arcgis-ios-sdk-samples/Layers/Display KML/DisplayKMLViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Display KML/DisplayKMLViewController.swift
@@ -45,7 +45,8 @@ class DisplayKMLViewController: UIViewController {
         super.viewDidLoad()
         
         // Instantiate a map with a dark gray basemap centered on the United States
-        let map = AGSMap(basemapType: .darkGrayCanvasVector, latitude: 39, longitude: -98, levelOfDetail: 4)
+        let map = AGSMap(basemapStyle: .arcGISDarkGray)
+        map.initialViewpoint = AGSViewpoint(latitude: 39, longitude: -98, scale: 3.6978595474472E7)
         // Display the map in the map view
         mapView.map = map
         

--- a/arcgis-ios-sdk-samples/Layers/Display annotation/DisplayAnnotationViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Display annotation/DisplayAnnotationViewController.swift
@@ -24,7 +24,8 @@ class DisplayAnnotationViewController: UIViewController {
     }
     
     func makeMap() -> AGSMap {
-        let map = AGSMap(basemapType: .lightGrayCanvas, latitude: 55.882436, longitude: -2.725610, levelOfDetail: 13)
+        let map = AGSMap(basemapStyle: .arcGISLightGray)
+        map.initialViewpoint = AGSViewpoint(latitude: 55.882436, longitude: -2.725610, scale: 72223.819286)
         
         // Create a feature layer.
         let featureServiceURL = URL(string: "https://services1.arcgis.com/6677msI40mnLuuLr/arcgis/rest/services/East_Lothian_Rivers/FeatureServer/0")!

--- a/arcgis-ios-sdk-samples/Layers/Identify raster cell/IdentifyRasterCellViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Identify raster cell/IdentifyRasterCellViewController.swift
@@ -52,7 +52,8 @@ class IdentifyRasterCellViewController: UIViewController {
     ///
     /// - Returns: An `AGSMap` object.
     func makeMap() -> AGSMap {
-        let map = AGSMap(basemapType: .oceans, latitude: -34.1, longitude: 18.6, levelOfDetail: 9)
+        let map = AGSMap(basemapStyle: .arcGISOceans)
+        map.initialViewpoint = AGSViewpoint(latitude: -34.1, longitude: 18.6, scale: 1155581.108577)
         map.operationalLayers.add(rasterLayer)
         return map
     }

--- a/arcgis-ios-sdk-samples/Layers/OpenStreetMap layer/OpenStreetMapLayerViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/OpenStreetMap layer/OpenStreetMapLayerViewController.swift
@@ -21,8 +21,9 @@ class OpenStreetMapLayerViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //initialize map with an OpenStreetMap basemap
-        let map = AGSMap(basemapType: .openStreetMap, latitude: 34.056295, longitude: -117.195800, levelOfDetail: 10)
+        //initialize map with an OpenStreetMap standard basemap
+        let map = AGSMap(basemapStyle: .osmStandard)
+        map.initialViewpoint = AGSViewpoint(latitude: 34.056295, longitude: -117.195800, scale: 577790.554289)
         //assign the map to the map view
         mapView.map = map
     

--- a/arcgis-ios-sdk-samples/Layers/Query a map image sublayer/QueryMapImageSublayerViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Query a map image sublayer/QueryMapImageSublayerViewController.swift
@@ -23,7 +23,7 @@ class QueryMapImageSublayerViewController: UIViewController {
     let graphicsOverlay: AGSGraphicsOverlay
     
     required init?(coder: NSCoder) {
-        map = AGSMap(basemap: .streetsVector())
+        map = AGSMap(basemapStyle: .arcGISStreets)
         
         // Set the initial viewpoint.
         let center = AGSPoint(x: -12716000.00, y: 4170400.00, spatialReference: .webMercator())

--- a/arcgis-ios-sdk-samples/Layers/Raster layer (geopackage)/RasterLayerGPKGViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Raster layer (geopackage)/RasterLayerGPKGViewController.swift
@@ -26,7 +26,8 @@ class RasterLayerGPKGViewController: UIViewController {
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["RasterLayerGPKGViewController"]
         
         // Instantiate a map using a basemap, location, and zoom level.
-        let map = AGSMap(basemapType: .lightGrayCanvasVector, latitude: 39.7294, longitude: -104.8319, levelOfDetail: 11)
+        let map = AGSMap(basemapStyle: .arcGISLightGrayBase)
+        map.initialViewpoint = AGSViewpoint(latitude: 39.7294, longitude: -104.8319, scale: 288895.277144)
         
         // Create a geopackage from a named bundle resource.
         geoPackage = AGSGeoPackage(name: "AuroraCO")

--- a/arcgis-ios-sdk-samples/Layers/Symbolize shapefile/SymbolizeShapefileViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Symbolize shapefile/SymbolizeShapefileViewController.swift
@@ -23,7 +23,7 @@ class SymbolizeShapefileViewController: UIViewController {
         super.viewDidLoad()
         
         // Instantiate a map using a basemap.
-        let map = AGSMap(basemap: .streetsVector())
+        let map = AGSMap(basemapStyle: .arcGISStreets)
         
         // Create a shapefile feature table from a named bundle resource.
         let shapefileTable = AGSShapefileFeatureTable(name: "Subdivisions")

--- a/arcgis-ios-sdk-samples/Layers/WMS layer (URL)/WMSLayerUsingURLViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/WMS layer (URL)/WMSLayerUsingURLViewController.swift
@@ -22,7 +22,8 @@ class WMSLayerUsingURLViewController: UIViewController {
         super.viewDidLoad()
         
         //initialize the map with a light gray basemap centered on the United States
-        let map = AGSMap(basemapType: .lightGrayCanvasVector, latitude: 39, longitude: -98, levelOfDetail: 4)
+        let map = AGSMap(basemapStyle: .arcGISLightGrayBase)
+        map.initialViewpoint = AGSViewpoint(latitude: 39, longitude: -98, scale: 3.6978595474472E7)
         //assign the map to the map view
         mapView.map = map
         

--- a/arcgis-ios-sdk-samples/Maps/Read a geopackage/ReadGeopackageViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Read a geopackage/ReadGeopackageViewController.swift
@@ -23,7 +23,8 @@ class ReadGeopackageViewController: UIViewController, UIPopoverPresentationContr
 
     func makeMap() -> AGSMap {
         // Instantiate and display a map using a basemap, location, and zoom level.
-        let map = AGSMap(basemapType: .streets, latitude: 39.7294, longitude: -104.8319, levelOfDetail: 11)
+        let map = AGSMap(basemapStyle: .arcGISStreets)
+        map.initialViewpoint = AGSViewpoint(latitude: 39.7294, longitude: -104.8319, scale: 288895.277144)
         
         // Create a geopackage from a named bundle resource.
         let geoPackage = AGSGeoPackage(name: "AuroraCO")

--- a/arcgis-ios-sdk-samples/Maps/Set initial map location/SetInitialMapLocationViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Set initial map location/SetInitialMapLocationViewController.swift
@@ -26,7 +26,9 @@ class SetInitialMapLocationViewController: UIViewController {
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["SetInitialMapLocationViewController"]
         
         //initialize map with `imagery with labels` basemap and an initial location
-        self.map = AGSMap(basemapType: .imageryWithLabels, latitude: -33.867886, longitude: -63.985, levelOfDetail: 16)
+        let map = AGSMap(basemapStyle: .arcGISImageryLabels)
+        map.initialViewpoint = AGSViewpoint(latitude: -33.867886, longitude: -63.985, scale: 9027.977411)
+        self.map = map
         
         //assign the map to the map view
         self.mapView.map = self.map

--- a/arcgis-ios-sdk-samples/Maps/Set initial map location/SetInitialMapLocationViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Set initial map location/SetInitialMapLocationViewController.swift
@@ -26,7 +26,7 @@ class SetInitialMapLocationViewController: UIViewController {
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["SetInitialMapLocationViewController"]
         
         //initialize map with `imagery with labels` basemap and an initial location
-        let map = AGSMap(basemapStyle: .arcGISImageryLabels)
+        let map = AGSMap(basemapStyle: .arcGISImagery)
         map.initialViewpoint = AGSViewpoint(latitude: -33.867886, longitude: -63.985, scale: 9027.977411)
         self.map = map
         

--- a/arcgis-ios-sdk-samples/Maps/Show location history/LocationHistoryViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Show location history/LocationHistoryViewController.swift
@@ -177,7 +177,7 @@ class LocationHistoryViewController: UIViewController {
     }
     
     private func setupMapView() {
-        let map = AGSMap(basemap: .lightGrayCanvasVector())
+        let map = AGSMap(basemapStyle: .arcGISLightGrayBase)
         mapView.map = map
         map.load { [weak self, unowned map] (_) in
             guard let self = self else { return }

--- a/arcgis-ios-sdk-samples/Route and directions/Find closest facility to an incident (interactive)/FindClosestFacilityInteractiveViewController.swift
+++ b/arcgis-ios-sdk-samples/Route and directions/Find closest facility to an incident (interactive)/FindClosestFacilityInteractiveViewController.swift
@@ -21,7 +21,9 @@ class FindClosestFacilityInteractiveViewController: UIViewController {
     @IBOutlet var mapView: AGSMapView! {
         didSet {
             // Initialize the map.
-            mapView.map = AGSMap(basemapType: .streets, latitude: 32.727, longitude: -117.1750, levelOfDetail: 12)
+            let map = AGSMap(basemapStyle: .arcGISStreets)
+            map.initialViewpoint = AGSViewpoint(latitude: 32.727, longitude: -117.1750, scale: 144447.638572)
+            mapView.map = map
             mapView.touchDelegate = self
             
             // Create symbols and graphics to add to the graphic overlays.

--- a/arcgis-ios-sdk-samples/Route and directions/Find service area interactive/FindServiceAreaInteractiveViewController.swift
+++ b/arcgis-ios-sdk-samples/Route and directions/Find service area interactive/FindServiceAreaInteractiveViewController.swift
@@ -38,7 +38,7 @@ class FindServiceAreaInteractiveViewController: UIViewController, AGSGeoViewTouc
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["FindServiceAreaInteractiveViewController", "ServiceAreaSettingsViewController"]
         
         //initialize map with basemap
-        let map = AGSMap(basemap: .terrainWithLabels())
+        let map = AGSMap(basemapStyle: .arcGISTerrain)
         
         //center for initial viewpoint
         let center = AGSPoint(x: -13041154, y: 3858170, spatialReference: .webMercator())

--- a/arcgis-ios-sdk-samples/Scenes/Terrain exaggeration/TerrainExaggerationViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Terrain exaggeration/TerrainExaggerationViewController.swift
@@ -21,7 +21,7 @@ class TerrainExaggerationViewController: UIViewController {
     @IBOutlet weak var sceneView: AGSSceneView!
     
     //initialize scene with streets basemap
-    let scene = AGSScene(basemapType: .streets)
+    let scene = AGSScene(basemapStyle: .arcGISStreets)
     
     //initialize surface
     let surface = AGSSurface()

--- a/arcgis-ios-sdk-samples/Utility network/Display utility associations/DisplayUtilityAssociationsViewController.swift
+++ b/arcgis-ios-sdk-samples/Utility network/Display utility associations/DisplayUtilityAssociationsViewController.swift
@@ -19,7 +19,9 @@ class DisplayUtilityAssociationsViewController: UIViewController {
     // Set the map.
     @IBOutlet var mapView: AGSMapView! {
         didSet {
-            mapView.map = AGSMap(basemapType: .topographicVector, latitude: 41.8057655, longitude: -88.1489692, levelOfDetail: 23)
+            let map = AGSMap(basemapStyle: .arcGISTopographic)
+            map.initialViewpoint = AGSViewpoint(latitude: 41.8057655, longitude: -88.1489692, scale: 70.5310735)
+            mapView.map = map
             mapView.graphicsOverlays.add(associationsOverlay)
         }
     }


### PR DESCRIPTION
This PR updates the basemap constructors to use the U10 new metered APIs.

---

## Initializer With `levelOfDetail`

The mapping between `levelOfDetail` and `scale` is copied from https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer

```swift
// From
let map = AGSMap(basemapType: .streets, latitude: 39.7294, longitude: -104.8319, levelOfDetail: 11)
// To
let map = AGSMap(basemapStyle: .arcGISStreets)
map.initialViewpoint = AGSViewpoint(latitude: 39.7294, longitude: -104.8319, scale: 288895.277144)
```

## Various basemap styles

Below are the remaining changes that will lead to many-to-one basemap mappings. For example: previously we had `streetsVector` and `streets` types, but the new API only has `arcGISStreets`. So both are mapped to the same new API.
According to Mike: 

> the new metered basemaps only showcase the vector versions. The raster basemaps are not accessible via the new basemap style enums.

AGSMap(basemap: .streetsVector())
AGSMap(basemapStyle: .arcGISStreets)

AGSMap(basemap: .lightGrayCanvasVector())
AGSMap(basemapStyle: .arcGISLightGrayBase)

AGSMap(basemap: .imageryWithLabelsVector())
AGSMap(basemapStyle: .arcGISImagery)

AGSMap(basemap: .topographicVector())
AGSMap(basemapStyle: .arcGISTopographic)

AGSMap(basemap: .terrainWithLabels())
AGSMap(basemapStyle: .arcGISTerrain)
