### PR TITLE
Fix: Remove credentials when leaving OAuth samples

### DIFF
--- a/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/NavigateARRoutePlannerViewController.swift
+++ b/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/NavigateARRoutePlannerViewController.swift
@@ -202,6 +202,7 @@ class NavigateARRoutePlannerViewController: UIViewController {
     
     deinit {
         AGSAuthenticationManager.shared().oAuthConfigurations.remove(oAuthConfiguration)
+        AGSAuthenticationManager.shared().credentialCache.removeAllCredentials()
     }
 }
 
@@ -230,7 +231,6 @@ extension NavigateARRoutePlannerViewController: AGSGeoViewTouchDelegate {
 
 extension NavigateARRoutePlannerViewController: AGSAuthenticationManagerDelegate {
     func authenticationManager( _ authenticationManager: AGSAuthenticationManager, wantsToShow viewController: UIViewController) {
-        viewController.modalPresentationStyle = .overFullScreen
         present(viewController, animated: true)
     }
     

--- a/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/NavigateARRoutePlannerViewController.swift
+++ b/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/NavigateARRoutePlannerViewController.swift
@@ -231,6 +231,7 @@ extension NavigateARRoutePlannerViewController: AGSGeoViewTouchDelegate {
 
 extension NavigateARRoutePlannerViewController: AGSAuthenticationManagerDelegate {
     func authenticationManager( _ authenticationManager: AGSAuthenticationManager, wantsToShow viewController: UIViewController) {
+        viewController.modalPresentationStyle = .overFullScreen
         present(viewController, animated: true)
     }
     

--- a/arcgis-ios-sdk-samples/Cloud and portal/Authenticate with OAuth/AuthenticateWithOAuthViewController.swift
+++ b/arcgis-ios-sdk-samples/Cloud and portal/Authenticate with OAuth/AuthenticateWithOAuthViewController.swift
@@ -60,6 +60,7 @@ class AuthenticateWithOAuthViewController: UIViewController {
     
     deinit {
         AGSAuthenticationManager.shared().oAuthConfigurations.remove(oAuthConfiguration)
+        AGSAuthenticationManager.shared().credentialCache.removeAllCredentials()
     }
     
     // MARK: UIViewController
@@ -75,7 +76,6 @@ class AuthenticateWithOAuthViewController: UIViewController {
 
 extension AuthenticateWithOAuthViewController: AGSAuthenticationManagerDelegate {
     func authenticationManager(_ authenticationManager: AGSAuthenticationManager, wantsToShow viewController: UIViewController) {
-        viewController.modalPresentationStyle = .formSheet
         present(viewController, animated: true)
     }
     

--- a/arcgis-ios-sdk-samples/Cloud and portal/Authenticate with OAuth/AuthenticateWithOAuthViewController.swift
+++ b/arcgis-ios-sdk-samples/Cloud and portal/Authenticate with OAuth/AuthenticateWithOAuthViewController.swift
@@ -76,6 +76,7 @@ class AuthenticateWithOAuthViewController: UIViewController {
 
 extension AuthenticateWithOAuthViewController: AGSAuthenticationManagerDelegate {
     func authenticationManager(_ authenticationManager: AGSAuthenticationManager, wantsToShow viewController: UIViewController) {
+        viewController.modalPresentationStyle = .formSheet
         present(viewController, animated: true)
     }
     


### PR DESCRIPTION
This PR fixes the issue of

- common-samples/issues/1613

by removing credentials on deinit, the samples won't share credential cache;
~~by reset the presentation style to default, the OAuth webpage cannot be dismissed with iOS 13 interactive swipe (which hangs the auth process in an unknown state) on both iPhone and iPad~~ this will be fixed in the SDK
