### PR TITLE
Fix: Replace map.initialViewpoint with mapView.setViewpoint

### DIFF
--- a/arcgis-ios-sdk-samples/Analysis/Analyze hotspots/AnalyzeHotspotsViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Analyze hotspots/AnalyzeHotspotsViewController.swift
@@ -42,11 +42,9 @@ class AnalyzeHotspotsViewController: UIViewController, HotspotSettingsViewContro
         //initialize map with basemap
         let map = AGSMap(basemapStyle: .arcGISTopographic)
         
-        //center for initial viewpoint
-        let center = AGSPoint(x: -13671170.647485, y: 5693633.356735, spatialReference: .webMercator())
-        
         //assign map to map view
         mapView.map = map
+        let center = AGSPoint(x: -13671170.647485, y: 5693633.356735, spatialReference: .webMercator())
         mapView.setViewpoint(AGSViewpoint(center: center, scale: 57779))
     }
     

--- a/arcgis-ios-sdk-samples/Analysis/Analyze hotspots/AnalyzeHotspotsViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Analyze hotspots/AnalyzeHotspotsViewController.swift
@@ -45,11 +45,9 @@ class AnalyzeHotspotsViewController: UIViewController, HotspotSettingsViewContro
         //center for initial viewpoint
         let center = AGSPoint(x: -13671170.647485, y: 5693633.356735, spatialReference: .webMercator())
         
-        //set initial viewpoint
-        map.initialViewpoint = AGSViewpoint(center: center, scale: 57779)
-        
         //assign map to map view
         mapView.map = map
+        mapView.setViewpoint(AGSViewpoint(center: center, scale: 57779))
     }
     
     private func analyzeHotspots(_ fromDate: Date, toDate: Date) {

--- a/arcgis-ios-sdk-samples/Analysis/Viewshed (geoprocessing)/ViewshedGeoprocessingViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Viewshed (geoprocessing)/ViewshedGeoprocessingViewController.swift
@@ -31,9 +31,9 @@ class ViewshedGeoprocessingViewController: UIViewController, AGSGeoViewTouchDele
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["ViewshedGeoprocessingViewController"]
 
         let map = AGSMap(basemapStyle: .arcGISTopographic)
-        map.initialViewpoint = AGSViewpoint(latitude: 45.3790902612337, longitude: 6.84905317262762, scale: 144447.638572)
         
         self.mapView.map = map
+        self.mapView.setViewpoint(AGSViewpoint(latitude: 45.3790902612337, longitude: 6.84905317262762, scale: 144447.638572))
         
         self.mapView.touchDelegate = self
         

--- a/arcgis-ios-sdk-samples/Analysis/Viewshed (geoprocessing)/ViewshedGeoprocessingViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Viewshed (geoprocessing)/ViewshedGeoprocessingViewController.swift
@@ -30,9 +30,7 @@ class ViewshedGeoprocessingViewController: UIViewController, AGSGeoViewTouchDele
         //add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["ViewshedGeoprocessingViewController"]
 
-        let map = AGSMap(basemapStyle: .arcGISTopographic)
-        
-        self.mapView.map = map
+        self.mapView.map = AGSMap(basemapStyle: .arcGISTopographic)
         self.mapView.setViewpoint(AGSViewpoint(latitude: 45.3790902612337, longitude: 6.84905317262762, scale: 144447.638572))
         
         self.mapView.touchDelegate = self

--- a/arcgis-ios-sdk-samples/Display information/Add graphics with symbols/GraphicsWithSymbolsViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Add graphics with symbols/GraphicsWithSymbolsViewController.swift
@@ -28,13 +28,13 @@ class GraphicsWithSymbolsViewController: UIViewController {
         
         //instantiate map with basemap, initial viewpoint and level of detail
         let map = AGSMap(basemapStyle: .arcGISOceans)
-        map.initialViewpoint = AGSViewpoint(latitude: 56.075844, longitude: -2.681572, scale: 288895.277144)
         
         //assign the map to the map view
-        self.mapView.map = map
+        mapView.map = map
+        mapView.setViewpoint(AGSViewpoint(latitude: 56.075844, longitude: -2.681572, scale: 288895.277144))
         
         let graphicsOverlay = AGSGraphicsOverlay()
-        self.mapView.graphicsOverlays.add(graphicsOverlay)
+        mapView.graphicsOverlays.add(graphicsOverlay)
         
         //add some buoy positions to the graphics overlay
         addBuoyPoints(to: graphicsOverlay)

--- a/arcgis-ios-sdk-samples/Display information/Add graphics with symbols/GraphicsWithSymbolsViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Add graphics with symbols/GraphicsWithSymbolsViewController.swift
@@ -26,11 +26,8 @@ class GraphicsWithSymbolsViewController: UIViewController {
         //add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["GraphicsWithSymbolsViewController"]
         
-        //instantiate map with basemap, initial viewpoint and level of detail
-        let map = AGSMap(basemapStyle: .arcGISOceans)
-        
         //assign the map to the map view
-        mapView.map = map
+        mapView.map = AGSMap(basemapStyle: .arcGISOceans)
         mapView.setViewpoint(AGSViewpoint(latitude: 56.075844, longitude: -2.681572, scale: 288895.277144))
         
         let graphicsOverlay = AGSGraphicsOverlay()

--- a/arcgis-ios-sdk-samples/Display information/Display grid/DisplayGridViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Display grid/DisplayGridViewController.swift
@@ -29,12 +29,9 @@ class DisplayGridViewController: UIViewController {
             "OptionsTableViewController",
             "ColorPickerViewController"
         ]
-
-        // Initialize map with imagery basemap.
-        let map = AGSMap(basemapStyle: .arcGISImageryStandard)
         
         // Assign map to the map view.
-        mapView.map = map
+        mapView.map = AGSMap(basemapStyle: .arcGISImageryStandard)
         // Set viewpoint.
         let center = AGSPoint(x: -7702852.905619, y: 6217972.345771, spatialReference: .webMercator())
         mapView.setViewpoint(AGSViewpoint(center: center, scale: 23227))

--- a/arcgis-ios-sdk-samples/Display information/Display grid/DisplayGridViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Display grid/DisplayGridViewController.swift
@@ -22,7 +22,7 @@ class DisplayGridViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        // Add the source code button item to the right of navigation bar
+        // Add the source code button item to the right of navigation bar.
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = [
             "DisplayGridViewController",
             "DisplayGridSettingsViewController",
@@ -30,17 +30,16 @@ class DisplayGridViewController: UIViewController {
             "ColorPickerViewController"
         ]
 
-        // Initialize map with imagery basemap
+        // Initialize map with imagery basemap.
         let map = AGSMap(basemapStyle: .arcGISImageryStandard)
         
-        // Set initial viewpoint
-        let center = AGSPoint(x: -7702852.905619, y: 6217972.345771, spatialReference: .webMercator())
-        map.initialViewpoint = AGSViewpoint(center: center, scale: 23227)
-        
-        // Assign map to the map view
+        // Assign map to the map view.
         mapView.map = map
+        // Set viewpoint.
+        let center = AGSPoint(x: -7702852.905619, y: 6217972.345771, spatialReference: .webMercator())
+        mapView.setViewpoint(AGSViewpoint(center: center, scale: 23227))
         
-        // Add lat long grid
+        // Add lat long grid.
         mapView.grid = AGSLatitudeLongitudeGrid()
     }
     

--- a/arcgis-ios-sdk-samples/Display information/Picture marker symbols/PictureMarkerSymbolsViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Picture marker symbols/PictureMarkerSymbolsViewController.swift
@@ -26,22 +26,19 @@ class PictureMarkerSymbolsViewController: UIViewController {
         //add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["PictureMarkerSymbolsViewController"]
         
-        //initialize map with basemap
-        let map = AGSMap(basemapStyle: .arcGISTopographic)
-        
         //assign the map to the map view
-        mapView.map = map
+        self.mapView.map = AGSMap(basemapStyle: .arcGISTopographic)
         let center = AGSPoint(x: -225166.5, y: 6551249, spatialReference: .webMercator())
-        mapView.setViewpoint(AGSViewpoint(center: center, scale: 1e5))
+        self.mapView.setViewpoint(AGSViewpoint(center: center, scale: 1e5))
         
         //add the graphics overlay to the map view
-        mapView.graphicsOverlays.add(graphicsOverlay)
+        self.mapView.graphicsOverlays.add(graphicsOverlay)
         
         //add picture marker symbol using a remote image
-        addPictureMarkerSymbolFromURL()
+        self.addPictureMarkerSymbolFromURL()
         
         //add picture marker symbol using image in assets
-        addPictureMarkerSymbolFromImage()
+        self.addPictureMarkerSymbolFromImage()
     }
     
     private func addPictureMarkerSymbolFromURL() {
@@ -60,7 +57,7 @@ class PictureMarkerSymbolsViewController: UIViewController {
         let graphic = AGSGraphic(geometry: campsitePoint, symbol: campsiteSymbol, attributes: nil)
         
         //add the graphic to the overlay
-        graphicsOverlay.graphics.add(graphic)
+        self.graphicsOverlay.graphics.add(graphic)
     }
     
     private func addPictureMarkerSymbolFromImage() {
@@ -80,6 +77,6 @@ class PictureMarkerSymbolsViewController: UIViewController {
         let graphic = AGSGraphic(geometry: pinPoint, symbol: pinSymbol, attributes: nil)
         
         //add the graphic to the overlay
-        graphicsOverlay.graphics.add(graphic)
+        self.graphicsOverlay.graphics.add(graphic)
     }
 }

--- a/arcgis-ios-sdk-samples/Display information/Picture marker symbols/PictureMarkerSymbolsViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Picture marker symbols/PictureMarkerSymbolsViewController.swift
@@ -18,7 +18,7 @@ import ArcGIS
 class PictureMarkerSymbolsViewController: UIViewController {
     @IBOutlet var mapView: AGSMapView!
     
-    private var graphicsOverlay = AGSGraphicsOverlay()
+    private let graphicsOverlay = AGSGraphicsOverlay()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -29,21 +29,19 @@ class PictureMarkerSymbolsViewController: UIViewController {
         //initialize map with basemap
         let map = AGSMap(basemapStyle: .arcGISTopographic)
         
-        //initial envelope
-        let center = AGSPoint(x: -225166.5, y: 6551249, spatialReference: .webMercator())
-        map.initialViewpoint = AGSViewpoint(center: center, scale: 1e5)
-        
         //assign the map to the map view
-        self.mapView.map = map
+        mapView.map = map
+        let center = AGSPoint(x: -225166.5, y: 6551249, spatialReference: .webMercator())
+        mapView.setViewpoint(AGSViewpoint(center: center, scale: 1e5))
         
         //add the graphics overlay to the map view
-        self.mapView.graphicsOverlays.add(self.graphicsOverlay)
+        mapView.graphicsOverlays.add(graphicsOverlay)
         
         //add picture marker symbol using a remote image
-        self.addPictureMarkerSymbolFromURL()
+        addPictureMarkerSymbolFromURL()
         
         //add picture marker symbol using image in assets
-        self.addPictureMarkerSymbolFromImage()
+        addPictureMarkerSymbolFromImage()
     }
     
     private func addPictureMarkerSymbolFromURL() {
@@ -62,7 +60,7 @@ class PictureMarkerSymbolsViewController: UIViewController {
         let graphic = AGSGraphic(geometry: campsitePoint, symbol: campsiteSymbol, attributes: nil)
         
         //add the graphic to the overlay
-        self.graphicsOverlay.graphics.add(graphic)
+        graphicsOverlay.graphics.add(graphic)
     }
     
     private func addPictureMarkerSymbolFromImage() {
@@ -82,6 +80,6 @@ class PictureMarkerSymbolsViewController: UIViewController {
         let graphic = AGSGraphic(geometry: pinPoint, symbol: pinSymbol, attributes: nil)
         
         //add the graphic to the overlay
-        self.graphicsOverlay.graphics.add(graphic)
+        graphicsOverlay.graphics.add(graphic)
     }
 }

--- a/arcgis-ios-sdk-samples/Display information/Simple marker symbol/SimpleMarkerSymbolViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Simple marker symbol/SimpleMarkerSymbolViewController.swift
@@ -18,7 +18,7 @@ import ArcGIS
 class SimpleMarkerSymbolViewController: UIViewController {
     @IBOutlet var mapView: AGSMapView!
     
-    private var graphicsOverlay = AGSGraphicsOverlay()
+    private let graphicsOverlay = AGSGraphicsOverlay()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -29,18 +29,16 @@ class SimpleMarkerSymbolViewController: UIViewController {
         //initialize map with basemap
         let map = AGSMap(basemapStyle: .arcGISImagery)
         
-        //initial viewpoint
-        let center = AGSPoint(x: -226773, y: 6550477, spatialReference: .webMercator())
-        map.initialViewpoint = AGSViewpoint(center: center, scale: 6500)
-        
         //assign map to the map view
-        self.mapView.map = map
+        mapView.map = map
+        let center = AGSPoint(x: -226773, y: 6550477, spatialReference: .webMercator())
+        mapView.setViewpoint(AGSViewpoint(center: center, scale: 6500))
         
         //add graphics overlay to the map view
-        self.mapView.graphicsOverlays.add(graphicsOverlay)
+        mapView.graphicsOverlays.add(graphicsOverlay)
         
         //add a graphic with simple marker symbol
-        self.addSimpleMarkerSymbol()
+        addSimpleMarkerSymbol()
     }
 
     private func addSimpleMarkerSymbol() {
@@ -54,6 +52,6 @@ class SimpleMarkerSymbolViewController: UIViewController {
         let graphic = AGSGraphic(geometry: point, symbol: symbol, attributes: nil)
         
         //add the graphic to the graphics overlay
-        self.graphicsOverlay.graphics.add(graphic)
+        graphicsOverlay.graphics.add(graphic)
     }
 }

--- a/arcgis-ios-sdk-samples/Display information/Simple marker symbol/SimpleMarkerSymbolViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Simple marker symbol/SimpleMarkerSymbolViewController.swift
@@ -26,19 +26,16 @@ class SimpleMarkerSymbolViewController: UIViewController {
         //add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["SimpleMarkerSymbolViewController"]
         
-        //initialize map with basemap
-        let map = AGSMap(basemapStyle: .arcGISImagery)
-        
         //assign map to the map view
-        mapView.map = map
+        self.mapView.map = AGSMap(basemapStyle: .arcGISImagery)
         let center = AGSPoint(x: -226773, y: 6550477, spatialReference: .webMercator())
-        mapView.setViewpoint(AGSViewpoint(center: center, scale: 6500))
+        self.mapView.setViewpoint(AGSViewpoint(center: center, scale: 6500))
         
         //add graphics overlay to the map view
-        mapView.graphicsOverlays.add(graphicsOverlay)
+        self.mapView.graphicsOverlays.add(graphicsOverlay)
         
         //add a graphic with simple marker symbol
-        addSimpleMarkerSymbol()
+        self.addSimpleMarkerSymbol()
     }
 
     private func addSimpleMarkerSymbol() {
@@ -52,6 +49,6 @@ class SimpleMarkerSymbolViewController: UIViewController {
         let graphic = AGSGraphic(geometry: point, symbol: symbol, attributes: nil)
         
         //add the graphic to the graphics overlay
-        graphicsOverlay.graphics.add(graphic)
+        self.graphicsOverlay.graphics.add(graphic)
     }
 }

--- a/arcgis-ios-sdk-samples/Display information/Sketch on the map/SketchViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Sketch on the map/SketchViewController.swift
@@ -22,7 +22,6 @@ class SketchViewController: UIViewController {
     @IBOutlet private weak var redoBBI: UIBarButtonItem!
     @IBOutlet private weak var clearBBI: UIBarButtonItem!
     
-    private var map: AGSMap!
     private var sketchEditor: AGSSketchEditor!
     
     override func viewDidLoad() {
@@ -31,20 +30,20 @@ class SketchViewController: UIViewController {
         //add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["SketchViewController"]
         
-        self.map = AGSMap(basemapStyle: .arcGISLightGrayBase)
+        let map = AGSMap(basemapStyle: .arcGISLightGrayBase)
         
         self.sketchEditor = AGSSketchEditor()
         self.mapView.sketchEditor = self.sketchEditor
         
         self.sketchEditor.start(with: nil, creationMode: .polyline)
         
-        self.mapView.map = self.map
+        self.mapView.map = map
         self.mapView.interactionOptions.isMagnifierEnabled = true
         
         NotificationCenter.default.addObserver(self, selector: #selector(SketchViewController.respondToGeomChanged), name: .AGSSketchEditorGeometryDidChange, object: nil)
         
-        //set initial viewpoint
-        self.map.initialViewpoint = AGSViewpoint(targetExtent: AGSEnvelope(xMin: -10049589.670344, yMin: 3480099.843772, xMax: -10010071.251113, yMax: 3512023.489701, spatialReference: .webMercator()))
+        //set viewpoint
+        self.mapView.setViewpoint(AGSViewpoint(targetExtent: AGSEnvelope(xMin: -10049589.670344, yMin: 3480099.843772, xMax: -10010071.251113, yMax: 3512023.489701, spatialReference: .webMercator())))
     }
     
     @objc

--- a/arcgis-ios-sdk-samples/Display information/Sketch on the map/SketchViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Sketch on the map/SketchViewController.swift
@@ -30,14 +30,12 @@ class SketchViewController: UIViewController {
         //add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["SketchViewController"]
         
-        let map = AGSMap(basemapStyle: .arcGISLightGrayBase)
-        
         self.sketchEditor = AGSSketchEditor()
         self.mapView.sketchEditor = self.sketchEditor
         
         self.sketchEditor.start(with: nil, creationMode: .polyline)
         
-        self.mapView.map = map
+        self.mapView.map = AGSMap(basemapStyle: .arcGISLightGrayBase)
         self.mapView.interactionOptions.isMagnifierEnabled = true
         
         NotificationCenter.default.addObserver(self, selector: #selector(SketchViewController.respondToGeomChanged), name: .AGSSketchEditorGeometryDidChange, object: nil)

--- a/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
@@ -29,18 +29,17 @@ class AddFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate {
         
         //instantiate map with a basemap
         let map = AGSMap(basemapStyle: .arcGISStreets)
-        //set initial viewpoint
-        map.initialViewpoint = AGSViewpoint(center: AGSPoint(x: 544871.19, y: 6806138.66, spatialReference: .webMercator()), scale: 2e6)
         
         //assign the map to the map view
-        self.mapView.map = map
+        mapView.map = map
+        mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: 544871.19, y: 6806138.66, spatialReference: .webMercator()), scale: 2e6))
         //set touch delegate on map view as self
-        self.mapView.touchDelegate = self
+        mapView.touchDelegate = self
         
         //instantiate service feature table using the url to the service
-        self.featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0")!)
+        featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0")!)
         //create a feature layer using the service feature table
-        let featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
+        let featureLayer = AGSFeatureLayer(featureTable: featureTable)
         
         //add the feature layer to the operational layers on map
         map.operationalLayers.add(featureLayer)

--- a/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
@@ -27,19 +27,17 @@ class AddFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate {
         //add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["AddFeaturesViewController"]
         
-        //instantiate map with a basemap
-        let map = AGSMap(basemapStyle: .arcGISStreets)
-        
         //assign the map to the map view
-        mapView.map = map
-        mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: 544871.19, y: 6806138.66, spatialReference: .webMercator()), scale: 2e6))
+        let map = AGSMap(basemapStyle: .arcGISStreets)
+        self.mapView.map = map
+        self.mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: 544871.19, y: 6806138.66, spatialReference: .webMercator()), scale: 2e6))
         //set touch delegate on map view as self
-        mapView.touchDelegate = self
+        self.mapView.touchDelegate = self
         
         //instantiate service feature table using the url to the service
-        featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0")!)
+        self.featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0")!)
         //create a feature layer using the service feature table
-        let featureLayer = AGSFeatureLayer(featureTable: featureTable)
+        let featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
         
         //add the feature layer to the operational layers on map
         map.operationalLayers.add(featureLayer)

--- a/arcgis-ios-sdk-samples/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
@@ -31,18 +31,17 @@ class DeleteFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate, A
         
         //instantiate map with a basemap
         let map = AGSMap(basemapStyle: .arcGISStreets)
-        //set initial viewpoint
-        map.initialViewpoint = AGSViewpoint(center: AGSPoint(x: 544871.19, y: 6806138.66, spatialReference: .webMercator()), scale: 2e6)
         
         //assign the map to the map view
-        self.mapView.map = map
+        mapView.map = map
+        mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: 544871.19, y: 6806138.66, spatialReference: .webMercator()), scale: 2e6))
         //set touch delegate on map view as self
-        self.mapView.touchDelegate = self
+        mapView.touchDelegate = self
         
         //instantiate service feature table using the url to the service
-        self.featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0")!)
+        featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0")!)
         //create a feature layer using the service feature table
-        let featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
+        let featureLayer = AGSFeatureLayer(featureTable: featureTable)
         
         //add the feature layer to the operational layers on map
         map.operationalLayers.add(featureLayer)

--- a/arcgis-ios-sdk-samples/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
@@ -33,15 +33,15 @@ class DeleteFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate, A
         let map = AGSMap(basemapStyle: .arcGISStreets)
         
         //assign the map to the map view
-        mapView.map = map
-        mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: 544871.19, y: 6806138.66, spatialReference: .webMercator()), scale: 2e6))
+        self.mapView.map = map
+        self.mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: 544871.19, y: 6806138.66, spatialReference: .webMercator()), scale: 2e6))
         //set touch delegate on map view as self
