### PR TITLE
Fix: Add plist item to fix a crash in popup attachments

### DIFF
--- a/arcgis-ios-sdk-samples/Info.plist
+++ b/arcgis-ios-sdk-samples/Info.plist
@@ -87,6 +87,8 @@
 	<string>For taking pictures or videos as attachments</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>To show your location on the map</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>For adding video recordings as attachments</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>For adding pictures from your photo library as attachments</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>


### PR DESCRIPTION
See details at `cocoa/issues/10241`