### PR TITLE
Fix: Group layer grouped toggle

### DIFF
--- a/arcgis-ios-sdk-samples/Layers/Group layers/GroupLayersSectionView.xib
+++ b/arcgis-ios-sdk-samples/Layers/Group layers/GroupLayersSectionView.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -24,7 +22,7 @@
                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9ku-4w-xzb">
                     <rect key="frame" x="310" y="6.5" width="51" height="31"/>
                     <connections>
-                        <action selector="toggleSwitch:" destination="-2" eventType="valueChanged" id="ndi-hb-abW"/>
+                        <action selector="toggleSwitch:" destination="XjP-9q-BD7" eventType="valueChanged" id="TNi-7m-uP8"/>
                     </connections>
                 </switch>
             </subviews>


### PR DESCRIPTION
This issue was spotted by Sarat. The PR fixes the toggle that controls group visibility.

To review: build with `v.next` and this branch to see the difference.

|Before|After|
|-|-|
|![before](https://user-images.githubusercontent.com/9660181/100912256-16a2e100-3485-11eb-8ec7-b124db9ccba5.gif)|![after](https://user-images.githubusercontent.com/9660181/100912252-1571b400-3485-11eb-92a9-8c463bd81036.gif)|