-        mapView.touchDelegate = self
+        self.mapView.touchDelegate = self
         
         //instantiate service feature table using the url to the service
         featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0")!)
         //create a feature layer using the service feature table
-        let featureLayer = AGSFeatureLayer(featureTable: featureTable)
+        let featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
         
         //add the feature layer to the operational layers on map
         map.operationalLayers.add(featureLayer)

--- a/arcgis-ios-sdk-samples/Edit data/Edit feature attachments/EditFeatureAttachmentsViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit feature attachments/EditFeatureAttachmentsViewController.swift
@@ -41,14 +41,13 @@ class EditFeatureAttachmentsViewController: UIViewController {
         ]
         
         let map = AGSMap(basemapStyle: .arcGISOceans)
-        //set initial viewpoint
-        map.initialViewpoint = AGSViewpoint(
-            center: AGSPoint(x: 0, y: 0, spatialReference: .webMercator()),
-            scale: 100000000
-        )
         map.operationalLayers.add(featureLayer)
         
         mapView.map = map
+        mapView.setViewpoint(AGSViewpoint(
+            center: AGSPoint(x: 0, y: 0, spatialReference: .webMercator()),
+            scale: 100000000
+        ))
         mapView.touchDelegate = self
     }
 

--- a/arcgis-ios-sdk-samples/Edit data/Edit features (connected)/EditFeaturesOnlineViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit features (connected)/EditFeaturesOnlineViewController.swift
@@ -34,9 +34,8 @@ class EditFeaturesOnlineViewController: UIViewController, AGSGeoViewTouchDelegat
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["EditFeaturesOnlineViewController", "FeatureTemplatePickerViewController"]
         
         self.map = AGSMap(basemapStyle: .arcGISTopographic)
-        //set initial viewpoint
-        self.map.initialViewpoint = AGSViewpoint(center: AGSPoint(x: -9184518.55, y: 3240636.90, spatialReference: .webMercator()), scale: 7e5)
         self.mapView.map = self.map
+        self.mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: -9184518.55, y: 3240636.90, spatialReference: .webMercator()), scale: 7e5))
         self.mapView.touchDelegate = self
         
         let featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0")!)

--- a/arcgis-ios-sdk-samples/Edit data/Edit features with feature-linked annotation/EditFeaturesWithFeatureLinkedAnnotationViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit features with feature-linked annotation/EditFeaturesWithFeatureLinkedAnnotationViewController.swift
@@ -20,8 +20,8 @@ class EditFeaturesWithFeatureLinkedAnnotationViewController: UIViewController {
         didSet {
             // Create the map with a light gray canvas basemap centered on Loudoun, Virginia.
             let map = AGSMap(basemapStyle: .arcGISLightGrayBase)
-            map.initialViewpoint = AGSViewpoint(latitude: 39.0204, longitude: -77.4159, scale: 2256.994353)
             mapView.map = map
+            mapView.setViewpoint(AGSViewpoint(latitude: 39.0204, longitude: -77.4159, scale: 2256.994353))
             // Set the touch delegate.
             mapView.touchDelegate = self
         }

--- a/arcgis-ios-sdk-samples/Edit data/Edit features with feature-linked annotation/EditFeaturesWithFeatureLinkedAnnotationViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit features with feature-linked annotation/EditFeaturesWithFeatureLinkedAnnotationViewController.swift
@@ -19,8 +19,7 @@ class EditFeaturesWithFeatureLinkedAnnotationViewController: UIViewController {
     @IBOutlet weak var mapView: AGSMapView! {
         didSet {
             // Create the map with a light gray canvas basemap centered on Loudoun, Virginia.
-            let map = AGSMap(basemapStyle: .arcGISLightGrayBase)
-            mapView.map = map
+            mapView.map = AGSMap(basemapStyle: .arcGISLightGrayBase)
             mapView.setViewpoint(AGSViewpoint(latitude: 39.0204, longitude: -77.4159, scale: 2256.994353))
             // Set the touch delegate.
             mapView.touchDelegate = self

--- a/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/UpdateAttributesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/UpdateAttributesViewController.swift
@@ -39,15 +39,13 @@ class UpdateAttributesViewController: UIViewController, AGSGeoViewTouchDelegate,
         ]
         
         self.map = AGSMap(basemapStyle: .arcGISOceans)
-        //set initial viewpoint
-        self.map.initialViewpoint = AGSViewpoint(center: AGSPoint(x: 544871.19, y: 6806138.66, spatialReference: .webMercator()), scale: 2e6)
-        
         self.featureTable = AGSServiceFeatureTable(url: URL(string: featureServiceURL)!)
         let featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
         
         self.map.operationalLayers.add(featureLayer)
         
         self.mapView.map = self.map
+        self.mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: 544871.19, y: 6806138.66, spatialReference: .webMercator()), scale: 2e6))
         self.mapView.touchDelegate = self
         
         //store the feature layer for later use

--- a/arcgis-ios-sdk-samples/Edit data/Update geometries (feature service)/EditGeometryViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update geometries (feature service)/EditGeometryViewController.swift
@@ -35,8 +35,6 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["EditGeometryViewController"]
         
         self.map = AGSMap(basemapStyle: .arcGISOceans)
-        //set initial viewpoint
-        self.map.initialViewpoint = AGSViewpoint(center: AGSPoint(x: -9030446.96, y: 943791.32, spatialReference: .webMercator()), scale: 2e6)
         
         self.featureTable = AGSServiceFeatureTable(url: URL(string: featureServiceURL)!)
         let featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
@@ -44,6 +42,7 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
         self.map.operationalLayers.add(featureLayer)
 
         self.mapView.map = self.map
+        self.mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: -9030446.96, y: 943791.32, spatialReference: .webMercator()), scale: 2e6))
         self.mapView.touchDelegate = self
         
         //store the feature layer for later use

--- a/arcgis-ios-sdk-samples/Features/Add delete related features/AddDeleteRelatedFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Add delete related features/AddDeleteRelatedFeaturesViewController.swift
@@ -37,9 +37,6 @@ class AddDeleteRelatedFeaturesViewController: UIViewController, AGSGeoViewTouchD
         //initial viewpoint
         let point = AGSPoint(x: -16507762.575543, y: 9058828.127243, spatialReference: .webMercator())
         
-        //set initial viewpoint on map
-        map.initialViewpoint = AGSViewpoint(center: point, scale: 36764077)
-        
         //parks feature table
         self.parksFeatureTable = AGSServiceFeatureTable(url: URL(string: "https://services2.arcgis.com/ZQgQTuoyBrtmoGdP/ArcGIS/rest/services/AlaskaNationalParksSpecies_Add_Delete/FeatureServer/0")!)
         
@@ -58,10 +55,11 @@ class AddDeleteRelatedFeaturesViewController: UIViewController, AGSGeoViewTouchD
         map.tables.add(speciesFeatureTable)
         
         //assign map to map view
-        self.mapView.map = map
+        mapView.map = map
+        mapView.setViewpoint(AGSViewpoint(center: point, scale: 36764077))
         
         //set touch delegate
-        self.mapView.touchDelegate = self
+        mapView.touchDelegate = self
         
         //store the feature layer for later use
         self.parksFeatureLayer = parksFeatureLayer

--- a/arcgis-ios-sdk-samples/Features/Change feature layer renderer/OverrideRendererViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Change feature layer renderer/OverrideRendererViewController.swift
@@ -50,11 +50,11 @@ class OverrideRendererViewController: UIViewController {
         //create a new renderer using the symbol just created
         let renderer = AGSSimpleRenderer(symbol: symbol)
         //assign the new renderer to the feature layer
-        featureLayer.renderer = renderer
+        self.featureLayer.renderer = renderer
     }
     
     @IBAction private func resetRenderer() {
         //reset the renderer to default
-        featureLayer.resetRenderer()
+        self.featureLayer.resetRenderer()
     }
 }

--- a/arcgis-ios-sdk-samples/Features/Change feature layer renderer/OverrideRendererViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Change feature layer renderer/OverrideRendererViewController.swift
@@ -18,7 +18,6 @@ import ArcGIS
 class OverrideRendererViewController: UIViewController {
     @IBOutlet private weak var mapView: AGSMapView!
     
-    private var map: AGSMap!
     private var featureLayer: AGSFeatureLayer!
     
     override func viewDidLoad() {
@@ -28,18 +27,18 @@ class OverrideRendererViewController: UIViewController {
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["OverrideRendererViewController"]
         
         //initialize map with topographic basemap
-        self.map = AGSMap(basemapStyle: .arcGISTopographic)
-        //initial viewpoint
-        self.map.initialViewpoint = AGSViewpoint(targetExtent: AGSEnvelope(xMin: -1.30758164047166E7, yMin: 4014771.46954516, xMax: -1.30730056797177E7, yMax: 4016869.78617381, spatialReference: .webMercator()))
+        let map = AGSMap(basemapStyle: .arcGISTopographic)
+        
         //assign map to the map view's map
-        self.mapView.map = self.map
+        mapView.map = map
+        mapView.setViewpoint(AGSViewpoint(targetExtent: AGSEnvelope(xMin: -1.30758164047166E7, yMin: 4014771.46954516, xMax: -1.30730056797177E7, yMax: 4016869.78617381, spatialReference: .webMercator())))
         
         //initialize feature table using a url to feature server url
         let featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0")!)
         //initialize feature layer with feature table
         let featureLayer = AGSFeatureLayer(featureTable: featureTable)
         //add the feature layer to the operational layers on the map view
-        self.map.operationalLayers.add(featureLayer)
+        map.operationalLayers.add(featureLayer)
         
         //store the feature layer for later use
         self.featureLayer = featureLayer
@@ -51,11 +50,11 @@ class OverrideRendererViewController: UIViewController {
         //create a new renderer using the symbol just created
         let renderer = AGSSimpleRenderer(symbol: symbol)
         //assign the new renderer to the feature layer
-        self.featureLayer.renderer = renderer
+        featureLayer.renderer = renderer
     }
     
     @IBAction private func resetRenderer() {
         //reset the renderer to default
-        self.featureLayer.resetRenderer()
+        featureLayer.resetRenderer()
     }
 }

--- a/arcgis-ios-sdk-samples/Features/Feature collection layer/FeatureCollectionLayerViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature collection layer/FeatureCollectionLayerViewController.swift
@@ -28,12 +28,12 @@ class FeatureCollectionLayerViewController: UIViewController {
         //initialize map with basemap
         let map = AGSMap(basemapStyle: .arcGISOceans)
         
-        //initial viewpoint
-        let point = AGSPoint(x: -79.497238, y: 8.849289, spatialReference: .wgs84())
-        map.initialViewpoint = AGSViewpoint(center: point, scale: 1.5e6)
-        
         //assign map to the map view
-        self.mapView.map = map
+        mapView.map = map
+        
+        //set viewpoint
+        let point = AGSPoint(x: -79.497238, y: 8.849289, spatialReference: .wgs84())
+        mapView.setViewpoint(AGSViewpoint(center: point, scale: 1.5e6))
         
         self.addFeatureCollectionLayer()
     }

--- a/arcgis-ios-sdk-samples/Features/Feature layer (feature service)/FeatureLayerURLViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer (feature service)/FeatureLayerURLViewController.swift
@@ -27,11 +27,9 @@ class FeatureLayerURLViewController: UIViewController {
         //initialize map with basemap
         let map = AGSMap(basemapStyle: .arcGISTerrain)
         
-        //initial viewpoint
-        map.initialViewpoint = AGSViewpoint(center: AGSPoint(x: -13176752, y: 4090404, spatialReference: .webMercator()), scale: 300000)
-        
         //assign map to the map view
         self.mapView.map = map
+        self.mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: -13176752, y: 4090404, spatialReference: .webMercator()), scale: 300000))
         
         //initialize service feature table using url
         let featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/9")!)

--- a/arcgis-ios-sdk-samples/Features/Feature layer (geodatabase)/FeatureLayerGDBViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer (geodatabase)/FeatureLayerGDBViewController.swift
@@ -29,24 +29,23 @@ class FeatureLayerGDBViewController: UIViewController {
         //instantiate map with basemap
         let map = AGSMap(basemapStyle: .arcGISImagery)
         
-        //set initial viewpoint
-        map.initialViewpoint = AGSViewpoint(center: AGSPoint(x: -13214155, y: 4040194, spatialReference: .webMercator()), scale: 35e4)
+        //assign map to the map view
+        mapView.map = map
+        mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: -13214155, y: 4040194, spatialReference: .webMercator()), scale: 35e4))
         
         //instantiate geodatabase with name
-        self.geodatabase = AGSGeodatabase(name: "LA_Trails")
+        geodatabase = AGSGeodatabase(name: "LA_Trails")
         
         //load the geodatabase for feature tables
-        self.geodatabase.load { [weak self] (error: Error?) in
+        geodatabase.load { [weak self] (error: Error?) in
+            guard let self = self else { return }
             if let error = error {
-                self?.presentAlert(error: error)
+                self.presentAlert(error: error)
             } else {
-                let featureTable = self!.geodatabase.geodatabaseFeatureTable(withName: "Trailheads")!
+                let featureTable = self.geodatabase.geodatabaseFeatureTable(withName: "Trailheads")!
                 let featureLayer = AGSFeatureLayer(featureTable: featureTable)
-                self?.mapView.map?.operationalLayers.add(featureLayer)
+                self.mapView.map?.operationalLayers.add(featureLayer)
             }
         }
-        
-        //assign map to the map view
-        self.mapView.map = map
     }
 }

--- a/arcgis-ios-sdk-samples/Features/Feature layer (geodatabase)/FeatureLayerGDBViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer (geodatabase)/FeatureLayerGDBViewController.swift
@@ -34,17 +34,16 @@ class FeatureLayerGDBViewController: UIViewController {
         mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: -13214155, y: 4040194, spatialReference: .webMercator()), scale: 35e4))
         
         //instantiate geodatabase with name
-        geodatabase = AGSGeodatabase(name: "LA_Trails")
+        self.geodatabase = AGSGeodatabase(name: "LA_Trails")
         
         //load the geodatabase for feature tables
-        geodatabase.load { [weak self] (error: Error?) in
-            guard let self = self else { return }
+        self.geodatabase.load { [weak self] (error: Error?) in
             if let error = error {
-                self.presentAlert(error: error)
+                self?.presentAlert(error: error)
             } else {
-                let featureTable = self.geodatabase.geodatabaseFeatureTable(withName: "Trailheads")!
+                let featureTable = self!.geodatabase.geodatabaseFeatureTable(withName: "Trailheads")!
                 let featureLayer = AGSFeatureLayer(featureTable: featureTable)
-                self.mapView.map?.operationalLayers.add(featureLayer)
+                self?.mapView.map?.operationalLayers.add(featureLayer)
             }
         }
     }

--- a/arcgis-ios-sdk-samples/Features/Feature layer (geopackage)/FeatureLayerGPKGViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer (geopackage)/FeatureLayerGPKGViewController.swift
@@ -25,9 +25,12 @@ class FeatureLayerGPKGViewController: UIViewController {
         //add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["FeatureLayerGPKGViewController"]
         
-        // Instantiate a map using a basemap, location, and zoom level.
+        // Instantiate a map.
         let map = AGSMap(basemapStyle: .arcGISLightGrayBase)
-        map.initialViewpoint = AGSViewpoint(latitude: 39.7294, longitude: -104.8319, scale: 577790.554289)
+        
+        // Display the map in the map view.
+        mapView.map = map
+        mapView.setViewpoint(AGSViewpoint(latitude: 39.7294, longitude: -104.8319, scale: 577790.554289))
         
         // Create a geopackage from a named bundle resource.
         geoPackage = AGSGeoPackage(name: "AuroraCO")
@@ -45,8 +48,5 @@ class FeatureLayerGPKGViewController: UIViewController {
                 map.operationalLayers.add(featureLayer)
             }
         }
-        
-        // Display the map in the map view.
-        mapView.map = map
     }
 }

--- a/arcgis-ios-sdk-samples/Features/Feature layer definition expression/DefinitionExpressionViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer definition expression/DefinitionExpressionViewController.swift
@@ -47,11 +47,11 @@ class DefinitionExpressionViewController: UIViewController {
     
     @IBAction func applyDefinitionExpression() {
         //adding definition expression to show specific features only
-        featureLayer.definitionExpression = "req_Type = 'Tree Maintenance or Damage'"
+        self.featureLayer.definitionExpression = "req_Type = 'Tree Maintenance or Damage'"
     }
     
     @IBAction func resetDefinitionExpression() {
         //reset definition expression
-        featureLayer.definitionExpression = ""
+        self.featureLayer.definitionExpression = ""
     }
 }

--- a/arcgis-ios-sdk-samples/Features/Feature layer definition expression/DefinitionExpressionViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer definition expression/DefinitionExpressionViewController.swift
@@ -18,7 +18,6 @@ import ArcGIS
 class DefinitionExpressionViewController: UIViewController {
     @IBOutlet private weak var mapView: AGSMapView!
     
-    private var map: AGSMap!
     private var featureLayer: AGSFeatureLayer!
     
     override func viewDidLoad() {
@@ -28,12 +27,11 @@ class DefinitionExpressionViewController: UIViewController {
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["DefinitionExpressionViewController"]
         
         //initialize map using topographic basemap
-        self.map = AGSMap(basemapStyle: .arcGISTopographic)
-        //initial viewpoint
-        self.map.initialViewpoint = AGSViewpoint(center: AGSPoint(x: -13630484, y: 4545415, spatialReference: .webMercator()), scale: 90000)
+        let map = AGSMap(basemapStyle: .arcGISTopographic)
         
         //assign map to the map view's map
-        self.mapView.map = self.map
+        mapView.map = map
+        mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: -13630484, y: 4545415, spatialReference: .webMercator()), scale: 90000))
         
         //create feature table using a url to feature server's layer
         let featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0")!)
@@ -41,7 +39,7 @@ class DefinitionExpressionViewController: UIViewController {
         let featureLayer = AGSFeatureLayer(featureTable: featureTable)
         
         //add the feature layer to the map
-        self.map.operationalLayers.add(featureLayer)
+        map.operationalLayers.add(featureLayer)
         
         //store the feature layer for later use
         self.featureLayer = featureLayer
@@ -49,11 +47,11 @@ class DefinitionExpressionViewController: UIViewController {
     
     @IBAction func applyDefinitionExpression() {
         //adding definition expression to show specific features only
-        self.featureLayer.definitionExpression = "req_Type = 'Tree Maintenance or Damage'"
+        featureLayer.definitionExpression = "req_Type = 'Tree Maintenance or Damage'"
     }
     
     @IBAction func resetDefinitionExpression() {
         //reset definition expression
-        self.featureLayer.definitionExpression = ""
+        featureLayer.definitionExpression = ""
     }
 }

--- a/arcgis-ios-sdk-samples/Features/Feature layer selection/FeatureLayerSelectionViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer selection/FeatureLayerSelectionViewController.swift
@@ -24,6 +24,7 @@ class FeatureLayerSelectionViewController: UIViewController {
     @IBOutlet weak var mapView: AGSMapView! {
         didSet {
             mapView.map = makeMap()
+            mapView.setViewpoint(AGSViewpoint(targetExtent: AGSEnvelope(xMin: -180, yMin: -90, xMax: 180, yMax: 90, spatialReference: .wgs84())))
             mapView.touchDelegate = self
             mapView.selectionProperties.color = .cyan
         }
@@ -50,8 +51,6 @@ class FeatureLayerSelectionViewController: UIViewController {
     func makeMap() -> AGSMap {
         // Initialize map with topographic basemap.
         let map = AGSMap(basemapStyle: .arcGISStreets)
-        // Set initial viewpoint.
-        map.initialViewpoint = AGSViewpoint(targetExtent: AGSEnvelope(xMin: -180, yMin: -90, xMax: 180, yMax: 90, spatialReference: .wgs84()))
         // Add feature layer to the map.
         map.operationalLayers.add(featureLayer)
         return map

--- a/arcgis-ios-sdk-samples/Features/List related features/ListRelatedFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/List related features/ListRelatedFeaturesViewController.swift
@@ -36,8 +36,6 @@ class ListRelatedFeaturesViewController: UIViewController, AGSGeoViewTouchDelega
         
         //initial viewpoint
         let point = AGSPoint(x: -16507762.575543, y: 9058828.127243, spatialReference: .webMercator())
-        //set initial viewpoint on map
-        map.initialViewpoint = AGSViewpoint(center: point, scale: 36764077)
         
         //add self as the touch delegate for map view
         //we will need to be notified when the user taps with the map
@@ -64,7 +62,8 @@ class ListRelatedFeaturesViewController: UIViewController, AGSGeoViewTouchDelega
         map.tables.addObjects(from: [preservesFeatureTable, speciesFeatureTable])
         
         //assign map to the map view
-        self.mapView.map = map
+        mapView.map = map
+        mapView.setViewpoint(AGSViewpoint(center: point, scale: 36764077))
         
         //set selection color
         mapView.selectionProperties.color = .yellow

--- a/arcgis-ios-sdk-samples/Features/List related features/ListRelatedFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/List related features/ListRelatedFeaturesViewController.swift
@@ -34,9 +34,6 @@ class ListRelatedFeaturesViewController: UIViewController, AGSGeoViewTouchDelega
         //initialize map with a basemap
         let map = AGSMap(basemap: .nationalGeographic())
         
-        //initial viewpoint
-        let point = AGSPoint(x: -16507762.575543, y: 9058828.127243, spatialReference: .webMercator())
-        
         //add self as the touch delegate for map view
         //we will need to be notified when the user taps with the map
         self.mapView.touchDelegate = self
@@ -63,6 +60,7 @@ class ListRelatedFeaturesViewController: UIViewController, AGSGeoViewTouchDelega
         
         //assign map to the map view
         mapView.map = map
+        let point = AGSPoint(x: -16507762.575543, y: 9058828.127243, spatialReference: .webMercator())
         mapView.setViewpoint(AGSViewpoint(center: point, scale: 36764077))
         
         //set selection color

--- a/arcgis-ios-sdk-samples/Features/Service feature table (cache)/OnInteractionCacheViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Service feature table (cache)/OnInteractionCacheViewController.swift
@@ -18,8 +18,6 @@ import ArcGIS
 class OnInteractionCacheViewController: UIViewController {
     @IBOutlet private weak var mapView: AGSMapView!
     
-    private var map: AGSMap!
-    
     private let featureServiceURL = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0"
     
     override func viewDidLoad() {
@@ -29,15 +27,7 @@ class OnInteractionCacheViewController: UIViewController {
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["OnInteractionCacheViewController"]
         
         //initialize map with light gray canvas basemap
-        self.map = AGSMap(basemapStyle: .arcGISLightGrayBase)
-        
-        //initial viewpoint
-        self.map.initialViewpoint = AGSViewpoint(targetExtent: AGSEnvelope(
-            xMin: -1.30758164047166E7,
-            yMin: 4014771.46954516,
-            xMax: -1.30730056797177E7,
-            yMax: 4016869.78617381,
-            spatialReference: .webMercator()))
+        let map = AGSMap(basemapStyle: .arcGISLightGrayBase)
         
         //feature layer
         let featureTable = AGSServiceFeatureTable(url: URL(string: featureServiceURL)!)
@@ -45,8 +35,16 @@ class OnInteractionCacheViewController: UIViewController {
         featureTable.featureRequestMode = AGSFeatureRequestMode.onInteractionCache
         let featureLayer = AGSFeatureLayer(featureTable: featureTable)
         //add the feature layer to the map
-        self.map.operationalLayers.add(featureLayer)
+        map.operationalLayers.add(featureLayer)
         
-        self.mapView.map = self.map
+        mapView.map = map
+        let extent = AGSEnvelope(
+            xMin: -1.30758164047166E7,
+            yMin: 4014771.46954516,
+            xMax: -1.30730056797177E7,
+            yMax: 4016869.78617381,
+            spatialReference: .webMercator()
+        )
+        mapView.setViewpoint(AGSViewpoint(targetExtent: extent))
     }
 }

--- a/arcgis-ios-sdk-samples/Features/Service feature table (manual cache)/ManualCacheViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Service feature table (manual cache)/ManualCacheViewController.swift
@@ -18,7 +18,6 @@ import ArcGIS
 class ManualCacheViewController: UIViewController {
     @IBOutlet private weak var mapView: AGSMapView!
     
-    private var map: AGSMap!
     var featureTable: AGSServiceFeatureTable!
     
     override func viewDidLoad() {
@@ -28,21 +27,20 @@ class ManualCacheViewController: UIViewController {
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["ManualCacheViewController"]
         
         //initialize map with topographic basemap
-        self.map = AGSMap(basemapStyle: .arcGISTopographic)
-        //initial viewpoint
-        self.map.initialViewpoint = AGSViewpoint(center: AGSPoint(x: -13630484, y: 4545415, spatialReference: .webMercator()), scale: 500000)
-        
-        //assign map to the map view
-        self.mapView.map = self.map
+        let map = AGSMap(basemapStyle: .arcGISTopographic)
         
         //create feature table using a url
-        self.featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0")!)
+        featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0")!)
         //set the feature request mode to Manual Cache
         featureTable.featureRequestMode = AGSFeatureRequestMode.manualCache
         //create feature layer using this feature table
-        let featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
+        let featureLayer = AGSFeatureLayer(featureTable: featureTable)
         //add feature layer to the map
-        self.map.operationalLayers.add(featureLayer)
+        map.operationalLayers.add(featureLayer)
+        
+        //assign map to the map view
+        mapView.map = map
+        mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: -13630484, y: 4545415, spatialReference: .webMercator()), scale: 500000))
     }
     
     // MARK: - Actions
@@ -54,7 +52,7 @@ class ManualCacheViewController: UIViewController {
         params.whereClause = "req_Type = 'Tree Maintenance or Damage'"
         
         //populate features based on query
-        self.featureTable.populateFromService(with: params, clearCache: true, outFields: ["*"]) { [weak self] (result: AGSFeatureQueryResult?, error: Error?) in
+        featureTable.populateFromService(with: params, clearCache: true, outFields: ["*"]) { [weak self] (result: AGSFeatureQueryResult?, error: Error?) in
             //check for error
             if let error = error {
                 self?.presentAlert(error: error)

--- a/arcgis-ios-sdk-samples/Features/Service feature table (manual cache)/ManualCacheViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Service feature table (manual cache)/ManualCacheViewController.swift
@@ -30,11 +30,11 @@ class ManualCacheViewController: UIViewController {
         let map = AGSMap(basemapStyle: .arcGISTopographic)
         
         //create feature table using a url
-        featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0")!)
+        self.featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0")!)
         //set the feature request mode to Manual Cache
         featureTable.featureRequestMode = AGSFeatureRequestMode.manualCache
         //create feature layer using this feature table
-        let featureLayer = AGSFeatureLayer(featureTable: featureTable)
+        let featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
         //add feature layer to the map
         map.operationalLayers.add(featureLayer)
         
@@ -52,7 +52,7 @@ class ManualCacheViewController: UIViewController {
         params.whereClause = "req_Type = 'Tree Maintenance or Damage'"
         
         //populate features based on query
-        featureTable.populateFromService(with: params, clearCache: true, outFields: ["*"]) { [weak self] (result: AGSFeatureQueryResult?, error: Error?) in
+        self.featureTable.populateFromService(with: params, clearCache: true, outFields: ["*"]) { [weak self] (result: AGSFeatureQueryResult?, error: Error?) in
             //check for error
             if let error = error {
                 self?.presentAlert(error: error)

--- a/arcgis-ios-sdk-samples/Features/Service feature table (no cache)/OnInteractionNoCacheViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Service feature table (no cache)/OnInteractionNoCacheViewController.swift
@@ -18,8 +18,6 @@ import ArcGIS
 class OnInteractionNoCacheViewController: UIViewController {
     @IBOutlet private weak var mapView: AGSMapView!
     
-    private var map: AGSMap!
-    
     private let featureServiceURL = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0"
     
     override func viewDidLoad() {
@@ -29,15 +27,7 @@ class OnInteractionNoCacheViewController: UIViewController {
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["OnInteractionNoCacheViewController"]
         
         //initialize map with topographic basemap
-        self.map = AGSMap(basemapStyle: .arcGISTopographic)
-        
-        //initial viewpoint
-        self.map.initialViewpoint = AGSViewpoint(targetExtent: AGSEnvelope(
-            xMin: -1.30758164047166E7,
-            yMin: 4014771.46954516,
-            xMax: -1.30730056797177E7,
-            yMax: 4016869.78617381,
-            spatialReference: .webMercator()))
+        let map = AGSMap(basemapStyle: .arcGISTopographic)
         
         //feature layer
         let featureTable = AGSServiceFeatureTable(url: URL(string: featureServiceURL)!)
@@ -45,8 +35,16 @@ class OnInteractionNoCacheViewController: UIViewController {
         featureTable.featureRequestMode = AGSFeatureRequestMode.onInteractionNoCache
         let featureLayer = AGSFeatureLayer(featureTable: featureTable)
         //add the feature layer to the map
-        self.map.operationalLayers.add(featureLayer)
+        map.operationalLayers.add(featureLayer)
         
-        self.mapView.map = self.map
+        mapView.map = map
+        let extent = AGSEnvelope(
+            xMin: -1.30758164047166E7,
+            yMin: 4014771.46954516,
+            xMax: -1.30730056797177E7,
+            yMax: 4016869.78617381,
+            spatialReference: .webMercator()
+        )
+        mapView.setViewpoint(AGSViewpoint(targetExtent: extent))
     }
 }

--- a/arcgis-ios-sdk-samples/Geometry/Spatial operations/SpatialOperationsViewController.swift
+++ b/arcgis-ios-sdk-samples/Geometry/Spatial operations/SpatialOperationsViewController.swift
@@ -25,7 +25,7 @@ class SpatialOperationsViewController: UIViewController {
             mapView.map = AGSMap(basemapStyle: .arcGISTopographic)
             // Add the graphics overlay with two polygon graphics and the result graphic to map view.
             mapView.graphicsOverlays.add(makeGraphicsOverlay())
-            // Set initial viewpoint.
+            // Set the map view's viewpoint.
             let center = AGSPoint(x: -13453, y: 6710127, spatialReference: .webMercator())
             mapView.setViewpointCenter(center, scale: 30000, completion: nil)
         }

--- a/arcgis-ios-sdk-samples/Layers/Change sublayer renderer/ChangeSublayerRendererViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Change sublayer renderer/ChangeSublayerRendererViewController.swift
@@ -20,7 +20,7 @@ class ChangeSublayerRendererViewController: UIViewController {
     @IBOutlet private var resetBarButtonItem: UIBarButtonItem!
     @IBOutlet private var applyRendererBarButtonItem: UIBarButtonItem!
     
-    //map image layer
+    /// Map image layer.
     private let mapImageLayer = AGSArcGISMapImageLayer(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer")!)
     /// The counties sublayer of the map image layer.
     private var countiesSublayer: AGSArcGISMapImageSublayer?
@@ -29,25 +29,23 @@ class ChangeSublayerRendererViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // Add the source code button item to the right of navigation bar.
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["ChangeSublayerRendererViewController"]
         
-        //initialize map with basemap
+        // Initialize map with basemap.
         let map = AGSMap(basemapStyle: .arcGISStreets)
         
-        //add map image layer to the map
-        map.operationalLayers.add(self.mapImageLayer)
+        // Add map image layer to the map.
+        map.operationalLayers.add(mapImageLayer)
         
-        //initial viewpoint
+        // Set map on the map view.
+        mapView.map = map
+        
+        // Set viewpoint.
         let envelope = AGSEnvelope(xMin: -13834661.666904, yMin: 331181.323482, xMax: -8255704.998713, yMax: 9118038.075882, spatialReference: .webMercator())
+        mapView.setViewpoint(AGSViewpoint(targetExtent: envelope))
         
-        //set initial viewpoint on map
-        map.initialViewpoint = AGSViewpoint(targetExtent: envelope)
-        
-        //set map on the map view
-        self.mapView.map = map
-        
-        //load map image layer to access sublayers
+        // Load map image layer to access sublayers.
         self.mapImageLayer.load { [weak self] (error: Error?) in
             guard let self = self else { return }
             if let error = error {
@@ -60,14 +58,14 @@ class ChangeSublayerRendererViewController: UIViewController {
     
     /// Called in response to the map image layer loading successfully.
     func mapImageLayerDidLoad() {
-        //get the counties sublayer
+        // Get the counties sublayer.
         let mapImageSublayers = mapImageLayer.mapImageSublayers
         guard mapImageSublayers.count >= 3,
             let sublayer = mapImageSublayers[2] as? AGSArcGISMapImageSublayer else {
                 return
         }
         countiesSublayer = sublayer
-        //load the sublayer to get the original renderer
+        // Load the sublayer to get the original renderer.
         sublayer.load { [weak self] (error) in
             guard let self = self else { return }
             if let error = error {
@@ -82,7 +80,7 @@ class ChangeSublayerRendererViewController: UIViewController {
     func countiesSublayerDidLoad() {
         originalRenderer = countiesSublayer?.renderer
         
-        //enable bar button items
+        // Enable bar button items.
         applyRendererBarButtonItem.isEnabled = true
         resetBarButtonItem.isEnabled = true
     }
@@ -92,24 +90,24 @@ class ChangeSublayerRendererViewController: UIViewController {
     ///
     /// - Returns: An `AGSClassBreaksRenderer` object.
     private func makeClassBreakRenderer() -> AGSClassBreaksRenderer {
-        //outline symbol
+        // Outline symbol.
         let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: UIColor(white: 0.6, alpha: 1), width: 0.5)
         
-        //symbols for each class break
+        // Symbols for each class break.
         let symbol1 = AGSSimpleFillSymbol(style: .solid, color: UIColor(red: 0.89, green: 0.92, blue: 0.81, alpha: 1), outline: lineSymbol)
         let symbol2 = AGSSimpleFillSymbol(style: .solid, color: UIColor(red: 0.59, green: 0.76, blue: 0.75, alpha: 1), outline: lineSymbol)
         let symbol3 = AGSSimpleFillSymbol(style: .solid, color: UIColor(red: 0.38, green: 0.65, blue: 0.71, alpha: 1), outline: lineSymbol)
         let symbol4 = AGSSimpleFillSymbol(style: .solid, color: UIColor(red: 0.27, green: 0.49, blue: 0.59, alpha: 1), outline: lineSymbol)
         let symbol5 = AGSSimpleFillSymbol(style: .solid, color: UIColor(red: 0.16, green: 0.33, blue: 0.47, alpha: 1), outline: lineSymbol)
         
-        //class breaks
+        // Class breaks.
         let classBreak1 = AGSClassBreak(description: "-99 to 8560", label: "-99 to 8560", minValue: -99, maxValue: 8560, symbol: symbol1)
         let classBreak2 = AGSClassBreak(description: "> 8,560 to 18,109", label: "> 8,560 to 18,109", minValue: 8561, maxValue: 18109, symbol: symbol2)
         let classBreak3 = AGSClassBreak(description: "> 18,109 to 35,501", label: "> 18,109 to 35,501", minValue: 18110, maxValue: 35501, symbol: symbol3)
         let classBreak4 = AGSClassBreak(description: "> 35,501 to 86,100", label: "> 35,501 to 86,100", minValue: 35502, maxValue: 86100, symbol: symbol4)
         let classBreak5 = AGSClassBreak(description: "> 86,100 to 10,110,975", label: "> 86,100 to 10,110,975", minValue: 86101, maxValue: 10110975, symbol: symbol5)
         
-        //create a class break renderer using the class breaks above
+        // Create a class break renderer using the class breaks above.
         let classBreakRenderer = AGSClassBreaksRenderer(fieldName: "POP2007", classBreaks: [ classBreak1, classBreak2, classBreak3, classBreak4, classBreak5])
         
         return classBreakRenderer

--- a/arcgis-ios-sdk-samples/Layers/Display KML/DisplayKMLViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Display KML/DisplayKMLViewController.swift
@@ -46,9 +46,10 @@ class DisplayKMLViewController: UIViewController {
         
         // Instantiate a map with a dark gray basemap centered on the United States
         let map = AGSMap(basemapStyle: .arcGISDarkGray)
-        map.initialViewpoint = AGSViewpoint(latitude: 39, longitude: -98, scale: 3.6978595474472E7)
+        
         // Display the map in the map view
         mapView.map = map
+        mapView.setViewpoint(AGSViewpoint(latitude: 39, longitude: -98, scale: 3.6978595474472E7))
         
         // Show the initial KML source
         updateMapForDisplayedSource()

--- a/arcgis-ios-sdk-samples/Layers/Display KML/DisplayKMLViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Display KML/DisplayKMLViewController.swift
@@ -44,14 +44,14 @@ class DisplayKMLViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        // Instantiate a map with a dark gray basemap centered on the United States
+        // Instantiate a map with a dark gray basemap.
         let map = AGSMap(basemapStyle: .arcGISDarkGray)
         
-        // Display the map in the map view
+        // Display the map in the map view.
         mapView.map = map
         mapView.setViewpoint(AGSViewpoint(latitude: 39, longitude: -98, scale: 3.6978595474472E7))
         
-        // Show the initial KML source
+        // Show the initial KML source.
         updateMapForDisplayedSource()
         
         // Add the source code button item to the right of navigation bar.

--- a/arcgis-ios-sdk-samples/Layers/Display a WFS layer/DisplayWFSViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Display a WFS layer/DisplayWFSViewController.swift
@@ -59,11 +59,9 @@ class DisplayWFSViewController: UIViewController {
             }
         }
         
-        // Set initial viewpoint
-        map.initialViewpoint = AGSViewpoint(targetExtent: AGSEnvelope(xMin: -122.341581, yMin: 47.613758, xMax: -122.332662, yMax: 47.617207, spatialReference: .wgs84()))
-        
         // Assign the map to the map view
         mapView.map = map
+        mapView.setViewpoint(AGSViewpoint(targetExtent: AGSEnvelope(xMin: -122.341581, yMin: 47.613758, xMax: -122.332662, yMax: 47.617207, spatialReference: .wgs84())))
 
         // Add the source code button item to the right of navigation bar
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["DisplayWFSViewController"]

--- a/arcgis-ios-sdk-samples/Layers/Display annotation/DisplayAnnotationViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Display annotation/DisplayAnnotationViewController.swift
@@ -20,12 +20,12 @@ class DisplayAnnotationViewController: UIViewController {
         didSet {
             // Assign the map to the map view.
             mapView.map = makeMap()
+            mapView.setViewpoint(AGSViewpoint(latitude: 55.882436, longitude: -2.725610, scale: 72223.819286))
         }
     }
     
     func makeMap() -> AGSMap {
         let map = AGSMap(basemapStyle: .arcGISLightGray)
-        map.initialViewpoint = AGSViewpoint(latitude: 55.882436, longitude: -2.725610, scale: 72223.819286)
         
         // Create a feature layer.
         let featureServiceURL = URL(string: "https://services1.arcgis.com/6677msI40mnLuuLr/arcgis/rest/services/East_Lothian_Rivers/FeatureServer/0")!

--- a/arcgis-ios-sdk-samples/Layers/Display subtype feature layer/DisplaySubtypeFeatureLayerViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Display subtype feature layer/DisplaySubtypeFeatureLayerViewController.swift
@@ -20,6 +20,7 @@ class DisplaySubtypeFeatureLayerViewController: UIViewController {
     @IBOutlet private weak var mapView: AGSMapView! {
         didSet {
             mapView.map = makeMap()
+            mapView.setViewpoint(AGSViewpoint(targetExtent: AGSEnvelope(xMin: -9812691.11079696, yMin: 5128687.20710657, xMax: -9812377.9447607, yMax: 5128865.36767282, spatialReference: .webMercator())))
         }
     }
     
@@ -54,7 +55,6 @@ class DisplaySubtypeFeatureLayerViewController: UIViewController {
     
     func makeMap() -> AGSMap {
         let map = AGSMap(basemapStyle: .arcGISStreetsNight)
-        map.initialViewpoint = AGSViewpoint(targetExtent: AGSEnvelope(xMin: -9812691.11079696, yMin: 5128687.20710657, xMax: -9812377.9447607, yMax: 5128865.36767282, spatialReference: .webMercator()))
 
         // Create a subtype feature layer from a service feature table.
         let featureServiceURL = URL(string: "https://sampleserver7.arcgisonline.com/arcgis/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer/100")

--- a/arcgis-ios-sdk-samples/Layers/Identify KML features/IdentifyKMLFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Identify KML features/IdentifyKMLFeaturesViewController.swift
@@ -36,10 +36,9 @@ class IdentifyKMLFeaturesViewController: UIViewController {
         let map = AGSMap(basemapStyle: .arcGISDarkGrayBase)
         map.operationalLayers.add(forecastLayer)
         
-        let center = AGSPoint(x: -48_885, y: 1_718_235, spatialReference: AGSSpatialReference(wkid: 5070))
-        map.initialViewpoint = AGSViewpoint(center: center, scale: 50_000_000)
-        
         mapView.map = map
+        let center = AGSPoint(x: -48_885, y: 1_718_235, spatialReference: AGSSpatialReference(wkid: 5070))
+        mapView.setViewpoint(AGSViewpoint(center: center, scale: 50_000_000))
         
         // Add the source code button item to the right of navigation bar.
         (self.navigationItem.rightBarButtonItem as? SourceCodeBarButtonItem)?.filenames = ["IdentifyKMLFeaturesViewController"]

--- a/arcgis-ios-sdk-samples/Layers/Identify raster cell/IdentifyRasterCellViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Identify raster cell/IdentifyRasterCellViewController.swift
@@ -25,6 +25,7 @@ class IdentifyRasterCellViewController: UIViewController {
     @IBOutlet weak var mapView: AGSMapView! {
         didSet {
             mapView.map = makeMap()
+            mapView.setViewpoint(AGSViewpoint(latitude: -34.1, longitude: 18.6, scale: 1155581.108577))
             mapView.touchDelegate = self
             mapView.callout.customView = calloutStackView
             mapView.callout.isAccessoryButtonHidden = true
@@ -53,7 +54,6 @@ class IdentifyRasterCellViewController: UIViewController {
     /// - Returns: An `AGSMap` object.
     func makeMap() -> AGSMap {
         let map = AGSMap(basemapStyle: .arcGISOceans)
-        map.initialViewpoint = AGSViewpoint(latitude: -34.1, longitude: 18.6, scale: 1155581.108577)
         map.operationalLayers.add(rasterLayer)
         return map
     }

--- a/arcgis-ios-sdk-samples/Layers/Manage sublayers/ManageSublayersViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Manage sublayers/ManageSublayersViewController.swift
@@ -44,7 +44,7 @@ class ManageSublayersViewController: UIViewController, MapImageSublayersViewCont
         //assign map to map view
         self.mapView.map = map
         
-        //set initial viewpoint on map
+        //set the viewpoint on map view
         self.mapView.setViewpoint(AGSViewpoint(targetExtent: envelope))
         
         //create sublayers from tableSublayerSource

--- a/arcgis-ios-sdk-samples/Layers/Manage sublayers/ManageSublayersViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Manage sublayers/ManageSublayersViewController.swift
@@ -41,11 +41,11 @@ class ManageSublayersViewController: UIViewController, MapImageSublayersViewCont
         //initial viewpoint
         let envelope = AGSEnvelope(xMin: -13834661.666904, yMin: 331181.323482, xMax: -8255704.998713, yMax: 9118038.075882, spatialReference: .webMercator())
         
-        //set initial viewpoint on map
-        map.initialViewpoint = AGSViewpoint(targetExtent: envelope)
-        
         //assign map to map view
         self.mapView.map = map
+        
+        //set initial viewpoint on map
+        self.mapView.setViewpoint(AGSViewpoint(targetExtent: envelope))
         
         //create sublayers from tableSublayerSource
         self.createSublayers()

--- a/arcgis-ios-sdk-samples/Layers/OpenStreetMap layer/OpenStreetMapLayerViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/OpenStreetMap layer/OpenStreetMapLayerViewController.swift
@@ -23,9 +23,10 @@ class OpenStreetMapLayerViewController: UIViewController {
         
         //initialize map with an OpenStreetMap standard basemap
         let map = AGSMap(basemapStyle: .osmStandard)
-        map.initialViewpoint = AGSViewpoint(latitude: 34.056295, longitude: -117.195800, scale: 577790.554289)
+        
         //assign the map to the map view
         mapView.map = map
+        mapView.setViewpoint(AGSViewpoint(latitude: 34.056295, longitude: -117.195800, scale: 577790.554289))
     
         //add the source code button item to the right of navigation bar
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["OpenStreetMapLayerViewController"]

--- a/arcgis-ios-sdk-samples/Layers/Query a map image sublayer/QueryMapImageSublayerViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Query a map image sublayer/QueryMapImageSublayerViewController.swift
@@ -25,10 +25,6 @@ class QueryMapImageSublayerViewController: UIViewController {
     required init?(coder: NSCoder) {
         map = AGSMap(basemapStyle: .arcGISStreets)
         
-        // Set the initial viewpoint.
-        let center = AGSPoint(x: -12716000.00, y: 4170400.00, spatialReference: .webMercator())
-        map.initialViewpoint = AGSViewpoint(center: center, scale: 6000000)
-        
         /// The url of a map service containing sample data of the United States.
         let unitedStatesMapServiceURL = URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer")!
         // Create an image layer and add it to the map.
@@ -62,6 +58,9 @@ class QueryMapImageSublayerViewController: UIViewController {
         
         // Assign the map to the map view.
         mapView.map = map
+        // Set the viewpoint.
+        let center = AGSPoint(x: -12716000.00, y: 4170400.00, spatialReference: .webMercator())
+        mapView.setViewpoint(AGSViewpoint(center: center, scale: 6000000))
         
         // Add the graphics overlay to the map view.
         mapView.graphicsOverlays.add(graphicsOverlay)

--- a/arcgis-ios-sdk-samples/Layers/Raster layer (geopackage)/RasterLayerGPKGViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Raster layer (geopackage)/RasterLayerGPKGViewController.swift
@@ -25,9 +25,8 @@ class RasterLayerGPKGViewController: UIViewController {
         //add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["RasterLayerGPKGViewController"]
         
-        // Instantiate a map using a basemap, location, and zoom level.
+        // Instantiate a map.
         let map = AGSMap(basemapStyle: .arcGISLightGrayBase)
-        map.initialViewpoint = AGSViewpoint(latitude: 39.7294, longitude: -104.8319, scale: 288895.277144)
         
         // Create a geopackage from a named bundle resource.
         geoPackage = AGSGeoPackage(name: "AuroraCO")
@@ -50,5 +49,6 @@ class RasterLayerGPKGViewController: UIViewController {
         
         // Display the map in the map view.
         mapView.map = map
+        mapView.setViewpoint(AGSViewpoint(latitude: 39.7294, longitude: -104.8319, scale: 288895.277144))
     }
 }

--- a/arcgis-ios-sdk-samples/Layers/WMS layer (URL)/WMSLayerUsingURLViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/WMS layer (URL)/WMSLayerUsingURLViewController.swift
@@ -21,7 +21,7 @@ class WMSLayerUsingURLViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //initialize the map with a light gray basemap centered on the United States
+        //initialize the map with a light gray basemap
         let map = AGSMap(basemapStyle: .arcGISLightGrayBase)
         
         //assign the map to the map view

--- a/arcgis-ios-sdk-samples/Layers/WMS layer (URL)/WMSLayerUsingURLViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/WMS layer (URL)/WMSLayerUsingURLViewController.swift
@@ -23,9 +23,10 @@ class WMSLayerUsingURLViewController: UIViewController {
         
         //initialize the map with a light gray basemap centered on the United States
         let map = AGSMap(basemapStyle: .arcGISLightGrayBase)
-        map.initialViewpoint = AGSViewpoint(latitude: 39, longitude: -98, scale: 3.6978595474472E7)
+        
         //assign the map to the map view
         mapView.map = map
+        mapView.setViewpoint(AGSViewpoint(latitude: 39, longitude: -98, scale: 3.6978595474472E7))
         
         // a URL to the GetCapabilities endpoint of a WMS service
         let wmsServiceURL = URL(string: "https://nowcoast.noaa.gov/arcgis/services/nowcoast/radar_meteo_imagery_nexrad_time/MapServer/WMSServer?request=GetCapabilities&service=WMS")!

--- a/arcgis-ios-sdk-samples/Maps/Change map view background/ChangeMapViewBackgroundViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Change map view background/ChangeMapViewBackgroundViewController.swift
@@ -21,25 +21,25 @@ class ChangeMapViewBackgroundViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // Add the source code button item to the right of navigation bar.
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["ChangeMapViewBackgroundViewController", "GridSettingsViewController", "ColorPickerViewController"]
         
-        //initialize tiled layer
+        // Initialize tiled layer.
         let tiledLayer = AGSArcGISTiledLayer(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer")!)
 
-        //initialize map with tiled layer as basemap
+        // Initialize map with tiled layer as basemap.
         let map = AGSMap(basemap: AGSBasemap(baseLayer: tiledLayer))
         
-        //set initial viewpoint
-        let center = AGSPoint(x: 3224786, y: 2661231, spatialReference: .webMercator())
-        map.initialViewpoint = AGSViewpoint(center: center, scale: 236663484)
-
-        //assign map to the map view
+        // Assign map to the map view.
         mapView.map = map
         
-        // create a background grid with default values
+        // Set initial viewpoint.
+        let center = AGSPoint(x: 3224786, y: 2661231, spatialReference: .webMercator())
+        mapView.setViewpoint(AGSViewpoint(center: center, scale: 236663484))
+        
+        // Create a background grid with default values.
         let backgroundGrid = AGSBackgroundGrid(color: .black, gridLineColor: .white, gridLineWidth: 2, gridSize: 32)
-        // assign the background grid to the map view
+        // Assign the background grid to the map view.
         mapView.backgroundGrid = backgroundGrid
     }
     
@@ -67,7 +67,7 @@ class ChangeMapViewBackgroundViewController: UIViewController {
 
 extension ChangeMapViewBackgroundViewController: UIAdaptivePresentationControllerDelegate {
     func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
-        // ensure that the settings are show in a popover even on small displays
+        // Ensure that the settings are shown in a popover on small displays.
         return .none
     }
 }

--- a/arcgis-ios-sdk-samples/Maps/Change map view background/ChangeMapViewBackgroundViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Change map view background/ChangeMapViewBackgroundViewController.swift
@@ -33,7 +33,7 @@ class ChangeMapViewBackgroundViewController: UIViewController {
         // Assign map to the map view.
         mapView.map = map
         
-        // Set initial viewpoint.
+        // Set the map view's viewpoint.
         let center = AGSPoint(x: 3224786, y: 2661231, spatialReference: .webMercator())
         mapView.setViewpoint(AGSViewpoint(center: center, scale: 236663484))
         

--- a/arcgis-ios-sdk-samples/Maps/Display drawing status/MapViewDrawStatusViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Display drawing status/MapViewDrawStatusViewController.swift
@@ -26,22 +26,20 @@ class MapViewDrawStatusViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // Add the source code button item to the right of navigation bar.
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["MapViewDrawStatusViewController"]
         
-        //instantiate the map with topographic basemap
-        self.map = AGSMap(basemapStyle: .arcGISTopographic)
+        // Instantiate the map with topographic basemap.
+        map = AGSMap(basemapStyle: .arcGISTopographic)
         
-        //initial viewpoint
-        self.map?.initialViewpoint = AGSViewpoint(targetExtent: AGSEnvelope(xMin: -13639984, yMin: 4537387, xMax: -13606734, yMax: 4558866, spatialReference: .webMercator()))
-        
-        //add a feature layer
+        // Add a feature layer.
         let featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0")!)
         let featureLayer = AGSFeatureLayer(featureTable: featureTable)
-        self.map?.operationalLayers.add(featureLayer)
+        map?.operationalLayers.add(featureLayer)
         
-        //assign the map to mapView
-        self.mapView.map = self.map
+        // Assign the map to mapView.
+        mapView.map = map
+        mapView.setViewpoint(AGSViewpoint(targetExtent: AGSEnvelope(xMin: -13639984, yMin: 4537387, xMax: -13606734, yMax: 4558866, spatialReference: .webMercator())))
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/arcgis-ios-sdk-samples/Maps/Display layer view state/LayerStatusViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Display layer view state/LayerStatusViewController.swift
@@ -22,6 +22,7 @@ class LayerStatusViewController: UIViewController {
     @IBOutlet weak var mapView: AGSMapView! {
         didSet {
             mapView.map = makeMap(featureLayer: featureLayer)
+            mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: -11e6, y: 45e5, spatialReference: .webMercator()), scale: 2e7))
             mapView.layerViewStateChangedHandler = { [weak self] layer, state in
                 guard let self = self else { return }
                 // Only check the view state of the feature layer.
@@ -55,7 +56,6 @@ class LayerStatusViewController: UIViewController {
     func makeMap(featureLayer: AGSFeatureLayer) -> AGSMap {
         let map = AGSMap(basemapStyle: .arcGISTopographic)
         map.operationalLayers.add(featureLayer)
-        map.initialViewpoint = AGSViewpoint(center: AGSPoint(x: -11e6, y: 45e5, spatialReference: .webMercator()), scale: 2e7)
         return map
     }
     

--- a/arcgis-ios-sdk-samples/Maps/Identify layers/IdentifyLayersViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Identify layers/IdentifyLayersViewController.swift
@@ -18,18 +18,16 @@ import ArcGIS
 class IdentifyLayersViewController: UIViewController, AGSGeoViewTouchDelegate {
     @IBOutlet var mapView: AGSMapView!
     
-    private var map: AGSMap!
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // Add the source code button item to the right of navigation bar.
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["IdentifyLayersViewController"]
         
-        //create an instance of a map
-        self.map = AGSMap(basemapStyle: .arcGISTopographic)
+        // Create an instance of a map
+        let map = AGSMap(basemapStyle: .arcGISTopographic)
         
-        //map image layer
+        // Map image layer.
         let mapImageLayer = AGSArcGISMapImageLayer(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer")!)
         
         //hide Continent and World layers
@@ -39,42 +37,42 @@ class IdentifyLayersViewController: UIViewController, AGSGeoViewTouchDelegate {
                 mapImageLayer?.subLayerContents[2].isVisible = false
             }
         }
-        self.map.operationalLayers.add(mapImageLayer)
+        map.operationalLayers.add(mapImageLayer)
         
-        //feature table
+        // Feature table.
         let featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0")!)
     
-        //feature layer
+        // Feature layer.
         let featureLayer = AGSFeatureLayer(featureTable: featureTable)
         
-        //add feature layer add to the operational layers
-        self.map.operationalLayers.add(featureLayer)
+        // Add feature layer add to the operational layers.
+        map.operationalLayers.add(featureLayer)
         
-        //set initial viewpoint to a specific region
-        self.map.initialViewpoint = AGSViewpoint(center: AGSPoint(x: -10977012.785807, y: 4514257.550369, spatialReference: .webMercator()), scale: 68015210)
+        // Assign map to the map view.
+        mapView.map = map
         
-        //assign map to the map view
-        self.mapView.map = self.map
+        // Set viewpoint to a specific region.
+        mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: -10977012.785807, y: 4514257.550369, spatialReference: .webMercator()), scale: 68015210))
         
-        //add self as the touch delegate for the map view
-        self.mapView.touchDelegate = self
+        // Add self as the touch delegate for the map view.
+        mapView.touchDelegate = self
     }
     
     // MARK: - AGSGeoViewTouchDelegate
     
     func geoView(_ geoView: AGSGeoView, didTapAtScreenPoint screenPoint: CGPoint, mapPoint: AGSPoint) {
-        //get the geoElements for all layers present at the tapped point
+        // Get the geoElements for all layers present at the tapped point.
         self.identifyLayers(screenPoint)
     }
     
     // MARK: - Identify layers
     
     private func identifyLayers(_ screen: CGPoint) {
-        //show progress hud
+        // Show progress hud.
         SVProgressHUD.show(withStatus: "Identifying")
         
         self.mapView.identifyLayers(atScreenPoint: screen, tolerance: 12, returnPopupsOnly: false, maximumResultsPerLayer: 10) { (results: [AGSIdentifyLayerResult]?, error: Error?) in
-            //dismiss progress hud
+            // Dismiss progress hud.
             SVProgressHUD.dismiss()
             
             if let error = error {
@@ -95,47 +93,47 @@ class IdentifyLayersViewController: UIViewController, AGSGeoViewTouchDelegate {
             let layerName = identifyLayerResult.layerContent.name
             messageString.append("\(layerName) :: \(count)")
             
-            //add new line character if not the final element in array
+            // Add new line character if not the final element in array.
             if identifyLayerResult != results.last! {
                 messageString.append(" \n ")
             }
             
-            //update total count
+            // Update total count.
             totalCount += count
         }
         
-        //if any elements were found show the results
-        //else notify user that no elements were found
         if totalCount > 0 {
+            // If any elements were found, show the results.
             presentAlert(title: "Number of elements found", message: messageString)
         } else {
+            // Notify user that no elements were found.
             presentAlert(message: "No element found")
         }
     }
     
     private func geoElementsCountFromResult(_ result: AGSIdentifyLayerResult) -> Int {
-        //create temp array
+        // Create temp array.
         var tempResults = [result]
         
-        //using Depth First Search approach to handle recursion
+        // Using Depth First Search approach to handle recursion.
         var count = 0
         var index = 0
         
         while index < tempResults.count {
-            //get the result object from the array
+            // Get the result object from the array.
             let identifyResult = tempResults[index]
             
-            //update count with geoElements from the result
+            // Update count with geoElements from the result.
             count += identifyResult.geoElements.count
             
-            //check if the result has any sublayer results
-            //if yes then add those result objects in the tempResults
-            //array after the current result
+            // Check if the result has any sublayer results.
+            // If yes then add those result objects in the tempResults
+            // array after the current result.
             if !identifyResult.sublayerResults.isEmpty {
                 tempResults.insert(contentsOf: identifyResult.sublayerResults, at: index + 1)
             }
             
-            //update the count and repeat
+            // Update the count and repeat.
             index += 1
         }
         

--- a/arcgis-ios-sdk-samples/Maps/Manage operational layers/ManageMapLayersViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Manage operational layers/ManageMapLayersViewController.swift
@@ -32,32 +32,32 @@ class ManageMapLayersViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // Add the source code button item to the right of navigation bar.
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = [
             "ManageMapLayersViewController",
             "MMLLayersViewController"
         ]
-                
-        let map = AGSMap(basemapStyle: .arcGISTopographic)
-        map.initialViewpoint = AGSViewpoint(center: AGSPoint(x: -133e5, y: 45e5, spatialReference: .webMercator()), scale: 2e7)
         
         let elevationImageLayer = AGSArcGISMapImageLayer(url: URL(string: "https://sampleserver5.arcgisonline.com/arcgis/rest/services/Elevation/WorldElevations/MapServer")!)
         let censusTiledLayer = AGSArcGISMapImageLayer(url: URL(string: "https://sampleserver5.arcgisonline.com/arcgis/rest/services/Census/MapServer")!)
         
         allLayers = [elevationImageLayer, censusTiledLayer]
         
-        // load all the layers into the map to start
+        let map = AGSMap(basemapStyle: .arcGISTopographic)
+        
+        // Load all the layers into the map to start.
         map.operationalLayers.addObjects(from: allLayers)
         
         mapView.map = map
+        mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: -133e5, y: 45e5, spatialReference: .webMercator()), scale: 2e7))
     }
     
     // MARK: - Navigation
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if let navController = segue.destination as? UINavigationController,
-            let controller = navController.viewControllers.first as? MMLLayersViewController {
-            // convert and assign the map's operational layers as a Swift array
+           let controller = navController.viewControllers.first as? MMLLayersViewController {
+            // Convert and assign the map's operational layers as a Swift array.
             controller.map = mapView?.map
             controller.allLayers = allLayers
             controller.preferredContentSize = CGSize(width: 300, height: 200)

--- a/arcgis-ios-sdk-samples/Maps/Map rotation/MapRotationViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Map rotation/MapRotationViewController.swift
@@ -42,7 +42,7 @@ class MapRotationViewController: UIViewController {
             }
         }
 
-        // Set initial viewpoint.
+        // Set the map view's viewpoint.
         mapView.setViewpoint(AGSViewpoint(targetExtent: AGSEnvelope(xMin: -13044000, yMin: 3855000, xMax: -13040000, yMax: 3858000, spatialReference: .webMercator())))
     }
     

--- a/arcgis-ios-sdk-samples/Maps/Map rotation/MapRotationViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Map rotation/MapRotationViewController.swift
@@ -26,24 +26,24 @@ class MapRotationViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // Add the source code button item to the right of navigation bar.
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["MapRotationViewController"]
         
-        //instantiate map with topographic basemap
-        self.map = AGSMap(basemapStyle: .arcGISStreets)
+        // Instantiate map with topographic basemap.
+        map = AGSMap(basemapStyle: .arcGISStreets)
         
-        //assign map to the map view
-        self.mapView.map = self.map
+        // Assign map to the map view.
+        mapView.map = map
         
-        //update the slider value when the user rotates by pinching
-        self.mapView.viewpointChangedHandler = { [weak self] in 
+        // Update the slider value when the user rotates by pinching.
+        mapView.viewpointChangedHandler = { [weak self] in
             DispatchQueue.main.async {
                 self?.mapViewpointDidChange()
             }
         }
 
-        //initial viewpoint
-        self.map.initialViewpoint = AGSViewpoint(targetExtent: AGSEnvelope(xMin: -13044000, yMin: 3855000, xMax: -13040000, yMax: 3858000, spatialReference: .webMercator()))
+        // Set initial viewpoint.
+        mapView.setViewpoint(AGSViewpoint(targetExtent: AGSEnvelope(xMin: -13044000, yMin: 3855000, xMax: -13040000, yMax: 3858000, spatialReference: .webMercator())))
     }
     
     func mapViewpointDidChange() {
@@ -54,16 +54,16 @@ class MapRotationViewController: UIViewController {
     
     // MARK: - Actions
     
-    //rotate the map view based on the value of the slider
+    // Rotate the map view based on the value of the slider
     @IBAction private func sliderValueChanged(_ slider: UISlider) {
-        if let viewpoint = self.mapView.currentViewpoint(with: AGSViewpointType.centerAndScale) {
+        if let viewpoint = mapView.currentViewpoint(with: AGSViewpointType.centerAndScale) {
             let rotatedViewpoint = AGSViewpoint(center: viewpoint.targetGeometry as! AGSPoint, scale: viewpoint.targetScale, rotation: Double(slider.value))
-            self.mapView.setViewpoint(rotatedViewpoint)
+            mapView.setViewpoint(rotatedViewpoint)
         }
     }
     
     @IBAction private func compassAction() {
-        self.compassButton.transform = CGAffineTransform.identity
-        self.mapView.setViewpointRotation(0, completion: nil)
+        compassButton.transform = CGAffineTransform.identity
+        mapView.setViewpointRotation(0, completion: nil)
     }
 }

--- a/arcgis-ios-sdk-samples/Maps/Read a geopackage/ReadGeopackageViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Read a geopackage/ReadGeopackageViewController.swift
@@ -18,13 +18,13 @@ class ReadGeopackageViewController: UIViewController, UIPopoverPresentationContr
     @IBOutlet weak var mapView: AGSMapView! {
         didSet {
             mapView.map = makeMap()
+            mapView.setViewpoint(AGSViewpoint(latitude: 39.7294, longitude: -104.8319, scale: 288895.277144))
         }
     }
 
     func makeMap() -> AGSMap {
-        // Instantiate and display a map using a basemap, location, and zoom level.
+        // Instantiate a map.
         let map = AGSMap(basemapStyle: .arcGISStreets)
-        map.initialViewpoint = AGSViewpoint(latitude: 39.7294, longitude: -104.8319, scale: 288895.277144)
         
         // Create a geopackage from a named bundle resource.
         let geoPackage = AGSGeoPackage(name: "AuroraCO")

--- a/arcgis-ios-sdk-samples/Maps/Set initial map area/SetInitialMapAreaViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Set initial map area/SetInitialMapAreaViewController.swift
@@ -30,7 +30,7 @@ class SetInitialMapAreaViewController: UIViewController {
         // Assign the map to the map view.
         mapView.map = map
         
-        // Set initial map area.
+        // Set the map view's viewpoint.
         let envelope = AGSEnvelope(xMin: -12211308.778729, yMin: 4645116.003309, xMax: -12208257.879667, yMax: 4650542.535773, spatialReference: .webMercator())
         mapView.setViewpoint(AGSViewpoint(targetExtent: envelope))
     }

--- a/arcgis-ios-sdk-samples/Maps/Set initial map area/SetInitialMapAreaViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Set initial map area/SetInitialMapAreaViewController.swift
@@ -17,22 +17,21 @@ import ArcGIS
 
 class SetInitialMapAreaViewController: UIViewController {
     @IBOutlet weak var mapView: AGSMapView!
-    var map: AGSMap!
     
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        //add the source code button item to the right of navigation bar
+        // Add the source code button item to the right of navigation bar.
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["SetInitialMapAreaViewController"]
         
-        //initialize the map with imagery basemap
-        self.map = AGSMap(basemapStyle: .arcGISImageryStandard)
-        
-        //set initial map area
-        let envelope = AGSEnvelope(xMin: -12211308.778729, yMin: 4645116.003309, xMax: -12208257.879667, yMax: 4650542.535773, spatialReference: .webMercator())
-        self.map.initialViewpoint = AGSViewpoint(targetExtent: envelope)
+        // Initialize the map with imagery basemap.
+        let map = AGSMap(basemapStyle: .arcGISImageryStandard)
 
-        //assign the map to the map view
-        self.mapView.map = map
+        // Assign the map to the map view.
+        mapView.map = map
+        
+        // Set initial map area.
+        let envelope = AGSEnvelope(xMin: -12211308.778729, yMin: 4645116.003309, xMax: -12208257.879667, yMax: 4650542.535773, spatialReference: .webMercator())
+        mapView.setViewpoint(AGSViewpoint(targetExtent: envelope))
     }
 }

--- a/arcgis-ios-sdk-samples/Maps/Set initial map location/SetInitialMapLocationViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Set initial map location/SetInitialMapLocationViewController.swift
@@ -24,7 +24,7 @@ class SetInitialMapLocationViewController: UIViewController {
         // Add the source code button item to the right of navigation bar.
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["SetInitialMapLocationViewController"]
         
-        // Initialize map with imagery basemap and an initial location.
+        // Initialize map with imagery basemap.
         let map = AGSMap(basemapStyle: .arcGISImagery)
         
         // Assign the map to the map view.

--- a/arcgis-ios-sdk-samples/Maps/Set initial map location/SetInitialMapLocationViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Set initial map location/SetInitialMapLocationViewController.swift
@@ -17,20 +17,18 @@ import ArcGIS
 
 class SetInitialMapLocationViewController: UIViewController {
     @IBOutlet weak var mapView: AGSMapView!
-    var map: AGSMap!
     
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        //add the source code button item to the right of navigation bar
+        // Add the source code button item to the right of navigation bar.
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["SetInitialMapLocationViewController"]
         
-        //initialize map with `imagery with labels` basemap and an initial location
+        // Initialize map with imagery basemap and an initial location.
         let map = AGSMap(basemapStyle: .arcGISImagery)
-        map.initialViewpoint = AGSViewpoint(latitude: -33.867886, longitude: -63.985, scale: 9027.977411)
-        self.map = map
         
-        //assign the map to the map view
-        self.mapView.map = self.map
+        // Assign the map to the map view.
+        mapView.map = map
+        mapView.setViewpoint(AGSViewpoint(latitude: -33.867886, longitude: -63.985, scale: 9027.977411))
     }
 }

--- a/arcgis-ios-sdk-samples/Route and directions/Find closest facility to an incident (interactive)/FindClosestFacilityInteractiveViewController.swift
+++ b/arcgis-ios-sdk-samples/Route and directions/Find closest facility to an incident (interactive)/FindClosestFacilityInteractiveViewController.swift
@@ -22,8 +22,8 @@ class FindClosestFacilityInteractiveViewController: UIViewController {
         didSet {
             // Initialize the map.
             let map = AGSMap(basemapStyle: .arcGISStreets)
-            map.initialViewpoint = AGSViewpoint(latitude: 32.727, longitude: -117.1750, scale: 144447.638572)
             mapView.map = map
+            mapView.setViewpoint(AGSViewpoint(latitude: 32.727, longitude: -117.1750, scale: 144447.638572))
             mapView.touchDelegate = self
             
             // Create symbols and graphics to add to the graphic overlays.

--- a/arcgis-ios-sdk-samples/Route and directions/Find service area interactive/FindServiceAreaInteractiveViewController.swift
+++ b/arcgis-ios-sdk-samples/Route and directions/Find service area interactive/FindServiceAreaInteractiveViewController.swift
@@ -43,11 +43,9 @@ class FindServiceAreaInteractiveViewController: UIViewController, AGSGeoViewTouc
         //center for initial viewpoint
         let center = AGSPoint(x: -13041154, y: 3858170, spatialReference: .webMercator())
         
-        //initial viewpoint
-        map.initialViewpoint = AGSViewpoint(center: center, scale: 1e5)
-        
         //assign map to map view
         self.mapView.map = map
+        self.mapView.setViewpoint(AGSViewpoint(center: center, scale: 1e5))
         
         //assign touch delegate as self to know when use interacted with the map view
         //Will be adding facilities and barriers on interaction

--- a/arcgis-ios-sdk-samples/Utility network/Display utility associations/DisplayUtilityAssociationsViewController.swift
+++ b/arcgis-ios-sdk-samples/Utility network/Display utility associations/DisplayUtilityAssociationsViewController.swift
@@ -20,8 +20,8 @@ class DisplayUtilityAssociationsViewController: UIViewController {
     @IBOutlet var mapView: AGSMapView! {
         didSet {
             let map = AGSMap(basemapStyle: .arcGISTopographic)
-            map.initialViewpoint = AGSViewpoint(latitude: 41.8057655, longitude: -88.1489692, scale: 70.5310735)
             mapView.map = map
+            mapView.setViewpoint(AGSViewpoint(latitude: 41.8057655, longitude: -88.1489692, scale: 70.5310735))
             mapView.graphicsOverlays.add(associationsOverlay)
         }
     }

--- a/arcgis-ios-sdk-samples/Utility network/Trace utility network/TraceUtilityNetworkViewController.swift
+++ b/arcgis-ios-sdk-samples/Utility network/Trace utility network/TraceUtilityNetworkViewController.swift
@@ -17,7 +17,7 @@ import ArcGIS
 
 class TraceUtilityNetworkViewController: UIViewController, AGSGeoViewTouchDelegate {
     @IBOutlet weak var mapView: AGSMapView!
-
+    
     @IBOutlet weak var traceNetworkButton: UIBarButtonItem!
     @IBOutlet weak var resetButton: UIBarButtonItem!
     @IBOutlet weak var typeButton: UIBarButtonItem!
@@ -57,13 +57,13 @@ class TraceUtilityNetworkViewController: UIViewController, AGSGeoViewTouchDelega
             return layer
         }
     }
-
+    
     private let map: AGSMap
     private let utilityNetwork: AGSUtilityNetwork
     private var utilityTier: AGSUtilityTier?
     private var traceType = (name: "Connected", type: AGSUtilityTraceType.connected)
     private var traceParameters = AGSUtilityTraceParameters(traceType: .connected, startingLocations: [])
-
+    
     private let parametersOverlay: AGSGraphicsOverlay = {
         let barrierPointSymbol = AGSSimpleMarkerSymbol(style: .X, color: .red, size: 20)
         let barrierUniqueValue = AGSUniqueValue(
@@ -79,7 +79,7 @@ class TraceUtilityNetworkViewController: UIViewController, AGSGeoViewTouchDelega
             defaultSymbol: startingPointSymbol)
         let overlay = AGSGraphicsOverlay()
         overlay.renderer = renderer
-
+        
         return overlay
     }()
     
@@ -87,17 +87,9 @@ class TraceUtilityNetworkViewController: UIViewController, AGSGeoViewTouchDelega
     required init?(coder aDecoder: NSCoder) {
         // Create the map
         map = AGSMap(basemapStyle: .arcGISStreetsNight)
-        map.initialViewpoint = AGSViewpoint(
-            targetExtent: AGSEnvelope(
-                xMin: -9813547.35557238,
-                yMin: 5129980.36635111,
-                xMax: -9813185.0602376,
-                yMax: 5130215.41254146,
-                spatialReference: .webMercator()
-        ))
         // Create the utility network, referencing the map.
         utilityNetwork = AGSUtilityNetwork(url: featureServiceURL, map: map)
-
+        
         super.init(coder: aDecoder)
         
         // Add the utility network feature layers to the map for display.
@@ -113,9 +105,17 @@ class TraceUtilityNetworkViewController: UIViewController, AGSGeoViewTouchDelega
         
         // Initialize the UI
         setUIState()
-
+        
         // Set up the map view
         mapView.map = map
+        let extent = AGSEnvelope(
+            xMin: -9813547.35557238,
+            yMin: 5129980.36635111,
+            xMax: -9813185.0602376,
+            yMax: 5130215.41254146,
+            spatialReference: .webMercator()
+        )
+        mapView.setViewpoint(AGSViewpoint(targetExtent: extent))
         mapView.graphicsOverlays.add(parametersOverlay)
         mapView.touchDelegate = self
         // Set the selection color for features in the map view.
@@ -147,7 +147,7 @@ class TraceUtilityNetworkViewController: UIViewController, AGSGeoViewTouchDelega
         if let identifyAction = identifyAction {
             identifyAction.cancel()
         }
-
+        
         setStatus(message: "Identifying trace locations…")
         identifyAction = mapView.identifyLayers(atScreenPoint: screenPoint, tolerance: 10, returnPopupsOnly: false) { [weak self] (result, error) in
             guard let self = self else { return }
@@ -158,7 +158,7 @@ class TraceUtilityNetworkViewController: UIViewController, AGSGeoViewTouchDelega
             }
             
             guard let feature = result?.first?.geoElements.first as? AGSArcGISFeature else { return }
-
+            
             self.addStartElementOrBarrier(for: feature, at: mapPoint)
         }
     }
@@ -171,25 +171,25 @@ class TraceUtilityNetworkViewController: UIViewController, AGSGeoViewTouchDelega
     ///   - location: The `AGSPoint` used to identify utility elements in the utility network.
     private func addStartElementOrBarrier(for feature: AGSArcGISFeature, at location: AGSPoint) {
         guard let featureTable = feature.featureTable as? AGSArcGISFeatureTable,
-            let networkSource = utilityNetwork.definition.networkSource(withName: featureTable.tableName) else {
-                self.setStatus(message: "Could not identify location.")
-                return
+              let networkSource = utilityNetwork.definition.networkSource(withName: featureTable.tableName) else {
+            self.setStatus(message: "Could not identify location.")
+            return
         }
         
         switch networkSource.sourceType {
         case .junction:
             // If the user tapped on a junction, get the asset's terminal(s).
             if let assetGroupField = featureTable.field(forName: featureTable.subtypeField),
-                let assetGroupCode = feature.attributes[assetGroupField.name] as? Int,
-                let assetGroup = networkSource.assetGroups.first(where: { $0.code == assetGroupCode }),
-                let assetTypeField = featureTable.field(forName: "ASSETTYPE"),
-                let assetTypeCode = feature.attributes[assetTypeField.name] as? Int,
-                let assetType = assetGroup.assetTypes.first(where: { $0.code == assetTypeCode }),
-                let terminals = assetType.terminalConfiguration?.terminals {
+               let assetGroupCode = feature.attributes[assetGroupField.name] as? Int,
+               let assetGroup = networkSource.assetGroups.first(where: { $0.code == assetGroupCode }),
+               let assetTypeField = featureTable.field(forName: "ASSETTYPE"),
+               let assetTypeCode = feature.attributes[assetTypeField.name] as? Int,
+               let assetType = assetGroup.assetTypes.first(where: { $0.code == assetTypeCode }),
+               let terminals = assetType.terminalConfiguration?.terminals {
                 selectTerminal(from: terminals, at: feature.geometry as? AGSPoint ?? location) { [weak self, currentMode] terminal in
                     guard let self = self,
-                        let element = self.utilityNetwork.createElement(with: feature, terminal: terminal),
-                        let location = feature.geometry as? AGSPoint else { return }
+                          let element = self.utilityNetwork.createElement(with: feature, terminal: terminal),
+                          let location = feature.geometry as? AGSPoint else { return }
                     
                     self.add(element: element, for: location, mode: currentMode)
                     self.setStatus(message: "terminal: \(terminal.name)")
@@ -198,8 +198,8 @@ class TraceUtilityNetworkViewController: UIViewController, AGSGeoViewTouchDelega
         case .edge:
             // If the user tapped on an edge, determine how far along that edge.
             if let geometry = feature.geometry,
-                let line = AGSGeometryEngine.geometryByRemovingZ(from: geometry) as? AGSPolyline,
-                let element = utilityNetwork.createElement(with: feature, terminal: nil) {
+               let line = AGSGeometryEngine.geometryByRemovingZ(from: geometry) as? AGSPolyline,
+               let element = utilityNetwork.createElement(with: feature, terminal: nil) {
                 element.fractionAlongEdge = AGSGeometryEngine.fraction(alongLine: line, to: location, tolerance: -1)
                 
                 add(element: element, for: location, mode: currentMode)
@@ -229,7 +229,7 @@ class TraceUtilityNetworkViewController: UIViewController, AGSGeoViewTouchDelega
         SVProgressHUD.show(withStatus: "Running \(traceType.name.lowercased()) trace…")
         let parameters = AGSUtilityTraceParameters(traceType: traceType.type, startingLocations: traceParameters.startingLocations)
         parameters.barriers.append(contentsOf: traceParameters.barriers)
-
+        
         // Set the trace configuration using the tier from the utility domain network.
         parameters.traceConfiguration = utilityTier?.traceConfiguration
         
@@ -240,27 +240,27 @@ class TraceUtilityNetworkViewController: UIViewController, AGSGeoViewTouchDelega
                 self?.presentAlert(error: error)
                 return
             }
-
+            
             guard let self = self else { return }
             
             guard let elementTraceResult = traceResult?.first as? AGSUtilityElementTraceResult,
-                !elementTraceResult.elements.isEmpty else {
-                    self.setStatus(message: "Trace completed with no output.")
-                    SVProgressHUD.dismiss()
-                    return
+                  !elementTraceResult.elements.isEmpty else {
+                self.setStatus(message: "Trace completed with no output.")
+                SVProgressHUD.dismiss()
+                return
             }
             
             self.clearSelection()
-
+            
             SVProgressHUD.show(withStatus: "Trace completed. Selecting features…")
-
+            
             let groupedElements = Dictionary(grouping: elementTraceResult.elements) { $0.networkSource.name }
             
             let selectionGroup = DispatchGroup()
-
+            
             for (networkName, elements) in groupedElements {
                 guard let layer = self.map.operationalLayers.first(where: { ($0 as? AGSFeatureLayer)?.featureTable?.tableName == networkName }) as? AGSFeatureLayer else { continue }
-
+                
                 selectionGroup.enter()
                 self.utilityNetwork.features(for: elements) { [weak self, layer] (features, error) in
                     defer {
@@ -326,7 +326,7 @@ class TraceUtilityNetworkViewController: UIViewController, AGSGeoViewTouchDelega
             completion(terminal)
         }
     }
-
+    
     // MARK: Interaction Mode
     private enum InteractionMode: Int {
         case addingStartLocation = 0
@@ -394,7 +394,7 @@ class TraceUtilityNetworkViewController: UIViewController, AGSGeoViewTouchDelega
         traceType = (name: "Connected", type: .connected)
         setInstructionMessage()
     }
-
+    
     // MARK: UI and Feedback
     private func setStatus(message: String) {
         statusLabel.text = message


### PR DESCRIPTION
This PR replaces the `map.initialViewpoint` with `mapView.setViewpoint` to follow the best practice of 
> *`mapView` handles display; `map` handles content*

Please see more discussion at `common-samples/issues/2479`

Some additional changes are made to clean up comment and to standardize coding style. However, if it involves too many (irrelevant) line-of-change in a file to fix styling, then it is left untouched to avoid making it hard to review.

---

Not changed:
- BookmarksViewController: the `initialViewpoint` save with the map, which makes sense for bookmark
- Create and save map: when saving the map, it also saves the initial viewpoint of the map
- LineOfSightGeoElementViewController: the initial view point is set on a scene.