### PR TITLE
[Linting] Lint comment for comment_spacing rule

### DIFF
--- a/arcgis-ios-sdk-samples/Analysis/Viewshed (geoprocessing)/ViewshedGeoprocessingViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Viewshed (geoprocessing)/ViewshedGeoprocessingViewController.swift
@@ -27,7 +27,7 @@ class ViewshedGeoprocessingViewController: UIViewController, AGSGeoViewTouchDele
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["ViewshedGeoprocessingViewController"]
 
         self.mapView.map = AGSMap(basemapStyle: .arcGISTopographic)
@@ -35,7 +35,7 @@ class ViewshedGeoprocessingViewController: UIViewController, AGSGeoViewTouchDele
         
         self.mapView.touchDelegate = self
         
-        //renderer for graphics overlays
+        // renderer for graphics overlays
         let pointSymbol = AGSSimpleMarkerSymbol(style: .circle, color: .red, size: 10)
         let renderer = AGSSimpleRenderer(symbol: pointSymbol)
         self.inputGraphicsOverlay.renderer = renderer
@@ -44,7 +44,7 @@ class ViewshedGeoprocessingViewController: UIViewController, AGSGeoViewTouchDele
         let fillSymbol = AGSSimpleFillSymbol(style: .solid, color: fillColor, outline: nil)
         self.resultGraphicsOverlay.renderer = AGSSimpleRenderer(symbol: fillSymbol)
         
-        //add graphics overlays to the map view
+        // add graphics overlays to the map view
         self.mapView.graphicsOverlays.addObjects(from: [self.resultGraphicsOverlay, self.inputGraphicsOverlay])
         
         let viewshedURL = URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Elevation/ESRI_Elevation_World/GPServer/Viewshed")!
@@ -52,46 +52,46 @@ class ViewshedGeoprocessingViewController: UIViewController, AGSGeoViewTouchDele
     }
     
     private func addGraphicForPoint(_ point: AGSPoint) {
-        //remove existing graphics
+        // remove existing graphics
         self.inputGraphicsOverlay.graphics.removeAllObjects()
         
-        //new graphic
+        // new graphic
         let graphic = AGSGraphic(geometry: point, symbol: nil, attributes: nil)
         
-        //add new graphic to the graphics overlay
+        // add new graphic to the graphics overlay
         self.inputGraphicsOverlay.graphics.add(graphic)
     }
     
     private func calculateViewshed(at point: AGSPoint) {
-        //remove previous graphics
+        // remove previous graphics
         self.resultGraphicsOverlay.graphics.removeAllObjects()
         
-        //Cancel previous job
+        // Cancel previous job
         self.geoprocessingJob?.progress.cancel()
         
-        //the service requires input of rest data type GPFeatureRecordSetLayer
-        //which is AGSGeoprocessingFeatures in runtime
-        //in order to create an object of AGSGeoprocessingFeatures we need a featureSet
-        //for which we will create a featureCollectionTable (since feature collection table
-        //is a feature set) and add the geometry as a feature to that table.
+        // the service requires input of rest data type GPFeatureRecordSetLayer
+        // which is AGSGeoprocessingFeatures in runtime
+        // in order to create an object of AGSGeoprocessingFeatures we need a featureSet
+        // for which we will create a featureCollectionTable (since feature collection table
+        // is a feature set) and add the geometry as a feature to that table.
         
-        //create feature collection table for point geometry
+        // create feature collection table for point geometry
         let featureCollectionTable = AGSFeatureCollectionTable(fields: [AGSField](), geometryType: .point, spatialReference: point.spatialReference)
         
-        //create a new feature and assign the geometry
+        // create a new feature and assign the geometry
         let newFeature = featureCollectionTable.createFeature()
         newFeature.geometry = point
         
-        //show progress hud
+        // show progress hud
         SVProgressHUD.show(withStatus: "Adding Feature")
         
-        //add the new feature to the feature collection table
+        // add the new feature to the feature collection table
         featureCollectionTable.add(newFeature) { [weak self] (error: Error?) in
-            //dismiss progress hud
+            // dismiss progress hud
             SVProgressHUD.dismiss()
             
             if let error = error {
-                //show error
+                // show error
                 self?.presentAlert(error: error)
             } else {
                 self?.performGeoprocessing(featureCollectionTable)
@@ -100,23 +100,23 @@ class ViewshedGeoprocessingViewController: UIViewController, AGSGeoViewTouchDele
     }
     
     private func performGeoprocessing(_ featureCollectionTable: AGSFeatureCollectionTable) {
-        //geoprocessing parameters
+        // geoprocessing parameters
         let params = AGSGeoprocessingParameters(executionType: .synchronousExecute)
         params.processSpatialReference = featureCollectionTable.spatialReference
         params.outputSpatialReference = featureCollectionTable.spatialReference
         
-        //use the feature collection table to create the required AGSGeoprocessingFeatures input
+        // use the feature collection table to create the required AGSGeoprocessingFeatures input
         params.inputs["Input_Observation_Point"] = AGSGeoprocessingFeatures(featureSet: featureCollectionTable)
         
-        //initialize job from geoprocessing task
+        // initialize job from geoprocessing task
         geoprocessingJob = geoprocessingTask.geoprocessingJob(with: params)
         
-        //start the job
+        // start the job
         geoprocessingJob.start(statusHandler: { (status: AGSJobStatus) in
-            //show progress hud with job status
+            // show progress hud with job status
             SVProgressHUD.show(withStatus: status.statusString())
         }, completion: { [weak self] (result: AGSGeoprocessingResult?, error: Error?) in
-            //dismiss progress hud
+            // dismiss progress hud
             SVProgressHUD.dismiss()
             
             guard let self = self else {
@@ -124,13 +124,13 @@ class ViewshedGeoprocessingViewController: UIViewController, AGSGeoViewTouchDele
             }
             
             if let error = error {
-                if (error as NSError).code != NSUserCancelledError { //if not cancelled
+                if (error as NSError).code != NSUserCancelledError { // if not cancelled
                     self.presentAlert(error: error)
                 }
             } else {
-                //The service returns result in form of AGSGeoprocessingFeatures
-                //Cast the results and add the features from featureSet to graphics overlay
-                //in form of graphics
+                // The service returns result in form of AGSGeoprocessingFeatures
+                // Cast the results and add the features from featureSet to graphics overlay
+                // in form of graphics
                 if let resultFeatures = result?.outputs["Viewshed_Result"] as? AGSGeoprocessingFeatures,
                     let featureSet = resultFeatures.features {
                     for feature in featureSet.featureEnumerator().allObjects {
@@ -145,10 +145,10 @@ class ViewshedGeoprocessingViewController: UIViewController, AGSGeoViewTouchDele
     // MARK: - AGSGeoViewTouchDelegate
     
     func geoView(_ geoView: AGSGeoView, didTapAtScreenPoint screenPoint: CGPoint, mapPoint: AGSPoint) {
-        //add a graphic in graphics overlay for the tapped point
+        // add a graphic in graphics overlay for the tapped point
         self.addGraphicForPoint(mapPoint)
         
-        //calculate viewshed
+        // calculate viewshed
         self.calculateViewshed(at: mapPoint)
     }
 }

--- a/arcgis-ios-sdk-samples/Analysis/Viewshed (location)/ViewshedLocationViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Viewshed (location)/ViewshedLocationViewController.swift
@@ -70,7 +70,7 @@ class ViewshedLocationViewController: UIViewController {
         analysisOverlay.analyses.add(viewshed)
         sceneView.analysisOverlays.add(analysisOverlay)
         
-        //set touch delegate on scene view as self
+        // set touch delegate on scene view as self
         sceneView.touchDelegate = self
     }
     

--- a/arcgis-ios-sdk-samples/AppDelegate.swift
+++ b/arcgis-ios-sdk-samples/AppDelegate.swift
@@ -43,7 +43,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
         navigationController.topViewController!.navigationItem.leftItemsSupplementBackButton = true
         splitViewController.delegate = self
         
-        //min max width for master
+        // min max width for master
         splitViewController.minimumPrimaryColumnWidth = 320
         splitViewController.maximumPrimaryColumnWidth = 320
         
@@ -89,7 +89,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
     // MARK: - Touch settings
     
     func setTouchPref() {
-        //enable/disable touches based on settings
+        // enable/disable touches based on settings
         let bool = UserDefaults.standard.bool(forKey: "showTouch")
         if bool {
             DemoTouchManager.shared.showTouches()

--- a/arcgis-ios-sdk-samples/Augmented reality/Collect data in AR/CollectDataAR.swift
+++ b/arcgis-ios-sdk-samples/Augmented reality/Collect data in AR/CollectDataAR.swift
@@ -99,7 +99,7 @@ class CollectDataAR: UIViewController {
         arView.locationDataSource = AGSCLLocationDataSource()
         configureSceneForAR()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["CollectDataAR"]
     }
 
@@ -269,7 +269,7 @@ extension CollectDataAR {
         
         if let newFeature = featureTable.createFeature(attributes: featureAttributes, geometry: featurePoint) as? AGSArcGISFeature {
             lastEditedFeature = newFeature
-            //add the feature to the feature table
+            // add the feature to the feature table
             featureTable.add(newFeature) { [weak self] (error: Error?) in
                 guard let self = self else { return }
                 

--- a/arcgis-ios-sdk-samples/Augmented reality/Display scenes in tabletop AR/DisplayScenesInTabletopAR.swift
+++ b/arcgis-ios-sdk-samples/Augmented reality/Display scenes in tabletop AR/DisplayScenesInTabletopAR.swift
@@ -44,7 +44,7 @@ class DisplayScenesInTabletopAR: UIViewController {
         // Listen for tracking state changes
         arView.arSCNViewDelegate = self
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["DisplayScenesInTabletopAR"]
     }
 

--- a/arcgis-ios-sdk-samples/Augmented reality/Explore scenes in flyover AR/ExploreScenesInFlyoverAR.swift
+++ b/arcgis-ios-sdk-samples/Augmented reality/Explore scenes in flyover AR/ExploreScenesInFlyoverAR.swift
@@ -28,7 +28,7 @@ class ExploreScenesInFlyoverAR: UIViewController {
 
         configureSceneForAR()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["ExploreScenesInFlyoverAR"]
     }
 

--- a/arcgis-ios-sdk-samples/Cloud and portal/List portal group users/GroupUsersViewController.swift
+++ b/arcgis-ios-sdk-samples/Cloud and portal/List portal group users/GroupUsersViewController.swift
@@ -25,28 +25,28 @@ class GroupUsersViewController: UIViewController, UITableViewDataSource, UITable
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["GroupUsersViewController", "GroupUserCell"]
 
-        //automatic cell sizing for table view
+        // automatic cell sizing for table view
         self.tableView.rowHeight = UITableView.automaticDimension
         self.tableView.estimatedRowHeight = 104
         
-        //initialize portal with AGOL
+        // initialize portal with AGOL
         self.portal = AGSPortal.arcGISOnline(withLoginRequired: false)
         
-        //load the portal group to be used
+        // load the portal group to be used
         self.loadPortalGroup()
     }
     
     private func loadPortalGroup() {
-        //show progress hud
+        // show progress hud
         SVProgressHUD.show(withStatus: "Loading Portal Group")
         
-        //query group based on owner and title
+        // query group based on owner and title
         let queryParams = AGSPortalQueryParameters(forGroupsWithOwner: "ArcGISRuntimeSDK", title: "Runtime Group")
         
-        //find groups with using query params
+        // find groups with using query params
         self.portal.findGroups(with: queryParams) { [weak self] (resultSet: AGSPortalQueryResultSet?, error: Error?) in
             SVProgressHUD.dismiss()
             
@@ -55,16 +55,16 @@ class GroupUsersViewController: UIViewController, UITableViewDataSource, UITable
             }
             
             if let error = error {
-                //show error
+                // show error
                 self.presentAlert(error: error)
             } else {
-                //fetch users for the resulting group
+                // fetch users for the resulting group
                 if let groups = resultSet?.results as? [AGSPortalGroup],
                     let group = groups.first {
                     self.portalGroup = group
                     self.fetchGroupUsers()
                 } else {
-                    //show error that no groups found
+                    // show error that no groups found
                     self.presentAlert(message: "No groups found")
                 }
             }
@@ -72,10 +72,10 @@ class GroupUsersViewController: UIViewController, UITableViewDataSource, UITable
     }
     
     private func fetchGroupUsers() {
-        //show progress hud
+        // show progress hud
         SVProgressHUD.show(withStatus: "Fetching Users")
         
-        //fetch users in group
+        // fetch users in group
         self.portalGroup.fetchUsers { [weak self] (users, _, error) in
             SVProgressHUD.dismiss()
             
@@ -84,14 +84,14 @@ class GroupUsersViewController: UIViewController, UITableViewDataSource, UITable
             }
             
             if let error = error {
-                //show error
+                // show error
                 self.presentAlert(error: error)
             } else if let users = users {
-                //if there are users in the group
+                // if there are users in the group
                 if !users.isEmpty {
-                    //initialize AGSPortalUser objects with user names
+                    // initialize AGSPortalUser objects with user names
                     self.portalUsers = users.map { AGSPortalUser(portal: self.portal, username: $0) }
-                    //load all users before populating into table view
+                    // load all users before populating into table view
                     self.loadAllUsers()
                 } else {
                     self.presentAlert(message: "No users found")
@@ -101,16 +101,16 @@ class GroupUsersViewController: UIViewController, UITableViewDataSource, UITable
     }
     
     private func loadAllUsers() {
-        //show progress hud
+        // show progress hud
         SVProgressHUD.show(withStatus: "Loading User Data")
         
-        //load user data
+        // load user data
         AGSLoadObjects(portalUsers) { [weak self] (success) in
-            //dismiss hud
+            // dismiss hud
             SVProgressHUD.dismiss()
             
             if success {
-                //reload table view
+                // reload table view
                 self?.tableView.reloadData()
             } else {
                 self?.presentAlert(message: "Error while loading users data")

--- a/arcgis-ios-sdk-samples/Cloud and portal/Search for webmap by keyword/SearchForWebmapByKeywordViewController.swift
+++ b/arcgis-ios-sdk-samples/Cloud and portal/Search for webmap by keyword/SearchForWebmapByKeywordViewController.swift
@@ -122,7 +122,7 @@ class SearchForWebmapByKeywordViewController: UICollectionViewController {
                     print(error.localizedDescription)
                 }
             } else {
-                //if our results are an array of portal items, set it on our web maps collection ViewController
+                // if our results are an array of portal items, set it on our web maps collection ViewController
                 if let portalItems = resultSet?.results as? [AGSPortalItem] {
                     self?.resultPortalItems = portalItems
                 } else {

--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ContentCollectionViewController.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ContentCollectionViewController.swift
@@ -85,21 +85,21 @@ class ContentCollectionViewController: UICollectionViewController, UICollectionV
         
         let category = categories[indexPath.item]
         
-        //mask to bounds
+        // mask to bounds
         cell.layer.masksToBounds = false
         
-        //name
+        // name
         cell.nameLabel.text = category.name.uppercased()
         
-        //icon
+        // icon
         let image = UIImage(named: "\(category.name)_icon")
         cell.iconImageView.image = image
         
-        //background image
+        // background image
         let bgImage = UIImage(named: "\(category.name)_bg")
         cell.backgroundImageView.image = bgImage
         
-        //cell shadow
+        // cell shadow
         cell.layer.cornerRadius = 5
         cell.layer.masksToBounds = true
         
@@ -109,7 +109,7 @@ class ContentCollectionViewController: UICollectionViewController, UICollectionV
     // MARK: - UICollectionViewDelegate
     
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        //hide keyboard if visible
+        // hide keyboard if visible
         view.endEditing(true)
         
         let category = categories[indexPath.item]
@@ -125,10 +125,10 @@ class ContentCollectionViewController: UICollectionViewController, UICollectionV
         let collectionViewSize = collectionView.bounds.inset(by: collectionView.safeAreaInsets).size
         
         let spacing: CGFloat = 10
-        //first try for 3 items in a row
+        // first try for 3 items in a row
         var width = (collectionViewSize.width - 4 * spacing) / 3
         if width < 150 {
-            //if too small then go for 2 in a row
+            // if too small then go for 2 in a row
             width = (collectionViewSize.width - 3 * spacing) / 2
         }
         return CGSize(width: width, height: width)

--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ContentTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ContentTableViewController.swift
@@ -42,7 +42,7 @@ class ContentTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //initialize download progress view
+        // initialize download progress view
         let downloadProgressView = DownloadProgressView()
         downloadProgressView.delegate = self
         self.downloadProgressView = downloadProgressView
@@ -67,35 +67,35 @@ class ContentTableViewController: UITableViewController {
     // MARK: - UITableViewDelegate
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        //hide keyboard if visible
+        // hide keyboard if visible
         view.endEditing(true)
         
         let sample = displayedSamples[indexPath.row]
         
-        //download on demand resources
+        // download on demand resources
         if !sample.dependencies.isEmpty {
             let bundleResourceRequest = NSBundleResourceRequest(tags: Set(sample.dependencies))
             bundleResourceRequest.loadingPriority = NSBundleResourceRequestLoadingPriorityUrgent
             self.bundleResourceRequest = bundleResourceRequest
             
-            //conditionally begin accessing to know if we need to show download progress view or not
+            // conditionally begin accessing to know if we need to show download progress view or not
             bundleResourceRequest.conditionallyBeginAccessingResources { [weak self] (isResourceAvailable: Bool) in
                 DispatchQueue.main.async {
-                    //if resource is already available then simply show the sample
+                    // if resource is already available then simply show the sample
                     if isResourceAvailable {
                         self?.showSample(sample)
                     }
-                    //else download the resource
+                    // else download the resource
                     else {
                         self?.downloadResource(for: sample, at: indexPath)
                     }
                 }
             }
         } else {
-            //clear bundleResourceRequest
+            // clear bundleResourceRequest
             bundleResourceRequest?.endAccessingResources()
             
-            //show view controller
+            // show view controller
             showSample(sample)
         }
     }
@@ -111,28 +111,28 @@ class ContentTableViewController: UITableViewController {
             return
         }
         
-        //show download progress view
+        // show download progress view
         downloadProgressView?.show(withStatus: "Just a moment while we download data for this sample...", progress: 0)
         
-        //add an observer to update the progress in download progress view
+        // add an observer to update the progress in download progress view
         downloadProgressObservation = bundleResourceRequest.progress.observe(\.fractionCompleted) { [weak self] (progress, _) in
             DispatchQueue.main.async {
                 self?.downloadProgressView?.updateProgress(progress: CGFloat(progress.fractionCompleted), animated: true)
             }
         }
         
-        //begin
+        // begin
         bundleResourceRequest.beginAccessingResources { [weak self] (error: Error?) in
             guard let self = self else {
                 return
             }
             
-            //in main thread
+            // in main thread
             DispatchQueue.main.async {
-                //remove observation
+                // remove observation
                 self.downloadProgressObservation = nil
                 
-                //dismiss download progress view
+                // dismiss download progress view
                 self.downloadProgressView?.dismiss()
                 
                 if let error = error {
@@ -144,7 +144,7 @@ class ContentTableViewController: UITableViewController {
                     }
                 } else {
                     if self.bundleResourceRequest?.progress.isCancelled == false {
-                        //show view controller
+                        // show view controller
                         self.showSample(sample)
                     }
                 }
@@ -157,22 +157,22 @@ class ContentTableViewController: UITableViewController {
         let controller = storyboard.instantiateInitialViewController()!
         controller.title = sample.name
         
-        //must use the presenting controller when opening from search results or else splitViewController will be nil
+        // must use the presenting controller when opening from search results or else splitViewController will be nil
         let presentingController: UIViewController? = searchEngine != nil ? presentingViewController : self
             
         let navController = UINavigationController(rootViewController: controller)
         
-        //don't use large titles on samples
+        // don't use large titles on samples
         controller.navigationItem.largeTitleDisplayMode = .never
         
-        //add the button on the left on the detail view controller
+        // add the button on the left on the detail view controller
         controller.navigationItem.leftBarButtonItem = presentingController?.splitViewController?.displayModeButtonItem
         controller.navigationItem.leftItemsSupplementBackButton = true
         
-        //present the sample view controller
+        // present the sample view controller
         presentingController?.showDetailViewController(navController, sender: self)
         
-        //create and setup the info button
+        // create and setup the info button
         let infoBBI = SourceCodeBarButtonItem()
         infoBBI.readmeURL = sample.readmeURL
         infoBBI.navController = navController
@@ -180,11 +180,11 @@ class ContentTableViewController: UITableViewController {
     }
     
     private func toggleExpansion(at indexPath: IndexPath) {
-        //if same row selected then hide the detail view
+        // if same row selected then hide the detail view
         if expandedRowIndexPaths.contains(indexPath) {
             expandedRowIndexPaths.remove(indexPath)
         } else {
-            //get the two cells and update
+            // get the two cells and update
             expandedRowIndexPaths.update(with: indexPath)
         }
         tableView.reloadRows(at: [indexPath], with: .automatic)

--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/SampleInfoViewController.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/SampleInfoViewController.swift
@@ -35,9 +35,9 @@ class SampleInfoViewController: UIViewController {
     }
     
     func markdownTextFromFile(at url: URL) -> String? {
-        //read the content of the file
+        // read the content of the file
         if let content = try? String(contentsOf: url, encoding: .utf8) {
-            //remove the images
+            // remove the images
             let pattern = "!\\[.*\\]\\(.*\\)"
             if let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) {
                 let range = NSRange(location: 0, length: content.count)

--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/SourceCodeViewController.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/SourceCodeViewController.swift
@@ -64,9 +64,9 @@ class SourceCodeViewController: UIViewController, UIAdaptivePresentationControll
     }
     
     func contentOfFile(_ name: String) -> String? {
-        //find the path of the file
+        // find the path of the file
         if let path = Bundle.main.path(forResource: name, ofType: ".swift") {
-            //read the content of the file
+            // read the content of the file
             if let content = try? String(contentsOfFile: path, encoding: String.Encoding.utf8) {
                 return content
             }

--- a/arcgis-ios-sdk-samples/Content Display Logic/Model/SampleSearchEngine.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Model/SampleSearchEngine.swift
@@ -29,7 +29,7 @@ class SampleSearchEngine {
                 return
             }
 
-            //index the content of all sample names, descriptions, and readme files
+            // index the content of all sample names, descriptions, and readme files
             strongSelf.indexSampleReadmes()
             strongSelf.isLoadingReadmeIndex = false
         }
@@ -53,11 +53,11 @@ class SampleSearchEngine {
                                     if  [NSLinguisticTag.noun, .verb, .adjective, .otherWord].contains(tag) {
                                         let word = ((string as NSString).substring(with: tokenRange) as String).lowercased()
                                         
-                                        //trivial comparisons
+                                        // trivial comparisons
                                         if word != "`." && word != "```" && word != "`" {
-                                            //if word already exists in the dictionary
+                                            // if word already exists in the dictionary
                                             if var samples = displayNamesByReadmeWords[word] {
-                                                //add the sample display name to the list if not already present
+                                                // add the sample display name to the list if not already present
                                                 if !samples.contains(sampleDisplayName) {
                                                     samples.append(sampleDisplayName)
                                                     displayNamesByReadmeWords[word] = samples

--- a/arcgis-ios-sdk-samples/Content Display Logic/Views/DownloadProgressView.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Views/DownloadProgressView.swift
@@ -155,7 +155,7 @@ class DownloadProgressView: UIView {
         self.shapeLayer.removeAllAnimations()
         
         if animated {
-            //create animation
+            // create animation
             let animation = CABasicAnimation(keyPath: #keyPath(CAShapeLayer.strokeEnd))
             animation.duration = 0.2
             animation.fromValue = self.shapeLayer.strokeEnd
@@ -168,7 +168,7 @@ class DownloadProgressView: UIView {
             self.shapeLayer.strokeEnd = self.progress
         }
         
-        //progress label
+        // progress label
         self.progressLabel.text = "\(Int(self.progress * 100))%"
     }
     

--- a/arcgis-ios-sdk-samples/Display information/Add graphics with renderer/GORenderersViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Add graphics with renderer/GORenderersViewController.swift
@@ -23,38 +23,38 @@ class GORenderersViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["GORenderersViewController"]
         
-        //initialize map with topographic basemap
+        // initialize map with topographic basemap
         self.map = AGSMap(basemapStyle: .arcGISTopographic)
         
-        //add the graphics overaly, with graphics added, to map view
+        // add the graphics overaly, with graphics added, to map view
         self.addGraphicsOverlay()
         
-        //assign map to the map view's map
+        // assign map to the map view's map
         self.mapView.map = self.map
     }
     
     func addGraphicsOverlay() {
-        //point graphic
+        // point graphic
         let pointGeometry = AGSPoint(x: 40e5, y: 40e5, spatialReference: .webMercator())
         let pointSymbol = AGSSimpleMarkerSymbol(style: AGSSimpleMarkerSymbolStyle.diamond, color: .red, size: 10)
         let pointGraphic = AGSGraphic(geometry: pointGeometry, symbol: nil, attributes: nil)
         
-        //create graphics overlay for point
+        // create graphics overlay for point
         let pointGraphicOverlay = AGSGraphicsOverlay()
         
-        //renderer
+        // renderer
         pointGraphicOverlay.renderer = AGSSimpleRenderer(symbol: pointSymbol)
         
-        //add the graphic to the overlay
+        // add the graphic to the overlay
         pointGraphicOverlay.graphics.add(pointGraphic)
         
-        //add the overlay to the map view
+        // add the overlay to the map view
         self.mapView.graphicsOverlays.add(pointGraphicOverlay)
         
-        //line graphic
+        // line graphic
         let lineGeometry = AGSPolylineBuilder(spatialReference: .webMercator())
         lineGeometry.addPointWith(x: -10e5, y: 40e5)
         lineGeometry.addPointWith(x: 20e5, y: 50e5)
@@ -64,16 +64,16 @@ class GORenderersViewController: UIViewController {
         // create graphics overlay for polyline
         let lineGraphicOverlay = AGSGraphicsOverlay()
         
-        //renderer
+        // renderer
         lineGraphicOverlay.renderer = AGSSimpleRenderer(symbol: lineSymbol)
         
-        //add the graphic to the overlay
+        // add the graphic to the overlay
         lineGraphicOverlay.graphics.add(lineGraphic)
         
-        //add the overlay to the map view
+        // add the overlay to the map view
         self.mapView.graphicsOverlays.add(lineGraphicOverlay)
         
-        //polygon graphic
+        // polygon graphic
         let polygonGeometry = AGSPolygonBuilder(spatialReference: .webMercator())
         polygonGeometry.addPointWith(x: -20e5, y: 20e5)
         polygonGeometry.addPointWith(x: 20e5, y: 20e5)
@@ -82,16 +82,16 @@ class GORenderersViewController: UIViewController {
         let polygonSymbol = AGSSimpleFillSymbol(style: AGSSimpleFillSymbolStyle.solid, color: .yellow, outline: nil)
         let polygonGraphic = AGSGraphic(geometry: polygonGeometry.toGeometry(), symbol: nil, attributes: nil)
         
-        //create graphics overlay for polygon
+        // create graphics overlay for polygon
         let polygonGraphicOverlay = AGSGraphicsOverlay()
         
-        //renderer
+        // renderer
         polygonGraphicOverlay.renderer = AGSSimpleRenderer(symbol: polygonSymbol)
         
-        //add the graphic to the overlay
+        // add the graphic to the overlay
         polygonGraphicOverlay.graphics.add(polygonGraphic)
         
-        //add the overlay to the map view
+        // add the overlay to the map view
         self.mapView.graphicsOverlays.add(polygonGraphicOverlay)
     }
 }

--- a/arcgis-ios-sdk-samples/Display information/Add graphics with symbols/GraphicsWithSymbolsViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Add graphics with symbols/GraphicsWithSymbolsViewController.swift
@@ -23,43 +23,43 @@ class GraphicsWithSymbolsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["GraphicsWithSymbolsViewController"]
         
-        //assign the map to the map view
+        // assign the map to the map view
         mapView.map = AGSMap(basemapStyle: .arcGISOceans)
         mapView.setViewpoint(AGSViewpoint(latitude: 56.075844, longitude: -2.681572, scale: 288895.277144))
         
         let graphicsOverlay = AGSGraphicsOverlay()
         mapView.graphicsOverlays.add(graphicsOverlay)
         
-        //add some buoy positions to the graphics overlay
+        // add some buoy positions to the graphics overlay
         addBuoyPoints(to: graphicsOverlay)
-        //add boat trip polyline to graphics overlay
+        // add boat trip polyline to graphics overlay
         addBoatTrip(to: graphicsOverlay)
-        //add nesting ground polygon to graphics overlay
+        // add nesting ground polygon to graphics overlay
         addNestingGround(to: graphicsOverlay)
-        //add text symbols and points to graphics overlay
+        // add text symbols and points to graphics overlay
         addText(to: graphicsOverlay)
     }
     
     private func addBuoyPoints(to graphicsOverlay: AGSGraphicsOverlay) {
-        //define the buoy locations
+        // define the buoy locations
         let buoy1Loc = AGSPoint(x: -2.712642647560347, y: 56.062812566811544, spatialReference: .wgs84())
         let buoy2Loc = AGSPoint(x: -2.6908416959572303, y: 56.06444173689877, spatialReference: .wgs84())
         let buoy3Loc = AGSPoint(x: -2.6697273884990937, y: 56.064250073402874, spatialReference: .wgs84())
         let buoy4Loc = AGSPoint(x: -2.6395150461199726, y: 56.06127916736989, spatialReference: .wgs84())
         
-        //create a marker symbol
+        // create a marker symbol
         let buoyMarker = AGSSimpleMarkerSymbol(style: .circle, color: .red, size: 10)
         
-        //create graphics
+        // create graphics
         let buoyGraphic1 = AGSGraphic(geometry: buoy1Loc, symbol: buoyMarker, attributes: nil)
         let buoyGraphic2 = AGSGraphic(geometry: buoy2Loc, symbol: buoyMarker, attributes: nil)
         let buoyGraphic3 = AGSGraphic(geometry: buoy3Loc, symbol: buoyMarker, attributes: nil)
         let buoyGraphic4 = AGSGraphic(geometry: buoy4Loc, symbol: buoyMarker, attributes: nil)
         
-        //add the graphics to the graphics overlay
+        // add the graphics to the graphics overlay
         graphicsOverlay.graphics.addObjects(from: [buoyGraphic1, buoyGraphic2, buoyGraphic3, buoyGraphic4])
     }
     
@@ -67,42 +67,42 @@ class GraphicsWithSymbolsViewController: UIViewController {
         let bassLocation = AGSPoint(x: -2.640631, y: 56.078083, spatialReference: .wgs84())
         let craigleithLocation = AGSPoint(x: -2.720324, y: 56.073569, spatialReference: .wgs84())
         
-        //create text symbols
+        // create text symbols
         let bassRockSymbol = AGSTextSymbol(text: "Bass Rock", color: UIColor(red: 0, green: 0, blue: 230 / 255.0, alpha: 1), size: 10, horizontalAlignment: AGSHorizontalAlignment.left, verticalAlignment: AGSVerticalAlignment.bottom)
         
         let craigleithSymbol = AGSTextSymbol(text: "Craigleith", color: UIColor(red: 0, green: 0, blue: 230 / 255.0, alpha: 1), size: 10, horizontalAlignment: AGSHorizontalAlignment.right, verticalAlignment: AGSVerticalAlignment.top)
         
-        //define a graphic from the geometry and symbol
+        // define a graphic from the geometry and symbol
         let bassRockGraphic = AGSGraphic(geometry: bassLocation, symbol: bassRockSymbol, attributes: nil)
         let  craigleithGraphic = AGSGraphic(geometry: craigleithLocation, symbol: craigleithSymbol, attributes: nil)
         
-        //add the text to the graphics overlay
+        // add the text to the graphics overlay
         graphicsOverlay.graphics.add(bassRockGraphic)
         graphicsOverlay.graphics.add(craigleithGraphic)
     }
     
     private func addBoatTrip(to graphicsOverlay: AGSGraphicsOverlay) {
-        //boat trip geometry
+        // boat trip geometry
         let boatRoute = boatTripGeometry
         
-        //define a line symbol
+        // define a line symbol
         let lineSymbol = AGSSimpleLineSymbol(
             style: .dash,
             color: UIColor(red: 0.5, green: 0, blue: 0.5, alpha: 1),
             width: 4)
         
-        //create the graphic
+        // create the graphic
         let boatTripGraphic = AGSGraphic(geometry: boatRoute, symbol: lineSymbol, attributes: nil)
         
-        //add to the graphics overlay
+        // add to the graphics overlay
         graphicsOverlay.graphics.add(boatTripGraphic)
     }
     
     private func addNestingGround(to graphicsOverlay: AGSGraphicsOverlay) {
-        //nesting ground geometry
+        // nesting ground geometry
         let nestingGround = nestingGroundGeometry
         
-        //define the fill symbol and outline
+        // define the fill symbol and outline
         let outlineSymbol = AGSSimpleLineSymbol(
             style: .dash,
             color: UIColor(red: 0, green: 0, blue: 0.5, alpha: 1),
@@ -112,18 +112,18 @@ class GraphicsWithSymbolsViewController: UIViewController {
             color: UIColor(red: 0, green: 80 / 255.0, blue: 0, alpha: 1),
             outline: outlineSymbol)
         
-        //nesting graphic
+        // nesting graphic
         let nestingGraphic = AGSGraphic(geometry: nestingGround, symbol: fillSymbol, attributes: nil)
         
-        //add to graphics overlay
+        // add to graphics overlay
         graphicsOverlay.graphics.add(nestingGraphic)
     }
     
     private let boatTripGeometry: AGSPolyline = {
-        //create a polyline
+        // create a polyline
         let boatRoute = AGSPolylineBuilder(spatialReference: .wgs84())
         
-        //add positions to the point collection
+        // add positions to the point collection
         boatRoute.addPointWith(x: -2.7184791227926772, y: 56.06147084563517)
         boatRoute.addPointWith(x: -2.7196807500463924, y: 56.06147084563517)
         boatRoute.addPointWith(x: -2.722084004553823, y: 56.062141712059706)
@@ -187,10 +187,10 @@ class GraphicsWithSymbolsViewController: UIViewController {
     }()
     
     private let nestingGroundGeometry: AGSPolygon = {
-        //create a polygon
+        // create a polygon
         let nestingGround = AGSPolygonBuilder(spatialReference: .wgs84())
         
-        //add points to the point collection
+        // add points to the point collection
         nestingGround.addPointWith(x: -2.643077012566659, y: 56.077125346044475)
         nestingGround.addPointWith(x: -2.6428195210159444, y: 56.07717324600376)
         nestingGround.addPointWith(x: -2.6425405718360033, y: 56.07774804087097)

--- a/arcgis-ios-sdk-samples/Display information/Control graphic draw order/GraphicDrawOrderViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Control graphic draw order/GraphicDrawOrderViewController.swift
@@ -30,74 +30,74 @@ class GraphicDrawOrderViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["GraphicDrawOrderViewController"]
         
-        //create an instance of a map with ESRI streets basemap
+        // create an instance of a map with ESRI streets basemap
         self.map = AGSMap(basemapStyle: .arcGISStreets)
-        //assign map to the map view
+        // assign map to the map view
         self.mapView.map = self.map
         
-        //add the graphics overlay to the map view
+        // add the graphics overlay to the map view
         self.mapView.graphicsOverlays.add(self.graphicsOverlay)
         
-        //add the graphics to the overlay
+        // add the graphics to the overlay
         self.addGraphics()
         
-        //set map scale
+        // set map scale
         let mapScale: Double = 53500
         
-        //initial viewpoint
+        // initial viewpoint
         self.mapView.setViewpointCenter(AGSPoint(x: -13148960, y: 4000040, spatialReference: .webMercator()), scale: mapScale)
         
-        //restricting map scale to preserve the graphics overlapping
+        // restricting map scale to preserve the graphics overlapping
         self.map.minScale = mapScale
         self.map.maxScale = mapScale
     }
     
     private func addGraphics() {
-        //starting x and y
+        // starting x and y
         let x: Double = -13149000
         let y: Double = 4e6
-        //distance between the graphics
+        // distance between the graphics
         let delta: Double = 100
         
-        //blue marker
+        // blue marker
         var geometry = AGSPoint(x: x, y: y, spatialReference: .webMercator())
         var symbol = AGSPictureMarkerSymbol(image: UIImage(named: "BlueMarker")!)
         var graphic = AGSGraphic(geometry: geometry, symbol: symbol, attributes: nil)
         graphics.append(graphic)
         
-        //red marker
+        // red marker
         geometry = AGSPoint(x: x + delta, y: y, spatialReference: .webMercator())
         symbol = AGSPictureMarkerSymbol(image: UIImage(named: "RedMarker2")!)
         graphic = AGSGraphic(geometry: geometry, symbol: symbol, attributes: nil)
         graphics.append(graphic)
         
-        //green marker
+        // green marker
         geometry = AGSPoint(x: x, y: y + delta, spatialReference: .webMercator())
         symbol = AGSPictureMarkerSymbol(image: UIImage(named: "GreenMarker")!)
         graphic = AGSGraphic(geometry: geometry, symbol: symbol, attributes: nil)
         graphics.append(graphic)
         
-        //Violet marker
+        // Violet marker
         geometry = AGSPoint(x: x + delta, y: y + delta, spatialReference: .webMercator())
         symbol = AGSPictureMarkerSymbol(image: UIImage(named: "VioletMarker")!)
         graphic = AGSGraphic(geometry: geometry, symbol: symbol, attributes: nil)
         graphics.append(graphic)
         
-        //add the graphics to the overlay
+        // add the graphics to the overlay
         self.graphicsOverlay.graphics.addObjects(from: graphics)
     }
     
     // MARK: - Actions
     
     @IBAction func buttonAction(_ sender: UIButton) {
-        //increment draw index by 1 and assign as the zIndex for the respective graphic
+        // increment draw index by 1 and assign as the zIndex for the respective graphic
         self.drawIndex += 1
         
-        //the button's tag value specifies which graphic to re-index
-        //for example, a button tag value of 1 will move self.graphics[1] - the red marker
+        // the button's tag value specifies which graphic to re-index
+        // for example, a button tag value of 1 will move self.graphics[1] - the red marker
         graphics[sender.tag].zIndex = self.drawIndex
     }
 }

--- a/arcgis-ios-sdk-samples/Display information/Identify graphics/GOIdentifyViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Identify graphics/GOIdentifyViewController.swift
@@ -24,27 +24,27 @@ class GOIdentifyViewController: UIViewController, AGSGeoViewTouchDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["GOIdentifyViewController"]
         
-        //initialize the map with topographic basemap
+        // initialize the map with topographic basemap
         self.map = AGSMap(basemapStyle: .arcGISTopographic)
         
-        //call the method to add a graphics to the map view
-        //will be using this graphic to test identify
+        // call the method to add a graphics to the map view
+        // will be using this graphic to test identify
         self.addGraphicsOverlay()
         
-        //assign the map to the map view's map object
+        // assign the map to the map view's map object
         self.mapView.map = self.map
         
-        //add self as the touch delegate of the mapview
-        //we will be using a method on the delegate to know 
-        //when the user tapped on the map view
+        // add self as the touch delegate of the mapview
+        // we will be using a method on the delegate to know 
+        // when the user tapped on the map view
         self.mapView.touchDelegate = self
     }
     
     func addGraphicsOverlay() {
-        //polygon graphic
+        // polygon graphic
         let polygonGeometry = AGSPolygonBuilder(spatialReference: .webMercator())
         polygonGeometry.addPointWith(x: -20e5, y: 20e5)
         polygonGeometry.addPointWith(x: 20e5, y: 20e5)
@@ -53,27 +53,27 @@ class GOIdentifyViewController: UIViewController, AGSGeoViewTouchDelegate {
         let polygonSymbol = AGSSimpleFillSymbol(style: AGSSimpleFillSymbolStyle.solid, color: .yellow, outline: nil)
         let polygonGraphic = AGSGraphic(geometry: polygonGeometry.toGeometry(), symbol: nil, attributes: nil)
         
-        //assign the renderer
+        // assign the renderer
         self.graphicsOverlay.renderer = AGSSimpleRenderer(symbol: polygonSymbol)
-        //add the polygon graphic
+        // add the polygon graphic
         self.graphicsOverlay.graphics.add(polygonGraphic)
-        //add the graphics overlay to the map view
+        // add the graphics overlay to the map view
         self.mapView.graphicsOverlays.add(self.graphicsOverlay)
     }
     
     // MARK: - AGSGeoViewTouchDelegate
     
     func geoView(_ geoView: AGSGeoView, didTapAtScreenPoint screenPoint: CGPoint, mapPoint: AGSPoint) {
-        //use the following method to identify graphics in a specific graphics overlay
-        //otherwise if you need to identify on all the graphics overlay present in the map view
-        //use `identifyGraphicsOverlaysAtScreenCoordinate:tolerance:maximumGraphics:completion:` method provided on map view
+        // use the following method to identify graphics in a specific graphics overlay
+        // otherwise if you need to identify on all the graphics overlay present in the map view
+        // use `identifyGraphicsOverlaysAtScreenCoordinate:tolerance:maximumGraphics:completion:` method provided on map view
         let tolerance: Double = 12
         
         self.mapView.identify(self.graphicsOverlay, screenPoint: screenPoint, tolerance: tolerance, returnPopupsOnly: false, maximumResults: 10) { [weak self] (result: AGSIdentifyGraphicsOverlayResult) in
             if let error = result.error {
                 print("error while identifying :: \(error.localizedDescription)")
             } else {
-                //if a graphics is found then show an alert
+                // if a graphics is found then show an alert
                 if !result.graphics.isEmpty {
                     self?.presentAlert(message: "Tapped on graphic")
                 }

--- a/arcgis-ios-sdk-samples/Display information/Picture marker symbols/PictureMarkerSymbolsViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Picture marker symbols/PictureMarkerSymbolsViewController.swift
@@ -23,21 +23,21 @@ class PictureMarkerSymbolsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["PictureMarkerSymbolsViewController"]
         
-        //assign the map to the map view
+        // assign the map to the map view
         self.mapView.map = AGSMap(basemapStyle: .arcGISTopographic)
         let center = AGSPoint(x: -225166.5, y: 6551249, spatialReference: .webMercator())
         self.mapView.setViewpoint(AGSViewpoint(center: center, scale: 1e5))
         
-        //add the graphics overlay to the map view
+        // add the graphics overlay to the map view
         self.mapView.graphicsOverlays.add(graphicsOverlay)
         
-        //add picture marker symbol using a remote image
+        // add picture marker symbol using a remote image
         self.addPictureMarkerSymbolFromURL()
         
-        //add picture marker symbol using image in assets
+        // add picture marker symbol using image in assets
         self.addPictureMarkerSymbolFromImage()
     }
     
@@ -46,37 +46,37 @@ class PictureMarkerSymbolsViewController: UIViewController {
         
         let campsiteSymbol = AGSPictureMarkerSymbol(url: url)
         
-        //optionally set the size (if not set, the size in pixels of the image will be used)
+        // optionally set the size (if not set, the size in pixels of the image will be used)
         campsiteSymbol.width = 24
         campsiteSymbol.height = 24
         
-        //location for camp site
+        // location for camp site
         let campsitePoint = AGSPoint(x: -223560, y: 6552021, spatialReference: .webMercator())
         
-        //graphic for camp site
+        // graphic for camp site
         let graphic = AGSGraphic(geometry: campsitePoint, symbol: campsiteSymbol, attributes: nil)
         
-        //add the graphic to the overlay
+        // add the graphic to the overlay
         self.graphicsOverlay.graphics.add(graphic)
     }
     
     private func addPictureMarkerSymbolFromImage() {
-        //image name
+        // image name
         let imageName = "PinBlueStar"
         
-        //create pin symbol using the image
+        // create pin symbol using the image
         let pinSymbol = AGSPictureMarkerSymbol(image: UIImage(named: imageName)!)
         
-        //change offsets, so the symbol aligns properly to the point
+        // change offsets, so the symbol aligns properly to the point
         pinSymbol.offsetY = pinSymbol.image!.size.height / 2
         
-        //location for pin
+        // location for pin
         let pinPoint = AGSPoint(x: -226773, y: 6550477, spatialReference: .webMercator())
         
-        //graphic for pin
+        // graphic for pin
         let graphic = AGSGraphic(geometry: pinPoint, symbol: pinSymbol, attributes: nil)
         
-        //add the graphic to the overlay
+        // add the graphic to the overlay
         self.graphicsOverlay.graphics.add(graphic)
     }
 }

--- a/arcgis-ios-sdk-samples/Display information/Show callout/CalloutViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Show callout/CalloutViewController.swift
@@ -23,31 +23,31 @@ class CalloutViewController: UIViewController, AGSGeoViewTouchDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["CalloutViewController"]
         
-        //initialize map with topographic basemap
+        // initialize map with topographic basemap
         self.map = AGSMap(basemapStyle: .arcGISTopographic)
-        //assign map to the map view
+        // assign map to the map view
         self.mapView.map = self.map
-        //register as the map view's touch delegate
-        //in order to get tap notifications
+        // register as the map view's touch delegate
+        // in order to get tap notifications
         self.mapView.touchDelegate = self
-        //zoom to custom view point
+        // zoom to custom view point
         self.mapView.setViewpointCenter(AGSPoint(x: -1.2e7, y: 5e6, spatialReference: .webMercator()), scale: 4e7)
     }
     
     // MARK: - AGSGeoViewTouchDelegate
     
-    //user tapped on the map
+    // user tapped on the map
     func geoView(_ geoView: AGSGeoView, didTapAtScreenPoint screenPoint: CGPoint, mapPoint: AGSPoint) {
-        //if the callout is not shown, show the callout with the coordinates of the tapped location
+        // if the callout is not shown, show the callout with the coordinates of the tapped location
         if self.mapView.callout.isHidden {
             self.mapView.callout.title = "Location"
             self.mapView.callout.detail = String(format: "x: %.2f, y: %.2f", mapPoint.x, mapPoint.y)
             self.mapView.callout.isAccessoryButtonHidden = true
             self.mapView.callout.show(at: mapPoint, screenOffset: CGPoint.zero, rotateOffsetWithMap: false, animated: true)
-        } else {  //hide the callout
+        } else {  // hide the callout
             self.mapView.callout.dismiss()
         }
     }

--- a/arcgis-ios-sdk-samples/Display information/Show legend/MILLegendTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Show legend/MILLegendTableViewController.swift
@@ -31,7 +31,7 @@ class MILLegendTableViewController: UITableViewController {
             if !layer.subLayerContents.isEmpty {
                 self.populateLegends(with: layer.subLayerContents)
             } else {
-                //else if no sublayers fetch legend info
+                // else if no sublayers fetch legend info
                 self.orderArray.append(layer)
                 layer.fetchLegendInfos { [weak self] (legendInfos, error) in
                     if let error = error {

--- a/arcgis-ios-sdk-samples/Display information/Show legend/MILShowLegendViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Show legend/MILShowLegendViewController.swift
@@ -24,26 +24,26 @@ class MILShowLegendViewController: UIViewController, UIAdaptivePresentationContr
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["MILShowLegendViewController", "MILLegendTableViewController"]
         
-        //initialize the map
+        // initialize the map
         self.map = AGSMap(basemapStyle: .arcGISTopographic)
         
-        //create tiled layer
+        // create tiled layer
         let tiledLayer = AGSArcGISTiledLayer(url: URL(string: "https://services.arcgisonline.com/ArcGIS/rest/services/Specialty/Soil_Survey_Map/MapServer")!)
         self.map.operationalLayers.add(tiledLayer)
         
-        //create a map image layer using a url
+        // create a map image layer using a url
         let mapImageLayer = AGSArcGISMapImageLayer(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer")!)
-        //add the image layer to the map
+        // add the image layer to the map
         self.map.operationalLayers.add(mapImageLayer)
         
-        //create feature table using a url
+        // create feature table using a url
         let featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0")!)
-        //create feature layer using this feature table
+        // create feature layer using this feature table
         let featureLayer = AGSFeatureLayer(featureTable: featureTable)
-        //add feature layer to the map
+        // add feature layer to the map
         self.map.operationalLayers.add(featureLayer)
         
         self.map.load { [weak self] (error: Error?) in
@@ -54,7 +54,7 @@ class MILShowLegendViewController: UIViewController, UIAdaptivePresentationContr
         
         self.mapView.map = self.map
         
-        //zoom to a custom viewpoint
+        // zoom to a custom viewpoint
         self.mapView.setViewpointCenter(AGSPoint(x: -11e6, y: 6e6, spatialReference: .webMercator()), scale: 9e7)
     }
     

--- a/arcgis-ios-sdk-samples/Display information/Simple marker symbol/SimpleMarkerSymbolViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Simple marker symbol/SimpleMarkerSymbolViewController.swift
@@ -23,32 +23,32 @@ class SimpleMarkerSymbolViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["SimpleMarkerSymbolViewController"]
         
-        //assign map to the map view
+        // assign map to the map view
         self.mapView.map = AGSMap(basemapStyle: .arcGISImagery)
         let center = AGSPoint(x: -226773, y: 6550477, spatialReference: .webMercator())
         self.mapView.setViewpoint(AGSViewpoint(center: center, scale: 6500))
         
-        //add graphics overlay to the map view
+        // add graphics overlay to the map view
         self.mapView.graphicsOverlays.add(graphicsOverlay)
         
-        //add a graphic with simple marker symbol
+        // add a graphic with simple marker symbol
         self.addSimpleMarkerSymbol()
     }
 
     private func addSimpleMarkerSymbol() {
-        //create a simple marker symbol
+        // create a simple marker symbol
         let symbol = AGSSimpleMarkerSymbol(style: .circle, color: .red, size: 12)
         
-        //create point
+        // create point
         let point = AGSPoint(x: -226773, y: 6550477, spatialReference: .webMercator())
         
-        //graphic for point using simple marker symbol
+        // graphic for point using simple marker symbol
         let graphic = AGSGraphic(geometry: point, symbol: symbol, attributes: nil)
         
-        //add the graphic to the graphics overlay
+        // add the graphic to the graphics overlay
         self.graphicsOverlay.graphics.add(graphic)
     }
 }

--- a/arcgis-ios-sdk-samples/Display information/Simple renderer/SimpleRendererViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Simple renderer/SimpleRendererViewController.swift
@@ -24,52 +24,52 @@ class SimpleRendererViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["SimpleRendererViewController"]
         
-        //instantiate map with basemap
+        // instantiate map with basemap
         let map = AGSMap(basemapStyle: .arcGISImagery)
         
-        //assign map to the map view
+        // assign map to the map view
         self.mapView.map = map
         
-        //add graphics
+        // add graphics
         self.addGraphics()
         
-        //create and assign simple renderer
+        // create and assign simple renderer
         self.addSimpleRenderer()
     }
 
     private func addGraphics() {
-        //Create points to add graphics to the map to allow a renderer to style them
-        //These are in WGS84 coordinates (Long, Lat)
+        // Create points to add graphics to the map to allow a renderer to style them
+        // These are in WGS84 coordinates (Long, Lat)
         let oldFaithfulPoint = AGSPoint(x: -110.828140, y: 44.460458, spatialReference: .wgs84())
         let cascadeGeyserPoint = AGSPoint(x: -110.829004, y: 44.462438, spatialReference: .wgs84())
         let plumeGeyserPoint = AGSPoint(x: -110.829381, y: 44.462735, spatialReference: .wgs84())
         
-        //create graphics
+        // create graphics
         let oldFaithfulGraphic = AGSGraphic(geometry: oldFaithfulPoint, symbol: nil, attributes: nil)
         let cascadeGeyserGraphic = AGSGraphic(geometry: cascadeGeyserPoint, symbol: nil, attributes: nil)
         let plumeGeyserGraphic = AGSGraphic(geometry: plumeGeyserPoint, symbol: nil, attributes: nil)
         
-        //add the graphics to the graphics overlay
+        // add the graphics to the graphics overlay
         self.graphicsOverlay.graphics.addObjects(from: [oldFaithfulGraphic, cascadeGeyserGraphic, plumeGeyserGraphic])
         
-        //add the graphics overlay to the map view
+        // add the graphics overlay to the map view
         self.mapView.graphicsOverlays.add(self.graphicsOverlay)
         
-        //create an envelope using the points above to zoom to
+        // create an envelope using the points above to zoom to
         let envelope = AGSEnvelope(min: oldFaithfulPoint, max: plumeGeyserPoint)
         
-        //set viewpoint on the map view
+        // set viewpoint on the map view
         self.mapView.setViewpointGeometry(envelope, padding: 100, completion: nil)
     }
     
     private func addSimpleRenderer() {
-        //create a simple renderer with red cross symbol
+        // create a simple renderer with red cross symbol
         let simpleRenderer = AGSSimpleRenderer(symbol: AGSSimpleMarkerSymbol(style: .cross, color: .red, size: 12))
         
-        //assign the renderer to the graphics overlay
+        // assign the renderer to the graphics overlay
         self.graphicsOverlay.renderer = simpleRenderer
     }
 }

--- a/arcgis-ios-sdk-samples/Display information/Sketch on the map/SketchViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Sketch on the map/SketchViewController.swift
@@ -27,7 +27,7 @@ class SketchViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["SketchViewController"]
         
         self.sketchEditor = AGSSketchEditor()
@@ -40,13 +40,13 @@ class SketchViewController: UIViewController {
         
         NotificationCenter.default.addObserver(self, selector: #selector(SketchViewController.respondToGeomChanged), name: .AGSSketchEditorGeometryDidChange, object: nil)
         
-        //set viewpoint
+        // set viewpoint
         self.mapView.setViewpoint(AGSViewpoint(targetExtent: AGSEnvelope(xMin: -10049589.670344, yMin: 3480099.843772, xMax: -10010071.251113, yMax: 3512023.489701, spatialReference: .webMercator())))
     }
     
     @objc
     func respondToGeomChanged() {
-        //Enable/disable UI elements appropriately
+        // Enable/disable UI elements appropriately
         self.undoBBI.isEnabled = self.sketchEditor.undoManager.canUndo
         self.redoBBI.isEnabled = self.sketchEditor.undoManager.canRedo
         self.clearBBI.isEnabled = self.sketchEditor.geometry != nil && !self.sketchEditor.geometry!.isEmpty
@@ -56,19 +56,19 @@ class SketchViewController: UIViewController {
     
     @IBAction func geometryValueChanged(_ segmentedControl: UISegmentedControl) {
         switch segmentedControl.selectedSegmentIndex {
-        case 0://point
+        case 0:// point
             self.sketchEditor.start(with: nil, creationMode: .point)
             
-        case 1://polyline
+        case 1:// polyline
             self.sketchEditor.start(with: nil, creationMode: .polyline)
             
-        case 2://freehand polyline
+        case 2:// freehand polyline
             self.sketchEditor.start(with: nil, creationMode: .freehandPolyline)
             
-        case 3://polygon
+        case 3:// polygon
             self.sketchEditor.start(with: nil, creationMode: .polygon)
             
-        case 4://freehand polygon
+        case 4:// freehand polygon
             self.sketchEditor.start(with: nil, creationMode: .freehandPolygon)
             
         default:
@@ -79,13 +79,13 @@ class SketchViewController: UIViewController {
     }
     
     @IBAction func undo() {
-        if self.sketchEditor.undoManager.canUndo { //extra check, just to be sure
+        if self.sketchEditor.undoManager.canUndo { // extra check, just to be sure
             self.sketchEditor.undoManager.undo()
         }
     }
     
     @IBAction func redo() {
-        if self.sketchEditor.undoManager.canRedo { //extra check, just to be sure
+        if self.sketchEditor.undoManager.canRedo { // extra check, just to be sure
             self.sketchEditor.undoManager.redo()
         }
     }

--- a/arcgis-ios-sdk-samples/Display information/Unique value renderer/UniqueValueRendererViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Unique value renderer/UniqueValueRendererViewController.swift
@@ -22,10 +22,10 @@ class UniqueValueRendererViewController: UIViewController {
     /// The map view managed by the view controller.
     @IBOutlet var mapView: AGSMapView! {
         didSet {
-            //assign map to the map view
+            // assign map to the map view
             mapView.map = makeMap()
             
-            //set initial viewpoint
+            // set initial viewpoint
             let center = AGSPoint(x: -12966000.5, y: 4441498.5, spatialReference: .webMercator())
             mapView.setViewpoint(AGSViewpoint(center: center, scale: 4e7))
         }
@@ -36,17 +36,17 @@ class UniqueValueRendererViewController: UIViewController {
     ///
     /// - Returns: A new `AGSMap` object.
     func makeMap() -> AGSMap {
-        //instantiate map with basemap
+        // instantiate map with basemap
         let map = AGSMap(basemapStyle: .arcGISTopographic)
         
-        //create feature layer
+        // create feature layer
         let featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3")!)
         let featureLayer = AGSFeatureLayer(featureTable: featureTable)
         
-        //make unique value renderer and assign it to the feature layer
+        // make unique value renderer and assign it to the feature layer
         featureLayer.renderer = makeUniqueValueRenderer()
         
-        //add the layer to the map as operational layer
+        // add the layer to the map as operational layer
         map.operationalLayers.add(featureLayer)
         
         return map
@@ -57,29 +57,29 @@ class UniqueValueRendererViewController: UIViewController {
     ///
     /// - Returns: A new `AGSUniqueValueRenderer` object.
     func makeUniqueValueRenderer() -> AGSUniqueValueRenderer {
-        //instantiate a new unique value renderer
+        // instantiate a new unique value renderer
         let renderer = AGSUniqueValueRenderer()
         
-        //set the field to use for the unique values
-        //You can add multiple fields to be used for the renderer in the form of a list, in this case we are only adding a single field
+        // set the field to use for the unique values
+        // You can add multiple fields to be used for the renderer in the form of a list, in this case we are only adding a single field
         renderer.fieldNames = ["STATE_ABBR"]
         
-        //create symbols to be used in the renderer
+        // create symbols to be used in the renderer
         let defaultSymbol = AGSSimpleFillSymbol(style: .null, color: .clear, outline: AGSSimpleLineSymbol(style: .solid, color: .gray, width: 2))
         let californiaSymbol = AGSSimpleFillSymbol(style: .solid, color: .red, outline: AGSSimpleLineSymbol(style: .solid, color: .red, width: 2))
         let arizonaSymbol = AGSSimpleFillSymbol(style: .solid, color: .green, outline: AGSSimpleLineSymbol(style: .solid, color: .green, width: 2))
         let nevadaSymbol = AGSSimpleFillSymbol(style: .solid, color: .blue, outline: AGSSimpleLineSymbol(style: .solid, color: .blue, width: 2))
         
-        //set the default symbol
+        // set the default symbol
         renderer.defaultSymbol = defaultSymbol
         renderer.defaultLabel = "Other"
         
-        //create unique values
+        // create unique values
         let californiaValue = AGSUniqueValue(description: "State of California", label: "California", symbol: californiaSymbol, values: ["CA"])
         let arizonaValue = AGSUniqueValue(description: "State of Arizona", label: "Arizona", symbol: arizonaSymbol, values: ["AZ"])
         let nevadaValue = AGSUniqueValue(description: "State of Nevada", label: "Nevada", symbol: nevadaSymbol, values: ["NV"])
         
-        //add the values to the renderer
+        // add the values to the renderer
         renderer.uniqueValues.append(contentsOf: [californiaValue, arizonaValue, nevadaValue])
         
         return renderer
@@ -90,7 +90,7 @@ class UniqueValueRendererViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["UniqueValueRendererViewController"]
     }
 }

--- a/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
@@ -24,51 +24,51 @@ class AddFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["AddFeaturesViewController"]
         
-        //assign the map to the map view
+        // assign the map to the map view
         let map = AGSMap(basemapStyle: .arcGISStreets)
         self.mapView.map = map
         self.mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: 544871.19, y: 6806138.66, spatialReference: .webMercator()), scale: 2e6))
-        //set touch delegate on map view as self
+        // set touch delegate on map view as self
         self.mapView.touchDelegate = self
         
-        //instantiate service feature table using the url to the service
+        // instantiate service feature table using the url to the service
         self.featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0")!)
-        //create a feature layer using the service feature table
+        // create a feature layer using the service feature table
         let featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
         
-        //add the feature layer to the operational layers on map
+        // add the feature layer to the operational layers on map
         map.operationalLayers.add(featureLayer)
     }
     
     func addFeature(at mappoint: AGSPoint) {
-        //disable interaction with map view
+        // disable interaction with map view
         mapView.isUserInteractionEnabled = false
         
-        //normalize geometry
+        // normalize geometry
         let normalizedGeometry = AGSGeometryEngine.normalizeCentralMeridian(of: mappoint)!
         
-        //attributes for the new feature
+        // attributes for the new feature
         let featureAttributes = ["typdamage": "Minor", "primcause": "Earthquake"]
-        //create a new feature
+        // create a new feature
         let feature = featureTable.createFeature(attributes: featureAttributes, geometry: normalizedGeometry)
         
-        //show the progress hud
+        // show the progress hud
         SVProgressHUD.show(withStatus: "Adding..")
         
-        //add the feature to the feature table
+        // add the feature to the feature table
         featureTable.add(feature) { [weak self] (error: Error?) in
             SVProgressHUD.dismiss()
             
             if let error = error {
                 self?.presentAlert(message: "Error while adding feature: \(error.localizedDescription)")
             } else {
-                //applied edits on success
+                // applied edits on success
                 self?.applyEdits()
             }
-            //enable interaction with map view
+            // enable interaction with map view
             self?.mapView.isUserInteractionEnabled = true
         }
     }
@@ -90,7 +90,7 @@ class AddFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate {
     // MARK: - AGSGeoViewTouchDelegate
     
     func geoView(_ geoView: AGSGeoView, didTapAtScreenPoint screenPoint: CGPoint, mapPoint: AGSPoint) {
-        //add a feature at the tapped location
+        // add a feature at the tapped location
         self.addFeature(at: mapPoint)
     }
 }

--- a/arcgis-ios-sdk-samples/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
@@ -26,27 +26,27 @@ class DeleteFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate, A
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["DeleteFeaturesViewController"]
         
-        //instantiate map with a basemap
+        // instantiate map with a basemap
         let map = AGSMap(basemapStyle: .arcGISStreets)
         
-        //assign the map to the map view
+        // assign the map to the map view
         self.mapView.map = map
         self.mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: 544871.19, y: 6806138.66, spatialReference: .webMercator()), scale: 2e6))
-        //set touch delegate on map view as self
+        // set touch delegate on map view as self
         self.mapView.touchDelegate = self
         
-        //instantiate service feature table using the url to the service
+        // instantiate service feature table using the url to the service
         featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0")!)
-        //create a feature layer using the service feature table
+        // create a feature layer using the service feature table
         let featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
         
-        //add the feature layer to the operational layers on map
+        // add the feature layer to the operational layers on map
         map.operationalLayers.add(featureLayer)
         
-        //store the feature layer for later use
+        // store the feature layer for later use
         self.featureLayer = featureLayer
     }
     
@@ -88,7 +88,7 @@ class DeleteFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate, A
             lastQuery.cancel()
         }
         
-        //hide the callout
+        // hide the callout
         self.mapView.callout.dismiss()
         
         self.lastQuery = self.mapView.identifyLayer(self.featureLayer, screenPoint: screenPoint, tolerance: 12, returnPopupsOnly: false, maximumResults: 1) { [weak self] (identifyLayerResult: AGSIdentifyLayerResult) in
@@ -96,9 +96,9 @@ class DeleteFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate, A
                 print(error)
             } else if let features = identifyLayerResult.geoElements as? [AGSFeature],
                 let feature = features.first {
-                //show callout for the first feature
+                // show callout for the first feature
                 self?.showCallout(for: feature, at: mapPoint)
-                //update selected feature
+                // update selected feature
                 self?.selectedFeature = feature
             }
         }
@@ -107,22 +107,22 @@ class DeleteFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate, A
     // MARK: - AGSCalloutDelegate
     
     func didTapAccessoryButton(for callout: AGSCallout) {
-        //hide the callout
+        // hide the callout
         self.mapView.callout.dismiss()
         
-        //confirmation
+        // confirmation
         let alertController = UIAlertController(title: "Are you sure you want to delete the feature", message: nil, preferredStyle: .alert)
-        //action for Yes
+        // action for Yes
         let alertAction = UIAlertAction(title: "Yes", style: .default) { [weak self] (_) in
             self?.deleteFeature(self!.selectedFeature)
         }
         alertController.addAction(alertAction)
         
-        //action for cancel
+        // action for cancel
         let cancelAlertAction = UIAlertAction(title: "No", style: .cancel)
         alertController.addAction(cancelAlertAction)
         
-        //present alert controller
+        // present alert controller
         self.present(alertController, animated: true)
     }
 }

--- a/arcgis-ios-sdk-samples/Edit data/Edit and sync features/EditAndSyncFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit and sync features/EditAndSyncFeaturesViewController.swift
@@ -183,7 +183,7 @@ class EditAndSyncFeaturesViewController: UIViewController {
             self.generateJob = generateGeodatabaseJob
             generateGeodatabaseJob.start(
                 statusHandler: { (status: AGSJobStatus) in
-                    SVProgressHUD.show(withStatus: status.statusString()) //Show job status.
+                    SVProgressHUD.show(withStatus: status.statusString()) // Show job status.
                 },
                 completion: { [weak self] (_, error: Error?) in
                     SVProgressHUD.dismiss()

--- a/arcgis-ios-sdk-samples/Edit data/Edit feature attachments/AttachmentsTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit feature attachments/AttachmentsTableViewController.swift
@@ -25,11 +25,11 @@ class AttachmentsTableViewController: UITableViewController {
     private var attachments: [AGSAttachment] = []
     
     private func loadAttachments() {
-        //show progress hud
+        // show progress hud
         SVProgressHUD.show(withStatus: "Loading attachments")
         
         feature?.fetchAttachments { [weak self] (attachments: [AGSAttachment]?, error: Error?) in
-            //dismiss progress hud
+            // dismiss progress hud
             SVProgressHUD.dismiss()
             
             guard let self = self else {
@@ -130,11 +130,11 @@ class AttachmentsTableViewController: UITableViewController {
     
     @IBAction func doneAction() {
         if let table = feature?.featureTable as? AGSServiceFeatureTable {
-            //show progress hud
+            // show progress hud
             SVProgressHUD.show(withStatus: "Applying edits")
             
             table.applyEdits { [weak self] (_, error) in
-                //dismiss progress hud
+                // dismiss progress hud
                 SVProgressHUD.dismiss()
                 
                 guard let self = self else {
@@ -156,7 +156,7 @@ class AttachmentsTableViewController: UITableViewController {
             return
         }
         
-        //show progress hud
+        // show progress hud
         SVProgressHUD.show(withStatus: "Adding attachment")
         
         feature?.addAttachment(withName: "Attachment.png", contentType: "png", data: pngData) { [weak self] (attachment: AGSAttachment?, error: Error?) in

--- a/arcgis-ios-sdk-samples/Edit data/Edit feature attachments/EditFeatureAttachmentsViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit feature attachments/EditFeatureAttachmentsViewController.swift
@@ -34,7 +34,7 @@ class EditFeatureAttachmentsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = [
             "EditFeatureAttachmentsViewController",
             "AttachmentsTableViewController"
@@ -67,7 +67,7 @@ extension EditFeatureAttachmentsViewController: AGSGeoViewTouchDelegate {
             lastQuery.cancel()
         }
         
-        //hide the callout
+        // hide the callout
         mapView.callout.dismiss()
         
         lastQuery = mapView.identifyLayer(featureLayer, screenPoint: screenPoint, tolerance: 12, returnPopupsOnly: false, maximumResults: 1) { [weak self] (identifyLayerResult: AGSIdentifyLayerResult) in
@@ -79,9 +79,9 @@ extension EditFeatureAttachmentsViewController: AGSGeoViewTouchDelegate {
                 print(error)
             } else if let features = identifyLayerResult.geoElements as? [AGSArcGISFeature],
                 let feature = features.first,
-                //show callout for the first feature
+                // show callout for the first feature
                 let title = feature.attributes["typdamage"] as? String {
-                //fetch attachment
+                // fetch attachment
                 feature.fetchAttachments { (attachments: [AGSAttachment]?, error: Error?) in
                     if let error = error {
                         print(error)
@@ -91,7 +91,7 @@ extension EditFeatureAttachmentsViewController: AGSGeoViewTouchDelegate {
                         self.mapView.callout.detail = detail
                         self.mapView.callout.delegate = self
                         self.mapView.callout.show(for: feature, tapLocation: mapPoint, animated: true)
-                        //update selected feature
+                        // update selected feature
                         self.selectedFeature = feature
                     }
                 }
@@ -102,9 +102,9 @@ extension EditFeatureAttachmentsViewController: AGSGeoViewTouchDelegate {
 
 extension EditFeatureAttachmentsViewController: AGSCalloutDelegate {
     func didTapAccessoryButton(for callout: AGSCallout) {
-        //hide the callout
+        // hide the callout
         mapView.callout.dismiss()
-        //show the attachments list vc
+        // show the attachments list vc
         performSegue(withIdentifier: "AttachmentsSegue", sender: self)
     }
 }

--- a/arcgis-ios-sdk-samples/Edit data/Edit features (connected)/EditFeaturesOnlineViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit features (connected)/EditFeaturesOnlineViewController.swift
@@ -30,7 +30,7 @@ class EditFeaturesOnlineViewController: UIViewController, AGSGeoViewTouchDelegat
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["EditFeaturesOnlineViewController", "FeatureTemplatePickerViewController"]
         
         self.map = AGSMap(basemapStyle: .arcGISTopographic)
@@ -42,14 +42,14 @@ class EditFeaturesOnlineViewController: UIViewController, AGSGeoViewTouchDelegat
         let featureLayer = AGSFeatureLayer(featureTable: featureTable)
         self.map.operationalLayers.add(featureLayer)
         
-        //initialize sketch editor and assign to map view
+        // initialize sketch editor and assign to map view
         self.sketchEditor = AGSSketchEditor()
         self.mapView.sketchEditor = self.sketchEditor
                 
-        //hide the sketchToolbar initially
+        // hide the sketchToolbar initially
         self.sketchToolbar.isHidden = true
         
-        //store the feature layer for later use
+        // store the feature layer for later use
         self.featureLayer = featureLayer
     }
     
@@ -58,7 +58,7 @@ class EditFeaturesOnlineViewController: UIViewController, AGSGeoViewTouchDelegat
     }
     
     func applyEdits() {
-        //show progress hud
+        // show progress hud
         SVProgressHUD.show(withStatus: "Applying edits")
         
         (featureLayer.featureTable as! AGSServiceFeatureTable).applyEdits { [weak self] (_, error) in
@@ -97,10 +97,10 @@ class EditFeaturesOnlineViewController: UIViewController, AGSGeoViewTouchDelegat
     
     func popupsViewController(_ popupsViewController: AGSPopupsViewController, sketchEditorFor popup: AGSPopup) -> AGSSketchEditor? {
         if let geometry = popup.geoElement.geometry {
-            //start sketch editing
+            // start sketch editing
             self.mapView.sketchEditor?.start(with: geometry)
             
-            //zoom to the existing feature's geometry
+            // zoom to the existing feature's geometry
             self.mapView.setViewpointGeometry(geometry.extent, padding: 10, completion: nil)
         }
         
@@ -108,34 +108,34 @@ class EditFeaturesOnlineViewController: UIViewController, AGSGeoViewTouchDelegat
     }
     
     func popupsViewController(_ popupsViewController: AGSPopupsViewController, readyToEditGeometryWith sketchEditor: AGSSketchEditor?, for popup: AGSPopup) {
-        //Dismiss the popup view controller
+        // Dismiss the popup view controller
         self.dismiss(animated: true)
         
-        //Prepare the current view controller for sketch mode
+        // Prepare the current view controller for sketch mode
         self.mapView.callout.isHidden = true
         
-        //hide the back button
+        // hide the back button
         self.navigationItem.hidesBackButton = true
         
-        //disable the code button
+        // disable the code button
         self.navigationItem.rightBarButtonItem?.isEnabled = false
         
-        //unhide the sketchToolbar
+        // unhide the sketchToolbar
         self.sketchToolbar.isHidden = false
         
-        //disable the done button until any geometry changes
+        // disable the done button until any geometry changes
         self.doneBBI.isEnabled = false
         
         NotificationCenter.default.addObserver(self, selector: #selector(EditFeaturesOnlineViewController.sketchChanged(_:)), name: .AGSSketchEditorGeometryDidChange, object: nil)
     }
     
     func popupsViewController(_ popupsViewController: AGSPopupsViewController, didCancelEditingFor popup: AGSPopup) {
-        //stop sketch editor
+        // stop sketch editor
         self.disableSketchEditor()
     }
     
     func popupsViewController(_ popupsViewController: AGSPopupsViewController, didFinishEditingFor popup: AGSPopup) {
-        //stop sketch editor
+        // stop sketch editor
         self.disableSketchEditor()
         
         let feature = popup.geoElement as! AGSFeature
@@ -143,16 +143,16 @@ class EditFeaturesOnlineViewController: UIViewController, AGSGeoViewTouchDelegat
         // simplify the geometry, this will take care of self intersecting polygons and
         feature.geometry = AGSGeometryEngine.simplifyGeometry(feature.geometry!)
         
-        //normalize the geometry, this will take care of geometries that extend beyone the dateline
-        //(ifwraparound was enabled on the map)
+        // normalize the geometry, this will take care of geometries that extend beyone the dateline
+        // (ifwraparound was enabled on the map)
         feature.geometry = AGSGeometryEngine.normalizeCentralMeridian(of: feature.geometry!)
         
-        //apply edits
+        // apply edits
         self.applyEdits()
     }
     
     func popupsViewControllerDidFinishViewingPopups(_ popupsViewController: AGSPopupsViewController) {
-        //dismiss the popups view controller
+        // dismiss the popups view controller
         self.dismiss(animated: true)
         
         self.popupsViewController = nil
@@ -160,30 +160,30 @@ class EditFeaturesOnlineViewController: UIViewController, AGSGeoViewTouchDelegat
     
     @objc
     func sketchChanged(_ notification: Notification) {
-        //Check if the sketch geometry is valid to decide whether to enable
-        //the sketchCompleteButton
+        // Check if the sketch geometry is valid to decide whether to enable
+        // the sketchCompleteButton
         if let geometry = self.mapView.sketchEditor?.geometry, !geometry.isEmpty {
             self.doneBBI.isEnabled = true
         }
     }
     
     @IBAction func sketchDoneAction() {
-        //enable or unhide navigation bar button
+        // enable or unhide navigation bar button
         self.navigationItem.hidesBackButton = false
         self.navigationItem.rightBarButtonItem?.isEnabled = true
         
-        //present the popups view controller again
+        // present the popups view controller again
         self.present(self.popupsViewController, animated: true)
         
-        //remove self as observer for notifications
+        // remove self as observer for notifications
         NotificationCenter.default.removeObserver(self, name: .AGSSketchEditorGeometryDidChange, object: nil)
     }
     
     private func disableSketchEditor() {
-        //stop sketch editor
+        // stop sketch editor
         self.mapView.sketchEditor?.stop()
         
-        //hide sketch toolbar
+        // hide sketch toolbar
         self.sketchToolbar.isHidden = true
     }
     
@@ -202,33 +202,33 @@ class EditFeaturesOnlineViewController: UIViewController, AGSGeoViewTouchDelegat
     
     func featureTemplatePickerViewController(_ controller: FeatureTemplatePickerViewController, didSelectFeatureTemplate template: AGSFeatureTemplate, forFeatureLayer featureLayer: AGSFeatureLayer) {
         let featureTable = self.featureLayer.featureTable as! AGSArcGISFeatureTable
-        //create a new feature based on the template
+        // create a new feature based on the template
         let newFeature = featureTable.createFeature(with: template)!
         
-        //set the geometry as the center of the screen
+        // set the geometry as the center of the screen
         if let visibleArea = self.mapView.visibleArea {
             newFeature.geometry = visibleArea.extent.center
         } else {
             newFeature.geometry = AGSPoint(x: 0, y: 0, spatialReference: self.map.spatialReference)
         }
 
-        //initialize a popup definition using the feature layer
+        // initialize a popup definition using the feature layer
         let popupDefinition = AGSPopupDefinition(popupSource: self.featureLayer)
-        //create a popup
+        // create a popup
         let popup = AGSPopup(geoElement: newFeature, popupDefinition: popupDefinition)
         
-        //initialize popups view controller
+        // initialize popups view controller
         self.popupsViewController = AGSPopupsViewController(popups: [popup], containerStyle: .navigationBar)
         self.popupsViewController.delegate = self
         
-        //Only for iPad, set presentation style to Form sheet
-        //We don't want it to cover the entire screen
+        // Only for iPad, set presentation style to Form sheet
+        // We don't want it to cover the entire screen
         self.popupsViewController.modalPresentationStyle = .formSheet
 
-        //First, dismiss the Feature Template Picker
+        // First, dismiss the Feature Template Picker
         self.dismiss(animated: false)
 
-        //Next, Present the popup view controller
+        // Next, Present the popup view controller
         self.present(self.popupsViewController, animated: true) { [weak self] in
             self?.popupsViewController.startEditingCurrentPopup()
         }

--- a/arcgis-ios-sdk-samples/Edit data/Edit features (connected)/FeatureTemplatePickerViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit features (connected)/FeatureTemplatePickerViewController.swift
@@ -32,29 +32,29 @@ class FeatureTemplatePickerViewController: UITableViewController {
     
     func addTemplatesFromLayer(_ featureLayer: AGSFeatureLayer) {
         let featureTable = featureLayer.featureTable as! AGSServiceFeatureTable
-        //if layer contains only templates (no feature types)
+        // if layer contains only templates (no feature types)
         if !featureTable.featureTemplates.isEmpty {
-            //for each template
+            // for each template
             for template in featureTable.featureTemplates {
                 let info = FeatureTemplateInfo(
                     featureLayer: featureLayer,
                     featureTemplate: template
                 )
-                //add to array
+                // add to array
                 self.infos.append(info)
             }
         }
-            //otherwise if layer contains feature types
+            // otherwise if layer contains feature types
         else {
-            //for each type
+            // for each type
             for type in featureTable.featureTypes {
-                //for each temple in type
+                // for each temple in type
                 for template in type.templates {
                     let info = FeatureTemplateInfo(
                         featureLayer: featureLayer,
                         featureTemplate: template
                     )
-                    //add to array
+                    // add to array
                     self.infos.append(info)
                 }
             }
@@ -62,7 +62,7 @@ class FeatureTemplatePickerViewController: UITableViewController {
     }
     
     @IBAction func cancelAction() {
-        //Notify the delegate that user tried to dismiss the view controller
+        // Notify the delegate that user tried to dismiss the view controller
         self.delegate?.featureTemplatePickerViewControllerWantsToDismiss(self)
     }
     
@@ -77,10 +77,10 @@ class FeatureTemplatePickerViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        //Get a cell
+        // Get a cell
         let cell = tableView.dequeueReusableCell(withIdentifier: "TemplatePickerCell", for: indexPath)
         
-        //Set its label, image, etc for the template
+        // Set its label, image, etc for the template
         let info = self.infos[indexPath.row]
         cell.textLabel?.text = info.featureTemplate.name
         
@@ -90,11 +90,11 @@ class FeatureTemplatePickerViewController: UITableViewController {
     // MARK: - table view delegate
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        //Notify the delegate that the user picked a feature template
+        // Notify the delegate that the user picked a feature template
         let info = self.infos[indexPath.row]
         self.delegate?.featureTemplatePickerViewController(self, didSelectFeatureTemplate: info.featureTemplate, forFeatureLayer: info.featureLayer)
         
-        //unselect the cell
+        // unselect the cell
         tableView.deselectRow(at: indexPath, animated: true)
     }
 }

--- a/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/UpdateAttributesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/UpdateAttributesViewController.swift
@@ -32,7 +32,7 @@ class UpdateAttributesViewController: UIViewController, AGSGeoViewTouchDelegate,
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = [
             "UpdateAttributesViewController",
             "UpdateAttributesOptionsViewController"
@@ -48,7 +48,7 @@ class UpdateAttributesViewController: UIViewController, AGSGeoViewTouchDelegate,
         self.mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: 544871.19, y: 6806138.66, spatialReference: .webMercator()), scale: 2e6))
         self.mapView.touchDelegate = self
         
-        //store the feature layer for later use
+        // store the feature layer for later use
         self.featureLayer = featureLayer
     }
     
@@ -85,7 +85,7 @@ class UpdateAttributesViewController: UIViewController, AGSGeoViewTouchDelegate,
             lastQuery.cancel()
         }
         
-        //hide the callout
+        // hide the callout
         self.mapView.callout.dismiss()
         
         self.lastQuery = self.mapView.identifyLayer(self.featureLayer, screenPoint: screenPoint, tolerance: 12, returnPopupsOnly: false, maximumResults: 1) { [weak self] (identifyLayerResult: AGSIdentifyLayerResult) in
@@ -93,9 +93,9 @@ class UpdateAttributesViewController: UIViewController, AGSGeoViewTouchDelegate,
                 print(error)
             } else if let features = identifyLayerResult.geoElements as? [AGSArcGISFeature],
                 let feature = features.first {
-                //show callout for the first feature
+                // show callout for the first feature
                 self?.showCallout(feature, tapLocation: mapPoint)
-                //update selected feature
+                // update selected feature
                 self?.selectedFeature = feature
             }
         }
@@ -104,9 +104,9 @@ class UpdateAttributesViewController: UIViewController, AGSGeoViewTouchDelegate,
     // MARK: - AGSCalloutDelegate
     
     func didTapAccessoryButton(for callout: AGSCallout) {
-        //hide the callout
+        // hide the callout
         self.mapView.callout.dismiss()
-        //show editing options
+        // show editing options
         self.performSegue(withIdentifier: self.optionsSegueName, sender: self)
     }
     

--- a/arcgis-ios-sdk-samples/Edit data/Update geometries (feature service)/EditGeometryViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update geometries (feature service)/EditGeometryViewController.swift
@@ -31,7 +31,7 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["EditGeometryViewController"]
         
         self.map = AGSMap(basemapStyle: .arcGISOceans)
@@ -45,14 +45,14 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
         self.mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: -9030446.96, y: 943791.32, spatialReference: .webMercator()), scale: 2e6))
         self.mapView.touchDelegate = self
         
-        //store the feature layer for later use
+        // store the feature layer for later use
         self.featureLayer = featureLayer
     }
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        //default state for toolbar is off
+        // default state for toolbar is off
         self.setToolbarVisibility(visible: false)
     }
     
@@ -71,7 +71,7 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
             } else {
                 self?.presentAlert(message: "Saved successfully!")
             }
-            //un hide the feature
+            // un hide the feature
             self?.featureLayer.setFeature(self!.selectedFeature, visible: true)
         }
     }
@@ -83,7 +83,7 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
             lastQuery.cancel()
         }
         
-        //hide the callout
+        // hide the callout
         self.mapView.callout.dismiss()
         
         self.lastQuery = self.mapView.identifyLayer(self.featureLayer, screenPoint: screenPoint, tolerance: 12, returnPopupsOnly: false, maximumResults: 1) { [weak self] (identifyLayerResult: AGSIdentifyLayerResult) in
@@ -91,12 +91,12 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
                 print(error)
             } else if let features = identifyLayerResult.geoElements as? [AGSArcGISFeature],
                 let feature = features.first {
-                //show callout for the first feature
+                // show callout for the first feature
                 let title = feature.attributes["typdamage"] as! String
                 self?.mapView.callout.title = title
                 self?.mapView.callout.delegate = self
                 self?.mapView.callout.show(for: feature, tapLocation: mapPoint, animated: true)
-                //update selected feature
+                // update selected feature
                 self?.selectedFeature = feature
             }
         }
@@ -105,22 +105,22 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
     // MARK: - AGSCalloutDelegate
     
     func didTapAccessoryButton(for callout: AGSCallout) {
-        //hide the callout
+        // hide the callout
         self.mapView.callout.dismiss()
         
-        //add the default geometry
+        // add the default geometry
         let point = self.selectedFeature.geometry as! AGSPoint
         
-        //instantiate sketch editor with selected feature's geometry
+        // instantiate sketch editor with selected feature's geometry
         self.mapView.sketchEditor = AGSSketchEditor()
         
-        //enable the sketch editor to start tracking user gesture
+        // enable the sketch editor to start tracking user gesture
         self.mapView.sketchEditor?.start(with: point)
         
-        //show the toolbar
+        // show the toolbar
         self.setToolbarVisibility(visible: true)
         
-        //hide the feature for time being
+        // hide the feature for time being
         self.featureLayer.setFeature(self.selectedFeature, visible: false)
     }
     
@@ -133,22 +133,22 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
                 if let error = error {
                     self?.presentAlert(error: error)
                     
-                    //un hide the feature
+                    // un hide the feature
                     self?.featureLayer.setFeature(self!.selectedFeature, visible: true)
                 } else {
-                    //apply edits
+                    // apply edits
                     self?.applyEdits()
                 }
             }
         }
         
-        //hide toolbar
+        // hide toolbar
         self.setToolbarVisibility(visible: false)
         
-        //disable sketch editor
+        // disable sketch editor
         self.mapView.sketchEditor?.stop()
         
-        //clear sketch editor
+        // clear sketch editor
         self.mapView.sketchEditor?.clearGeometry()
     }
 }

--- a/arcgis-ios-sdk-samples/Features/Add delete related features/AddDeleteRelatedFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Add delete related features/AddDeleteRelatedFeaturesViewController.swift
@@ -28,62 +28,62 @@ class AddDeleteRelatedFeaturesViewController: UIViewController, AGSGeoViewTouchD
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["AddDeleteRelatedFeaturesViewController", "RelatedFeaturesViewController"]
 
-        //initialize map with basemap
+        // initialize map with basemap
         let map = AGSMap(basemapStyle: .arcGISStreets)
         
-        //initial viewpoint
+        // initial viewpoint
         let point = AGSPoint(x: -16507762.575543, y: 9058828.127243, spatialReference: .webMercator())
         
-        //parks feature table
+        // parks feature table
         self.parksFeatureTable = AGSServiceFeatureTable(url: URL(string: "https://services2.arcgis.com/ZQgQTuoyBrtmoGdP/ArcGIS/rest/services/AlaskaNationalParksSpecies_Add_Delete/FeatureServer/0")!)
         
-        //parks feature layer
+        // parks feature layer
         let parksFeatureLayer = AGSFeatureLayer(featureTable: self.parksFeatureTable)
         
-        //add feature layer to the map
+        // add feature layer to the map
         map.operationalLayers.add(parksFeatureLayer)
         
-        //species feature table (destination feature table)
-        //related to the parks feature layer in a 1..M relationship
+        // species feature table (destination feature table)
+        // related to the parks feature layer in a 1..M relationship
         let speciesFeatureTable = AGSServiceFeatureTable(url: URL(string: "https://services2.arcgis.com/ZQgQTuoyBrtmoGdP/ArcGIS/rest/services/AlaskaNationalParksSpecies_Add_Delete/FeatureServer/1")!)
         
-        //add table to the map
-        //for the related query to work, the related table should be present in the map
+        // add table to the map
+        // for the related query to work, the related table should be present in the map
         map.tables.add(speciesFeatureTable)
         
-        //assign map to map view
+        // assign map to map view
         mapView.map = map
         mapView.setViewpoint(AGSViewpoint(center: point, scale: 36764077))
         
-        //set touch delegate
+        // set touch delegate
         mapView.touchDelegate = self
         
-        //store the feature layer for later use
+        // store the feature layer for later use
         self.parksFeatureLayer = parksFeatureLayer
     }
     
     // MARK: - AGSGeoViewTouchDelegate
     
     func geoView(_ geoView: AGSGeoView, didTapAtScreenPoint screenPoint: CGPoint, mapPoint: AGSPoint) {
-        //show progress hud for identify
+        // show progress hud for identify
         SVProgressHUD.show(withStatus: "Identifying feature")
         
-        //identify features at tapped location
+        // identify features at tapped location
         self.mapView.identifyLayer(self.parksFeatureLayer, screenPoint: screenPoint, tolerance: 12, returnPopupsOnly: false) { [weak self] (result) in
-            //hide progress hud
+            // hide progress hud
             SVProgressHUD.dismiss()
             
             if let error = result.error {
-                //show error to user
+                // show error to user
                 self?.presentAlert(error: error)
             } else if let feature = result.geoElements.first as? AGSFeature {
-                //select the first feature
+                // select the first feature
                 self?.selectedPark = feature
                 
-                //show related features view controller
+                // show related features view controller
                 self?.performSegue(withIdentifier: "RelatedFeaturesSegue", sender: self)
             }
         }
@@ -95,10 +95,10 @@ class AddDeleteRelatedFeaturesViewController: UIViewController, AGSGeoViewTouchD
         if segue.identifier == "RelatedFeaturesSegue",
             let navigationController = segue.destination as? UINavigationController,
             let controller = navigationController.viewControllers.first as? RelatedFeaturesViewController {
-            //share selected park
+            // share selected park
             controller.originFeature = self.selectedPark as? AGSArcGISFeature
             
-            //share parks feature table as origin feature table
+            // share parks feature table as origin feature table
             controller.originFeatureTable = self.parksFeatureTable
         }
     }

--- a/arcgis-ios-sdk-samples/Features/Add delete related features/RelatedFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Add delete related features/RelatedFeaturesViewController.swift
@@ -27,117 +27,117 @@ class RelatedFeaturesViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        //query for related features and populate the table
+        // query for related features and populate the table
         self.queryRelatedFeatures()
         
-        //Displaying information on selected park using the field UNIT_NAME, name of the park
+        // Displaying information on selected park using the field UNIT_NAME, name of the park
         self.title = self.originFeature.attributes["UNIT_NAME"] as? String ?? "Origin Feature"
     }
     
     private func queryRelatedFeatures() {
-        //get relationship info
-        //feature table's layer info has an array of relationshipInfos, one for each relationship
-        //in this case there is only one describing the 1..M relationship between parks and species
+        // get relationship info
+        // feature table's layer info has an array of relationshipInfos, one for each relationship
+        // in this case there is only one describing the 1..M relationship between parks and species
         guard let relationshipInfo = self.originFeatureTable.layerInfo?.relationshipInfos.first else {
             presentAlert(message: "Relationship info not found")
             return
         }
         
-        //show progress hud
+        // show progress hud
         SVProgressHUD.show(withStatus: "Querying related features")
         
-        //keep for later use
+        // keep for later use
         self.relationshipInfo = relationshipInfo
         
-        //initialize related query parameters with relationshipInfo
+        // initialize related query parameters with relationshipInfo
         let parameters = AGSRelatedQueryParameters(relationshipInfo: relationshipInfo)
         
-        //order results by OBJECTID field
+        // order results by OBJECTID field
         parameters.orderByFields = [AGSOrderBy(fieldName: "OBJECTID", sortOrder: .descending)]
         
-        //query for species related to the selected park
+        // query for species related to the selected park
         self.originFeatureTable.queryRelatedFeatures(for: self.originFeature, parameters: parameters) { [weak self] (results: [AGSRelatedFeatureQueryResult]?, error: Error?) in
-            //dismiss progress hud
+            // dismiss progress hud
             SVProgressHUD.dismiss()
             
             if let error = error {
                 self?.presentAlert(error: error)
             } else if let result = results?.first {
-                //save the related features to display in the table view
+                // save the related features to display in the table view
                 self?.relatedFeatures = result.featureEnumerator().allObjects
                 
-                //reload table view to reflect changes
+                // reload table view to reflect changes
                 self?.tableView.reloadData()
             }
         }
     }
     
     private func addRelatedFeature() {
-        //get related table using relationshipInfo
+        // get related table using relationshipInfo
         guard let relatedTable = originFeatureTable.relatedTables(with: relationshipInfo)?.first as? AGSServiceFeatureTable,
-            //new feature
+            // new feature
             let feature = relatedTable.createFeature(attributes: ["Scientific_name": "New species"], geometry: nil) as? AGSArcGISFeature else {
             return
         }
         
-        //relate new feature to origin feature
+        // relate new feature to origin feature
         feature.relate(to: self.originFeature)
         
-        //show progress hud
+        // show progress hud
         SVProgressHUD.show(withStatus: "Adding feature")
         
-        //add new feature to related table
+        // add new feature to related table
         relatedTable.add(feature) { [weak self] (error) in
             SVProgressHUD.dismiss()
             
             if let error = error {
                 self?.presentAlert(error: error)
             } else {
-                //apply edits
+                // apply edits
                 self?.applyEdits()
             }
         }
     }
     
     private func deleteRelatedFeature(_ feature: AGSFeature) {
-        //get related table using relationshipInfo
+        // get related table using relationshipInfo
         guard let relatedTable = originFeatureTable.relatedTables(with: relationshipInfo)?.first as? AGSServiceFeatureTable else {
             return
         }
         
-        //show progress hud
+        // show progress hud
         SVProgressHUD.show(withStatus: "Deleting feature")
         
-        //delete feature from related table
+        // delete feature from related table
         relatedTable.delete(feature) { [weak self] (error) in
             SVProgressHUD.dismiss()
             
             if let error = error {
                 self?.presentAlert(error: error)
             } else {
-                //apply edits
+                // apply edits
                 self?.applyEdits()
             }
         }
     }
     
     private func applyEdits() {
-        //get the related table using the relationshipInfo
+        // get the related table using the relationshipInfo
         guard let relatedTable = originFeatureTable.relatedTables(with: relationshipInfo)?.first as? AGSServiceFeatureTable else {
             return
         }
         
-        //show progress hud
+        // show progress hud
         SVProgressHUD.show(withStatus: "Applying edits")
         
         relatedTable.applyEdits { [weak self] (_, error) in
             SVProgressHUD.dismiss()
             
             if let error = error {
-                //show error
+                // show error
                 self?.presentAlert(error: error)
             } else {
-                //query to update features
+                // query to update features
                 self?.queryRelatedFeatures()
             }
         }
@@ -154,7 +154,7 @@ class RelatedFeaturesViewController: UITableViewController {
         
         let relatedFeature = relatedFeatures[indexPath.row]
         
-        //display value for Scientific_Name field in the cell
+        // display value for Scientific_Name field in the cell
         cell.textLabel?.text = relatedFeature.attributes["Scientific_Name"] as? String
         
         return cell
@@ -168,7 +168,7 @@ class RelatedFeaturesViewController: UITableViewController {
     
     override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
-            //delete related feature
+            // delete related feature
             let relatedFeature = relatedFeatures[indexPath.row]
             self.deleteRelatedFeature(relatedFeature)
         }
@@ -181,7 +181,7 @@ class RelatedFeaturesViewController: UITableViewController {
     }
     
     @IBAction private func doneAction() {
-        //dismiss view controller
+        // dismiss view controller
         self.dismiss(animated: true)
     }
 }

--- a/arcgis-ios-sdk-samples/Features/Change feature layer renderer/OverrideRendererViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Change feature layer renderer/OverrideRendererViewController.swift
@@ -23,38 +23,38 @@ class OverrideRendererViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["OverrideRendererViewController"]
         
-        //initialize map with topographic basemap
+        // initialize map with topographic basemap
         let map = AGSMap(basemapStyle: .arcGISTopographic)
         
-        //assign map to the map view's map
+        // assign map to the map view's map
         mapView.map = map
         mapView.setViewpoint(AGSViewpoint(targetExtent: AGSEnvelope(xMin: -1.30758164047166E7, yMin: 4014771.46954516, xMax: -1.30730056797177E7, yMax: 4016869.78617381, spatialReference: .webMercator())))
         
-        //initialize feature table using a url to feature server url
+        // initialize feature table using a url to feature server url
         let featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0")!)
-        //initialize feature layer with feature table
+        // initialize feature layer with feature table
         let featureLayer = AGSFeatureLayer(featureTable: featureTable)
-        //add the feature layer to the operational layers on the map view
+        // add the feature layer to the operational layers on the map view
         map.operationalLayers.add(featureLayer)
         
-        //store the feature layer for later use
+        // store the feature layer for later use
         self.featureLayer = featureLayer
     }
     
     @IBAction private func overrideRenderer() {
-        //create a symbol to be used in the renderer
+        // create a symbol to be used in the renderer
         let symbol = AGSSimpleLineSymbol(style: AGSSimpleLineSymbolStyle.solid, color: .blue, width: 2)
-        //create a new renderer using the symbol just created
+        // create a new renderer using the symbol just created
         let renderer = AGSSimpleRenderer(symbol: symbol)
-        //assign the new renderer to the feature layer
+        // assign the new renderer to the feature layer
         self.featureLayer.renderer = renderer
     }
     
     @IBAction private func resetRenderer() {
-        //reset the renderer to default
+        // reset the renderer to default
         self.featureLayer.resetRenderer()
     }
 }

--- a/arcgis-ios-sdk-samples/Features/Feature collection layer (query)/FeatureCollectionLayerQueryViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature collection layer (query)/FeatureCollectionLayerQueryViewController.swift
@@ -24,46 +24,46 @@ class FeatureCollectionLayerQueryViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["FeatureCollectionLayerQueryViewController"]
         
-        //initialize map with basemap
+        // initialize map with basemap
         let map = AGSMap(basemapStyle: .arcGISOceans)
         
-        //assign map to the map view
+        // assign map to the map view
         self.mapView.map = map
         
-        //initialize service feature table to be queried
+        // initialize service feature table to be queried
         self.featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Wildfire/FeatureServer/0")!)
         
-        //create query parameters
+        // create query parameters
         let queryParams = AGSQueryParameters()
         
         // 1=1 will give all the features from the table
         queryParams.whereClause = "1=1"
         
-        //show progress hud
+        // show progress hud
         SVProgressHUD.show(withStatus: "Querying")
         
-        //query feature from the table
+        // query feature from the table
         self.featureTable.queryFeatures(with: queryParams) { [weak self] (queryResult: AGSFeatureQueryResult?, error: Error?) in
-            //hide progress hud
+            // hide progress hud
             SVProgressHUD.dismiss()
             
             if let error = error {
-                //show error
+                // show error
                 self?.presentAlert(error: error)
             } else {
-                //create a feature collection table fromt the query results
+                // create a feature collection table fromt the query results
                 let featureCollectionTable = AGSFeatureCollectionTable(featureSet: queryResult!)
                 
-                //create a feature collection from the above feature collection table
+                // create a feature collection from the above feature collection table
                 let featureCollection = AGSFeatureCollection(featureCollectionTables: [featureCollectionTable])
                 
-                //create a feature collection layer
+                // create a feature collection layer
                 let featureCollectionLayer = AGSFeatureCollectionLayer(featureCollection: featureCollection)
                 
-                //add the layer to the operational layers array
+                // add the layer to the operational layers array
                 self?.mapView.map?.operationalLayers.add(featureCollectionLayer)
             }
         }

--- a/arcgis-ios-sdk-samples/Features/Feature collection layer/FeatureCollectionLayerViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature collection layer/FeatureCollectionLayerViewController.swift
@@ -22,16 +22,16 @@ class FeatureCollectionLayerViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["FeatureCollectionLayerViewController"]
         
-        //initialize map with basemap
+        // initialize map with basemap
         let map = AGSMap(basemapStyle: .arcGISOceans)
         
-        //assign map to the map view
+        // assign map to the map view
         mapView.map = map
         
-        //set viewpoint
+        // set viewpoint
         let point = AGSPoint(x: -79.497238, y: 8.849289, spatialReference: .wgs84())
         mapView.setViewpoint(AGSViewpoint(center: point, scale: 1.5e6))
         
@@ -39,32 +39,32 @@ class FeatureCollectionLayerViewController: UIViewController {
     }
     
     private func addFeatureCollectionLayer() {
-        //feature collection table for point, polyline and polygon
+        // feature collection table for point, polyline and polygon
         let pointsCollectionTable = self.pointsCollectionTable()
         let linesCollectionTable = self.linesCollectionTable()
         let polygonsCollectionTable = self.polygonsCollectionTable()
         
-        //feature collection
+        // feature collection
         let featureCollection = AGSFeatureCollection(featureCollectionTables: [pointsCollectionTable, linesCollectionTable, polygonsCollectionTable])
         
-        //feature collection layer
+        // feature collection layer
         let featureCollectionLayer = AGSFeatureCollectionLayer(featureCollection: featureCollection)
         
-        //add layer to the map
+        // add layer to the map
         self.mapView.map?.operationalLayers.add(featureCollectionLayer)
     }
     
     private func pointsCollectionTable() -> AGSFeatureCollectionTable {
-        //create schema for points feature collection table
+        // create schema for points feature collection table
         var fields = [AGSField]()
         let placeField = AGSField(fieldType: .text, name: "Place", alias: "Place name", length: 40, domain: nil, editable: true, allowNull: false)
         fields.append(placeField)
         
-        //initialize feature collection table with the fields created 
-        //and geometry type as Point
+        // initialize feature collection table with the fields created 
+        // and geometry type as Point
         let pointsCollectionTable = AGSFeatureCollectionTable(fields: fields, geometryType: .point, spatialReference: .wgs84())
         
-        //renderer
+        // renderer
         let symbol = AGSSimpleMarkerSymbol(style: .triangle, color: .red, size: 18)
         pointsCollectionTable.renderer = AGSSimpleRenderer(symbol: symbol)
         
@@ -74,23 +74,23 @@ class FeatureCollectionLayerViewController: UIViewController {
         let point = AGSPoint(x: -79.497238, y: 8.849289, spatialReference: .wgs84())
         pointFeature.geometry = point
         
-        //add feature to the feature collection table
+        // add feature to the feature collection table
         pointsCollectionTable.add(pointFeature, completion: nil)
         
         return pointsCollectionTable
     }
     
     private func linesCollectionTable() -> AGSFeatureCollectionTable {
-        //create schema for points feature collection table
+        // create schema for points feature collection table
         var fields = [AGSField]()
         let boundaryField = AGSField(fieldType: .text, name: "Boundary", alias: "Boundary name", length: 40, domain: nil, editable: true, allowNull: false)
         fields.append(boundaryField)
         
-        //initialize feature collection table with the fields created
-        //and geometry type as Polyline
+        // initialize feature collection table with the fields created
+        // and geometry type as Polyline
         let linesCollectionTable = AGSFeatureCollectionTable(fields: fields, geometryType: .polyline, spatialReference: .wgs84())
         
-        //renderer
+        // renderer
         let symbol = AGSSimpleLineSymbol(style: .dash, color: .green, width: 3)
         linesCollectionTable.renderer = AGSSimpleRenderer(symbol: symbol)
         
@@ -98,28 +98,28 @@ class FeatureCollectionLayerViewController: UIViewController {
         let lineFeature = linesCollectionTable.createFeature()
         lineFeature.attributes["Boundary"] = "AManAPlanACanalPanama"
         
-        //geometry
+        // geometry
         let point1 = AGSPoint(x: -79.497238, y: 8.849289, spatialReference: .wgs84())
         let point2 = AGSPoint(x: -80.035568, y: 9.432302, spatialReference: .wgs84())
         lineFeature.geometry = AGSPolyline(points: [point1, point2])
         
-        //add feature to the feature collection table
+        // add feature to the feature collection table
         linesCollectionTable.add(lineFeature, completion: nil)
         
         return linesCollectionTable
     }
     
     private func polygonsCollectionTable() -> AGSFeatureCollectionTable {
-        //create schema for points feature collection table
+        // create schema for points feature collection table
         var fields = [AGSField]()
         let areaField = AGSField(fieldType: .text, name: "Area", alias: "Area name", length: 40, domain: nil, editable: true, allowNull: false)
         fields.append(areaField)
         
-        //initialize feature collection table with the fields created
-        //and geometry type as Polygon
+        // initialize feature collection table with the fields created
+        // and geometry type as Polygon
         let polygonsCollectionTable = AGSFeatureCollectionTable(fields: fields, geometryType: .polygon, spatialReference: .wgs84())
         
-        //renderer
+        // renderer
         let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: .blue, width: 2)
         let fillSymbol = AGSSimpleFillSymbol(style: .diagonalCross, color: .cyan, outline: lineSymbol)
         polygonsCollectionTable.renderer = AGSSimpleRenderer(symbol: fillSymbol)
@@ -128,13 +128,13 @@ class FeatureCollectionLayerViewController: UIViewController {
         let polygonFeature = polygonsCollectionTable.createFeature()
         polygonFeature.attributes["Area"] = "Restricted area"
         
-        //geometry
+        // geometry
         let point1 = AGSPoint(x: -79.497238, y: 8.849289, spatialReference: .wgs84())
         let point2 = AGSPoint(x: -79.337936, y: 8.638903, spatialReference: .wgs84())
         let point3 = AGSPoint(x: -79.11409, y: 8.895422, spatialReference: .wgs84())
         polygonFeature.geometry = AGSPolygon(points: [point1, point2, point3])
         
-        //add feature to the feature collection table
+        // add feature to the feature collection table
         polygonsCollectionTable.add(polygonFeature, completion: nil)
         
         return polygonsCollectionTable

--- a/arcgis-ios-sdk-samples/Features/Feature layer (feature service)/FeatureLayerURLViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer (feature service)/FeatureLayerURLViewController.swift
@@ -21,23 +21,23 @@ class FeatureLayerURLViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["FeatureLayerURLViewController"]
         
-        //initialize map with basemap
+        // initialize map with basemap
         let map = AGSMap(basemapStyle: .arcGISTerrain)
         
-        //assign map to the map view
+        // assign map to the map view
         self.mapView.map = map
         self.mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: -13176752, y: 4090404, spatialReference: .webMercator()), scale: 300000))
         
-        //initialize service feature table using url
+        // initialize service feature table using url
         let featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/9")!)
 
-        //create a feature layer
+        // create a feature layer
         let featureLayer = AGSFeatureLayer(featureTable: featureTable)
         
-        //add the feature layer to the operational layers
+        // add the feature layer to the operational layers
         map.operationalLayers.add(featureLayer)
     }
 }

--- a/arcgis-ios-sdk-samples/Features/Feature layer (geodatabase)/FeatureLayerGDBViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer (geodatabase)/FeatureLayerGDBViewController.swift
@@ -23,20 +23,20 @@ class FeatureLayerGDBViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["FeatureLayerGDBViewController"]
         
-        //instantiate map with basemap
+        // instantiate map with basemap
         let map = AGSMap(basemapStyle: .arcGISImagery)
         
-        //assign map to the map view
+        // assign map to the map view
         mapView.map = map
         mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: -13214155, y: 4040194, spatialReference: .webMercator()), scale: 35e4))
         
-        //instantiate geodatabase with name
+        // instantiate geodatabase with name
         self.geodatabase = AGSGeodatabase(name: "LA_Trails")
         
-        //load the geodatabase for feature tables
+        // load the geodatabase for feature tables
         self.geodatabase.load { [weak self] (error: Error?) in
             if let error = error {
                 self?.presentAlert(error: error)

--- a/arcgis-ios-sdk-samples/Features/Feature layer (geopackage)/FeatureLayerGPKGViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer (geopackage)/FeatureLayerGPKGViewController.swift
@@ -22,7 +22,7 @@ class FeatureLayerGPKGViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["FeatureLayerGPKGViewController"]
         
         // Instantiate a map.

--- a/arcgis-ios-sdk-samples/Features/Feature layer definition expression/DefinitionExpressionViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer definition expression/DefinitionExpressionViewController.swift
@@ -23,35 +23,35 @@ class DefinitionExpressionViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["DefinitionExpressionViewController"]
         
-        //initialize map using topographic basemap
+        // initialize map using topographic basemap
         let map = AGSMap(basemapStyle: .arcGISTopographic)
         
-        //assign map to the map view's map
+        // assign map to the map view's map
         mapView.map = map
         mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: -13630484, y: 4545415, spatialReference: .webMercator()), scale: 90000))
         
-        //create feature table using a url to feature server's layer
+        // create feature table using a url to feature server's layer
         let featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0")!)
-        //create feature layer using this feature table
+        // create feature layer using this feature table
         let featureLayer = AGSFeatureLayer(featureTable: featureTable)
         
-        //add the feature layer to the map
+        // add the feature layer to the map
         map.operationalLayers.add(featureLayer)
         
-        //store the feature layer for later use
+        // store the feature layer for later use
         self.featureLayer = featureLayer
     }
     
     @IBAction func applyDefinitionExpression() {
-        //adding definition expression to show specific features only
+        // adding definition expression to show specific features only
         self.featureLayer.definitionExpression = "req_Type = 'Tree Maintenance or Damage'"
     }
     
     @IBAction func resetDefinitionExpression() {
-        //reset definition expression
+        // reset definition expression
         self.featureLayer.definitionExpression = ""
     }
 }

--- a/arcgis-ios-sdk-samples/Features/Feature layer query/FLQueryViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer query/FLQueryViewController.swift
@@ -26,7 +26,7 @@ class FLQueryViewController: UIViewController, UISearchBarDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["FLQueryViewController"]
         
         // initialize map with topographic basemap

--- a/arcgis-ios-sdk-samples/Features/Feature layer rendering mode (map)/FeatureLayerRenderingModeMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer rendering mode (map)/FeatureLayerRenderingModeMapViewController.swift
@@ -26,42 +26,42 @@ class FeatureLayerRenderingModeMapViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["FeatureLayerRenderingModeMapViewController"]
         
-        //points for zoomed in and zoomed out
+        // points for zoomed in and zoomed out
         let zoomedInPoint = AGSPoint(x: -118.37, y: 34.46, spatialReference: .wgs84())
         let zoomedOutPoint = AGSPoint(x: -118.45, y: 34.395, spatialReference: .wgs84())
         zoomedInViewpoint = AGSViewpoint(center: zoomedInPoint, scale: 650000, rotation: 0)
         zoomedOutViewpoint = AGSViewpoint(center: zoomedOutPoint, scale: 50000, rotation: 90)
         
-        //assign maps to the map views
+        // assign maps to the map views
         self.dynamicMapView.map = AGSMap()
         self.staticMapView.map = AGSMap()
         
-        //create service feature tables using point,polygon, and polyline services
+        // create service feature tables using point,polygon, and polyline services
         let pointTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/0")!)
         let polylineTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/8")!)
         let polygonTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/9")!)
         
-        //create feature layers from the feature tables
+        // create feature layers from the feature tables
         let featureLayers: [AGSFeatureLayer] = [
             AGSFeatureLayer(featureTable: polygonTable),
             AGSFeatureLayer(featureTable: polylineTable),
             AGSFeatureLayer(featureTable: pointTable)]
         
         for featureLayer in featureLayers {
-            //add the layer to the dynamic view
+            // add the layer to the dynamic view
             featureLayer.renderingMode = AGSFeatureRenderingMode.dynamic
             self.dynamicMapView.map?.operationalLayers.add(featureLayer)
             
-            //add the layer to the static view
+            // add the layer to the static view
             let staticFeatureLayer = featureLayer.copy() as! AGSFeatureLayer
             staticFeatureLayer.renderingMode = AGSFeatureRenderingMode.static
             self.staticMapView.map?.operationalLayers.add(staticFeatureLayer)
         }
         
-        //set the initial viewpoint
+        // set the initial viewpoint
         self.dynamicMapView.setViewpoint(zoomedOutViewpoint)
         self.staticMapView.setViewpoint(zoomedOutViewpoint)
     }

--- a/arcgis-ios-sdk-samples/Features/Generate geodatabase/GenerateGeodatabaseViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Generate geodatabase/GenerateGeodatabaseViewController.swift
@@ -32,7 +32,7 @@ class GenerateGeodatabaseViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["GenerateGeodatabaseViewController"]
         
         let tpkURL = Bundle.main.url(forResource: "SanFrancisco", withExtension: "tpk")!
@@ -44,7 +44,7 @@ class GenerateGeodatabaseViewController: UIViewController {
         
         addFeatureLayers()
 
-        //setup extent view
+        // setup extent view
         extentView.layer.borderColor = UIColor.red.cgColor
         extentView.layer.borderWidth = 3
     }
@@ -70,7 +70,7 @@ class GenerateGeodatabaseViewController: UIViewController {
                 }
                 self.mapView.map?.operationalLayers.addObjects(from: featureLayers.reversed())
                 
-                //enable download
+                // enable download
                 self.downloadBBI.isEnabled = true
             }
         }
@@ -87,14 +87,14 @@ class GenerateGeodatabaseViewController: UIViewController {
     // MARK: - Actions
     
     @IBAction func downloadAction() {
-        //generate default param to contain all layers in the service
+        // generate default param to contain all layers in the service
         syncTask.defaultGenerateGeodatabaseParameters(withExtent: self.frameToExtent()) { [weak self] (params: AGSGenerateGeodatabaseParameters?, error: Error?) in
             if let params = params,
                 let self = self {
-                //don't include attachments to minimze the geodatabae size
+                // don't include attachments to minimze the geodatabae size
                 params.returnAttachments = false
                 
-                //create a unique name for the geodatabase based on current timestamp
+                // create a unique name for the geodatabase based on current timestamp
                 let dateFormatter = ISO8601DateFormatter()
                 
                 let documentDirectoryURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
@@ -102,10 +102,10 @@ class GenerateGeodatabaseViewController: UIViewController {
                     .appendingPathComponent(dateFormatter.string(from: Date()))
                     .appendingPathExtension("geodatabase")
                 
-                //request a job to generate the geodatabase
+                // request a job to generate the geodatabase
                 let generateJob = self.syncTask.generateJob(with: params, downloadFileURL: downloadFileURL)
                 self.activeJob = generateJob
-                //kick off the job
+                // kick off the job
                 generateJob.start(
                     statusHandler: { (status: AGSJobStatus) in
                         SVProgressHUD.show(withStatus: status.statusString())
@@ -146,7 +146,7 @@ class GenerateGeodatabaseViewController: UIViewController {
                 AGSLoadObjects(generatedGeodatabase.geodatabaseFeatureTables) { (success: Bool) in
                     if success {
                         for featureTable in generatedGeodatabase.geodatabaseFeatureTables.reversed() {
-                            //check if featureTable has geometry
+                            // check if featureTable has geometry
                             if featureTable.hasGeometry {
                                 let featureLayer = AGSFeatureLayer(featureTable: featureTable)
                                 self.mapView.map?.operationalLayers.add(featureLayer)

--- a/arcgis-ios-sdk-samples/Features/List related features/ListRelatedFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/List related features/ListRelatedFeaturesViewController.swift
@@ -28,115 +28,115 @@ class ListRelatedFeaturesViewController: UIViewController, AGSGeoViewTouchDelega
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["ListRelatedFeaturesViewController", "RelatedFeaturesListViewController"]
         
-        //initialize map with a basemap
+        // initialize map with a basemap
         let map = AGSMap(basemap: .nationalGeographic())
         
-        //add self as the touch delegate for map view
-        //we will need to be notified when the user taps with the map
+        // add self as the touch delegate for map view
+        // we will need to be notified when the user taps with the map
         self.mapView.touchDelegate = self
         
-        //create feature table for the parks layer, the origin layer in the relationship
+        // create feature table for the parks layer, the origin layer in the relationship
         self.parksFeatureTable = AGSServiceFeatureTable(url: URL(string: "https://services2.arcgis.com/ZQgQTuoyBrtmoGdP/arcgis/rest/services/AlaskaNationalParksPreservesSpecies_List/FeatureServer/1")!)
         
-        //feature layer for parks
+        // feature layer for parks
         let parksFeatureLayer = AGSFeatureLayer(featureTable: self.parksFeatureTable)
         
-        //add parks feature layer to the map
+        // add parks feature layer to the map
         map.operationalLayers.add(parksFeatureLayer)
         
-        //Feature table for related Preserves layer
+        // Feature table for related Preserves layer
         let preservesFeatureTable = AGSServiceFeatureTable(url: URL(string: "https://services2.arcgis.com/ZQgQTuoyBrtmoGdP/arcgis/rest/services/AlaskaNationalParksPreservesSpecies_List/FeatureServer/0")!)
         
-        //Feature table for related Species layer
+        // Feature table for related Species layer
         let speciesFeatureTable = AGSServiceFeatureTable(url: URL(string: "https://services2.arcgis.com/ZQgQTuoyBrtmoGdP/arcgis/rest/services/AlaskaNationalParksPreservesSpecies_List/FeatureServer/2")!)
         
-        //add these to the tables on the map
-        //to query related features in a layer, the layer must either be added as a feature
-        //layer in operational layers or as a feature table in tables on map
+        // add these to the tables on the map
+        // to query related features in a layer, the layer must either be added as a feature
+        // layer in operational layers or as a feature table in tables on map
         map.tables.addObjects(from: [preservesFeatureTable, speciesFeatureTable])
         
-        //assign map to the map view
+        // assign map to the map view
         mapView.map = map
         let point = AGSPoint(x: -16507762.575543, y: 9058828.127243, spatialReference: .webMercator())
         mapView.setViewpoint(AGSViewpoint(center: point, scale: 36764077))
         
-        //set selection color
+        // set selection color
         mapView.selectionProperties.color = .yellow
         
-        //store the feature layer for later use
+        // store the feature layer for later use
         self.parksFeatureLayer = parksFeatureLayer
     }
     
     // MARK: - AGSGeoViewTouchDelegate
     
     func geoView(_ geoView: AGSGeoView, didTapAtScreenPoint screenPoint: CGPoint, mapPoint: AGSPoint) {
-        //unselect previously selected park
+        // unselect previously selected park
         if let previousSelection = self.selectedPark {
             self.parksFeatureLayer.unselectFeature(previousSelection)
         }
         
-        //show progress hud
+        // show progress hud
         SVProgressHUD.show(withStatus: "Identifying feature")
         
-        //identify features at the tapped location
+        // identify features at the tapped location
         self.mapView.identifyLayer(self.parksFeatureLayer, screenPoint: screenPoint, tolerance: 12, returnPopupsOnly: false) { [weak self] (result: AGSIdentifyLayerResult) in
-            //dismiss progress hud
+            // dismiss progress hud
             SVProgressHUD.dismiss()
             
             if let error = result.error {
-                //dismiss progress hud
+                // dismiss progress hud
                 self?.presentAlert(error: error)
             }
-            //Check if a feature is identified
+            // Check if a feature is identified
             else if let feature = result.geoElements.first as? AGSArcGISFeature {
-                //store as selected park to use for querying
+                // store as selected park to use for querying
                 self?.selectedPark = feature
                 
-                //select feature on layer
+                // select feature on layer
                 self?.parksFeatureLayer.select(feature)
                 
-                //store the screen point for the tapped location to show popover at that location
+                // store the screen point for the tapped location to show popover at that location
                 self?.screenPoint = screenPoint
                 
-                //query for related features
+                // query for related features
                 self?.queryRelatedFeatures()
             }
         }
     }
 
-    //query for related features given the origin feature
+    // query for related features given the origin feature
     private func queryRelatedFeatures() {
-        //show progress hud
+        // show progress hud
         SVProgressHUD.show(withStatus: "Querying related features")
         
-        //query for related features
+        // query for related features
         self.parksFeatureTable.queryRelatedFeatures(for: self.selectedPark) { [weak self] (results: [AGSRelatedFeatureQueryResult]?, error: Error?) in
-            //dismiss progress hud
+            // dismiss progress hud
             SVProgressHUD.dismiss()
             
             guard let self = self else { return }
             
             if let error = error {
-                //display error
+                // display error
                 self.presentAlert(error: error)
             } else if let results = results {
-                //Show the related features found in popover
+                // Show the related features found in popover
                 if !results.isEmpty {
                     self.results = results
                     self.showRelatedFeatures()
-                } else {  //else notify user
+                } else {  // else notify user
                     self.presentAlert(message: "No related features found")
                 }
             }
         }
     }
     
-    //show related features in a table view as popover
+    // show related features in a table view as popover
     private func showRelatedFeatures() {
-        //perform popover segue
+        // perform popover segue
         self.performSegue(withIdentifier: "RelatedFeaturesSegue", sender: self)
     }
     
@@ -146,12 +146,12 @@ class ListRelatedFeaturesViewController: UIViewController, AGSGeoViewTouchDelega
         if segue.identifier == "RelatedFeaturesSegue",
             let navController = segue.destination as? UINavigationController,
             let controller = navController.viewControllers.first as? RelatedFeaturesListViewController {
-            //set results from related features query
+            // set results from related features query
             controller.results = results
         }
      }
     
-    //to hide popover controller on rotation
+    // to hide popover controller on rotation
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         self.dismiss(animated: true)
     }

--- a/arcgis-ios-sdk-samples/Features/List related features/RelatedFeaturesListViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/List related features/RelatedFeaturesListViewController.swift
@@ -16,7 +16,7 @@ import UIKit
 import ArcGIS
 
 class RelatedFeaturesListViewController: UITableViewController {
-    //results required for display
+    // results required for display
     var results = [AGSRelatedFeatureQueryResult]() {
         didSet {
             if let result = results.first {

--- a/arcgis-ios-sdk-samples/Features/Service feature table (cache)/OnInteractionCacheViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Service feature table (cache)/OnInteractionCacheViewController.swift
@@ -23,18 +23,18 @@ class OnInteractionCacheViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["OnInteractionCacheViewController"]
         
-        //initialize map with light gray canvas basemap
+        // initialize map with light gray canvas basemap
         let map = AGSMap(basemapStyle: .arcGISLightGrayBase)
         
-        //feature layer
+        // feature layer
         let featureTable = AGSServiceFeatureTable(url: URL(string: featureServiceURL)!)
-        //set the request mode
+        // set the request mode
         featureTable.featureRequestMode = AGSFeatureRequestMode.onInteractionCache
         let featureLayer = AGSFeatureLayer(featureTable: featureTable)
-        //add the feature layer to the map
+        // add the feature layer to the map
         map.operationalLayers.add(featureLayer)
         
         mapView.map = map

--- a/arcgis-ios-sdk-samples/Features/Service feature table (manual cache)/ManualCacheViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Service feature table (manual cache)/ManualCacheViewController.swift
@@ -23,22 +23,22 @@ class ManualCacheViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["ManualCacheViewController"]
         
-        //initialize map with topographic basemap
+        // initialize map with topographic basemap
         let map = AGSMap(basemapStyle: .arcGISTopographic)
         
-        //create feature table using a url
+        // create feature table using a url
         self.featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0")!)
-        //set the feature request mode to Manual Cache
+        // set the feature request mode to Manual Cache
         featureTable.featureRequestMode = AGSFeatureRequestMode.manualCache
-        //create feature layer using this feature table
+        // create feature layer using this feature table
         let featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
-        //add feature layer to the map
+        // add feature layer to the map
         map.operationalLayers.add(featureLayer)
         
-        //assign map to the map view
+        // assign map to the map view
         mapView.map = map
         mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: -13630484, y: 4545415, spatialReference: .webMercator()), scale: 500000))
     }
@@ -46,19 +46,19 @@ class ManualCacheViewController: UIViewController {
     // MARK: - Actions
     
     @IBAction func populateAction(_ sender: AnyObject) {
-        //set query parameters
+        // set query parameters
         let params = AGSQueryParameters()
-        //for specific request type
+        // for specific request type
         params.whereClause = "req_Type = 'Tree Maintenance or Damage'"
         
-        //populate features based on query
+        // populate features based on query
         self.featureTable.populateFromService(with: params, clearCache: true, outFields: ["*"]) { [weak self] (result: AGSFeatureQueryResult?, error: Error?) in
-            //check for error
+            // check for error
             if let error = error {
                 self?.presentAlert(error: error)
             } else {
-                //the resulting features should be displayed on the map
-                //you can print the count of features
+                // the resulting features should be displayed on the map
+                // you can print the count of features
                 print("Populated \(result?.featureEnumerator().allObjects.count ?? 0) features.")
             }
         }

--- a/arcgis-ios-sdk-samples/Features/Service feature table (no cache)/OnInteractionNoCacheViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Service feature table (no cache)/OnInteractionNoCacheViewController.swift
@@ -23,18 +23,18 @@ class OnInteractionNoCacheViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["OnInteractionNoCacheViewController"]
         
-        //initialize map with topographic basemap
+        // initialize map with topographic basemap
         let map = AGSMap(basemapStyle: .arcGISTopographic)
         
-        //feature layer
+        // feature layer
         let featureTable = AGSServiceFeatureTable(url: URL(string: featureServiceURL)!)
-        //set the request mode
+        // set the request mode
         featureTable.featureRequestMode = AGSFeatureRequestMode.onInteractionNoCache
         let featureLayer = AGSFeatureLayer(featureTable: featureTable)
-        //add the feature layer to the map
+        // add the feature layer to the map
         map.operationalLayers.add(featureLayer)
         
         mapView.map = map

--- a/arcgis-ios-sdk-samples/Features/Time based query/TimeBasedQueryViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Time based query/TimeBasedQueryViewController.swift
@@ -27,36 +27,36 @@ class TimeBasedQueryViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //initialize map with oceans basemap
+        // initialize map with oceans basemap
         self.map = AGSMap(basemapStyle: .arcGISOceans)
         
-        //assign map to the map view
+        // assign map to the map view
         self.mapView.map = self.map
         
-        //create feature table using a url
+        // create feature table using a url
         self.featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Hurricanes/MapServer/0")!)
         
-        //define the request mode
+        // define the request mode
         self.featureTable.featureRequestMode = .manualCache
         
-        //create feature layer using the feature table
+        // create feature layer using the feature table
         let layer = AGSFeatureLayer(featureTable: self.featureTable)
         
-        //add feature layer to map's operational layers
+        // add feature layer to map's operational layers
         self.map.operationalLayers.add(layer)
         
-        //populate features based on a time-based query
+        // populate features based on a time-based query
         self.populateFeaturesWithQuery()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["TimeBasedQueryViewController"]
     }
     
     func populateFeaturesWithQuery() {
-        //create query parameters
+        // create query parameters
         let queryParams = AGSQueryParameters()
 
-        //create a new time extent that covers the desired interval from September 1st to September 22th, 2000
+        // create a new time extent that covers the desired interval from September 1st to September 22th, 2000
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy/MM/dd HH:mm"
         let startTime = formatter.date(from: "2000/9/1 00:00")
@@ -64,17 +64,17 @@ class TimeBasedQueryViewController: UIViewController {
         
         let timeExtent = AGSTimeExtent(startTime: startTime, endTime: endTime)
         
-        //apply the time extent to query parameters to filter features based on time
+        // apply the time extent to query parameters to filter features based on time
         queryParams.timeExtent = timeExtent
         
-        //populate features based on query parameters
+        // populate features based on query parameters
         self.featureTable.populateFromService(with: queryParams, clearCache: true, outFields: ["*"]) { [weak self] (result: AGSFeatureQueryResult?, error: Error?) in
-            //check for error
+            // check for error
             if let error = error {
                 self?.presentAlert(error: error)
             } else {
-                //the resulting features should be displayed on the map
-                //you can print the count of features
+                // the resulting features should be displayed on the map
+                // you can print the count of features
                 print("Hurriance features during the time interval: \(result?.featureEnumerator().allObjects.count ?? 0)")
             }
         }

--- a/arcgis-ios-sdk-samples/Geometry/Buffer/BufferViewController.swift
+++ b/arcgis-ios-sdk-samples/Geometry/Buffer/BufferViewController.swift
@@ -55,7 +55,7 @@ class BufferViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = [
             "BufferViewController",
             "BufferOptionsViewController"

--- a/arcgis-ios-sdk-samples/Geometry/Create geometries/CreateGeometriesViewController.swift
+++ b/arcgis-ios-sdk-samples/Geometry/Create geometries/CreateGeometriesViewController.swift
@@ -23,35 +23,35 @@ class CreateGeometriesViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["CreateGeometriesViewController"]
         
-        //instantiate map using basemap
+        // instantiate map using basemap
         let map = AGSMap(basemapStyle: .arcGISTopographic)
         
-        //assign map to the map view
+        // assign map to the map view
         self.mapView.map = map
         
-        //add graphics overlay to the map view
+        // add graphics overlay to the map view
         self.mapView.graphicsOverlays.add(self.graphicsOverlay)
         
-        //create symbols for drawing graphics
+        // create symbols for drawing graphics
         let markerSymbol = AGSSimpleMarkerSymbol(style: .triangle, color: .blue, size: 14)
         let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: .blue, width: 3)
         let fillSymbol = AGSSimpleFillSymbol(style: .cross, color: .blue, outline: nil)
         
-        //add a graphic of point, multipoint, polyline and polygon
+        // add a graphic of point, multipoint, polyline and polygon
         self.graphicsOverlay.graphics.add(AGSGraphic(geometry: self.createPoint(), symbol: markerSymbol, attributes: nil))
         self.graphicsOverlay.graphics.add(AGSGraphic(geometry: self.createMultipoint(), symbol: markerSymbol, attributes: nil))
         self.graphicsOverlay.graphics.add(AGSGraphic(geometry: self.createPolyline(), symbol: lineSymbol, attributes: nil))
         self.graphicsOverlay.graphics.add(AGSGraphic(geometry: self.createPolygon(), symbol: fillSymbol, attributes: nil))
         
-        //use the envelope to set the viewpoint of the map view
+        // use the envelope to set the viewpoint of the map view
         self.mapView.setViewpointGeometry(self.createEnvelope(), padding: 100, completion: nil)
     }
     
     private func createEnvelope() -> AGSEnvelope {
-        //create an envelope using minimum and maximum x,y coordinates and a spatial reference
+        // create an envelope using minimum and maximum x,y coordinates and a spatial reference
         let envelope = AGSEnvelope(xMin: -123.0, yMin: 33.5, xMax: -101.0, yMax: 48.0, spatialReference: .wgs84())
         return envelope
     }
@@ -74,7 +74,7 @@ class CreateGeometriesViewController: UIViewController {
     }
     
     private func createPolyline() -> AGSPolyline {
-        //create a polyline
+        // create a polyline
         let polylineBuilder = AGSPolylineBuilder(spatialReference: .wgs84())
         polylineBuilder.addPointWith(x: -119.992, y: 41.989)
         polylineBuilder.addPointWith(x: -119.994, y: 38.994)

--- a/arcgis-ios-sdk-samples/Geometry/Format coordinates/FormatCoordinatesTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Geometry/Format coordinates/FormatCoordinatesTableViewController.swift
@@ -34,7 +34,7 @@ class FormatCoordinatesTableViewController: UITableViewController {
         updateCoordinateFieldsForPoint()
     }
     
-    //use AGSCoordinateFormatter to generate coordinate string for the given point
+    // use AGSCoordinateFormatter to generate coordinate string for the given point
     private func updateCoordinateFieldsForPoint() {
         guard let point = point else {
             return

--- a/arcgis-ios-sdk-samples/Geometry/Format coordinates/FormatCoordinatesViewController.swift
+++ b/arcgis-ios-sdk-samples/Geometry/Format coordinates/FormatCoordinatesViewController.swift
@@ -34,25 +34,25 @@ class FormatCoordinatesViewController: UIViewController, AGSGeoViewTouchDelegate
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = [
             "FormatCoordinatesViewController",
             "FormatCoordinatesTableViewController"
         ]
         
-        //initializer map with basemap
+        // initializer map with basemap
         let map = AGSMap(basemapStyle: .arcGISImageryStandard)
         
-        //assign map to map view
+        // assign map to map view
         mapView.map = map
         
-        //add graphics overlay to the map view
+        // add graphics overlay to the map view
         mapView.graphicsOverlays.add(graphicsOverlay)
         
-        //touch delegate for map view
+        // touch delegate for map view
         mapView.touchDelegate = self
         
-        //add initial graphic
+        // add initial graphic
         displayGraphicAtPoint(point)
     }
     
@@ -67,10 +67,10 @@ class FormatCoordinatesViewController: UIViewController, AGSGeoViewTouchDelegate
     }
     
     private func displayGraphicAtPoint(_ point: AGSPoint) {
-        //remove previous graphic from graphics overlay
+        // remove previous graphic from graphics overlay
         graphicsOverlay.graphics.removeAllObjects()
         
-        //add graphic at tapped location
+        // add graphic at tapped location
         let symbol = AGSSimpleMarkerSymbol(style: .cross, color: .yellow, size: 20)
         let graphic = AGSGraphic(geometry: point, symbol: symbol, attributes: nil)
         graphicsOverlay.graphics.add(graphic)

--- a/arcgis-ios-sdk-samples/Geometry/List transformations/ListTransformationsViewController.swift
+++ b/arcgis-ios-sdk-samples/Geometry/List transformations/ListTransformationsViewController.swift
@@ -43,7 +43,7 @@ class ListTransformationsViewController: UIViewController, UITableViewDelegate, 
         mapView.map = AGSMap(basemapStyle: .arcGISLightGrayBase)
         mapView.graphicsOverlays.add(graphicsOverlay)
         
-        //add original graphic to overlay
+        // add original graphic to overlay
         addGraphic(originalGeometry, color: .red, style: .square)
         
         mapView.map?.load { [weak self] (error) in

--- a/arcgis-ios-sdk-samples/Geometry/Project/ProjectViewController.swift
+++ b/arcgis-ios-sdk-samples/Geometry/Project/ProjectViewController.swift
@@ -18,12 +18,12 @@ import ArcGIS
 class ProjectViewController: UIViewController {
     @IBOutlet private weak var mapView: AGSMapView! {
         didSet {
-            //initialize the map
+            // initialize the map
             mapView.map = AGSMap(basemap: .nationalGeographic())
             mapView.touchDelegate = self
             mapView.setViewpointCenter(AGSPoint(x: -1.2e7, y: 5e6, spatialReference: .webMercator()), scale: 4e7)
             
-            //initialize the graphic overlay
+            // initialize the graphic overlay
             mapView.graphicsOverlays.add(graphicsOverlay)
         }
     }
@@ -32,7 +32,7 @@ class ProjectViewController: UIViewController {
     
     private let graphicsOverlay = AGSGraphicsOverlay()
     
-    //make graphics
+    // make graphics
     private func makeGraphics(geometry: AGSGeometry) -> AGSGraphic {
         let pointSymbol = AGSSimpleMarkerSymbol(style: .circle, color: .red, size: 5.0)
         pointSymbol.outline = AGSSimpleLineSymbol(style: .solid, color: .red, width: 2.0)
@@ -41,7 +41,7 @@ class ProjectViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["ProjectViewController", "ProjectStackView"]
     }
 }
@@ -58,7 +58,7 @@ extension ProjectViewController: AGSGeoViewTouchDelegate {
             mapView.callout.customView = customCallout
             mapView.callout.show(at: mapPoint, screenOffset: .zero, rotateOffsetWithMap: false, animated: true)
             graphicsOverlay.graphics.add(makeGraphics(geometry: mapPoint))
-        } else {  //hide the callout
+        } else {  // hide the callout
             graphicsOverlay.graphics.removeAllObjects()
             mapView.callout.dismiss()
         }

--- a/arcgis-ios-sdk-samples/Layers/ArcGIS map image layer (URL)/MILUsingURLViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/ArcGIS map image layer (URL)/MILUsingURLViewController.swift
@@ -23,14 +23,14 @@ class MILUsingURLViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["MILUsingURLViewController"]
         
-        //create a map image layer using a url
+        // create a map image layer using a url
         let mapImageLayer = AGSArcGISMapImageLayer(url: URL(string: "https://sampleserver5.arcgisonline.com/arcgis/rest/services/Elevation/WorldElevations/MapServer")!)
-        //initialize the map
+        // initialize the map
         self.map = AGSMap()
-        //add the image layer to the map
+        // add the image layer to the map
         self.map.operationalLayers.add(mapImageLayer)
         
         self.mapView.map = self.map

--- a/arcgis-ios-sdk-samples/Layers/ArcGIS tiled layer (URL)/TLUsingURLViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/ArcGIS tiled layer (URL)/TLUsingURLViewController.swift
@@ -23,17 +23,17 @@ class TLUsingURLViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //create a tiledLayer using url to a map server
+        // create a tiledLayer using url to a map server
         let tiledLayer = AGSArcGISTiledLayer(url: URL(string: "https://services.arcgisonline.com/arcgis/rest/services/NatGeo_World_Map/MapServer")!)
         
-        //initialize the map and add the tiled layer as an operational layer
+        // initialize the map and add the tiled layer as an operational layer
         self.map = AGSMap()
         self.map.operationalLayers.add(tiledLayer)
         
-        //assign the map to the map view
+        // assign the map to the map view
         self.mapView.map = self.map
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["TLUsingURLViewController"]
     }
 }

--- a/arcgis-ios-sdk-samples/Layers/ArcGIS tiled layer (tile cache)/LocalTiledLayerViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/ArcGIS tiled layer (tile cache)/LocalTiledLayerViewController.swift
@@ -22,17 +22,17 @@ class LocalTiledLayerViewController: UIViewController, TilePackagesListViewContr
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["LocalTiledLayerViewController", "TilePackagesListViewController"]
         
-        //create a tiled layer using one of the tile packages
+        // create a tiled layer using one of the tile packages
         let tileCache = AGSTileCache(name: "SanFrancisco")
         let localTiledLayer = AGSArcGISTiledLayer(tileCache: tileCache)
         
-        //instantiate a map, use the tiled layer as the basemap
+        // instantiate a map, use the tiled layer as the basemap
         let map = AGSMap(basemap: AGSBasemap(baseLayer: localTiledLayer))
         
-        //assign the map to the map view
+        // assign the map to the map view
         self.mapView.map = map
     }
     
@@ -46,9 +46,9 @@ class LocalTiledLayerViewController: UIViewController, TilePackagesListViewContr
     
     // MARK: - TilePackagesListViewControllerDelegate
     
-    //called when a selection is made in the tile packages list
+    // called when a selection is made in the tile packages list
     func tilePackagesListViewController(_ tilePackagesListViewController: TilePackagesListViewController, didSelectTilePackageAt url: URL) {
-        //create a new map with selected tile package as the basemap
+        // create a new map with selected tile package as the basemap
         let localTiledLayer = AGSArcGISTiledLayer(tileCache: AGSTileCache(fileURL: url))
         let map = AGSMap(basemap: AGSBasemap(baseLayer: localTiledLayer))
         self.mapView.map = map

--- a/arcgis-ios-sdk-samples/Layers/ArcGIS tiled layer (tile cache)/TilePackagesListViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/ArcGIS tiled layer (tile cache)/TilePackagesListViewController.swift
@@ -28,7 +28,7 @@ class TilePackagesListViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //fetch tile packages from bundle and document directory
+        // fetch tile packages from bundle and document directory
         self.fetchTilePackages()
     }
     

--- a/arcgis-ios-sdk-samples/Layers/Blend renderer/BlendRendererViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Blend renderer/BlendRendererViewController.swift
@@ -31,12 +31,12 @@ class BlendRendererViewController: UIViewController, BlendRendererSettingsViewCo
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["BlendRendererViewController", "BlendRendererSettingsViewController", "OptionsTableViewController"]
         
-        //initialize map
+        // initialize map
         let map = AGSMap()
-        //assign map to the map view
+        // assign map to the map view
         mapView.map = map
         
         // set the initial blend renderer

--- a/arcgis-ios-sdk-samples/Layers/Change sublayer visibility/SublayerVisibilityViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Change sublayer visibility/SublayerVisibilityViewController.swift
@@ -24,25 +24,25 @@ class SublayerVisibilityViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["SublayerVisibilityViewController", "SublayersTableViewController"]
         
-        //initialize map with topographic basemap
+        // initialize map with topographic basemap
         self.map = AGSMap(basemapStyle: .arcGISTopographic)
         
-        //initialize the map image layer using a url
+        // initialize the map image layer using a url
         let mapImageLayer = AGSArcGISMapImageLayer(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer")!)
         
-        //add the image layer to the map
+        // add the image layer to the map
         self.map.operationalLayers.add(mapImageLayer)
         
-        //assign the map to the map view
+        // assign the map to the map view
         self.mapView.map = self.map
         
-        //zoom to a custom viewpoint
+        // zoom to a custom viewpoint
         self.mapView.setViewpointCenter(AGSPoint(x: -11e6, y: 6e6, spatialReference: .webMercator()), scale: 9e7)
         
-        //store the map image layer for later use
+        // store the map image layer for later use
         self.mapImageLayer = mapImageLayer
     }
     
@@ -50,7 +50,7 @@ class SublayerVisibilityViewController: UIViewController {
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "SublayersPopover" {
-            //get the destination view controller as BookmarksListViewController
+            // get the destination view controller as BookmarksListViewController
             let controller = segue.destination as! SublayersTableViewController
             if let sublayers = mapImageLayer.mapImageSublayers as? [AGSArcGISMapImageSublayer] {
                 controller.sublayers = sublayers

--- a/arcgis-ios-sdk-samples/Layers/Change sublayer visibility/SublayersTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Change sublayer visibility/SublayersTableViewController.swift
@@ -52,7 +52,7 @@ class SublayersTableViewController: UITableViewController {
         let sublayer = sublayers[indexPath.row]
         let cell = tableView.dequeueReusableCell(withIdentifier: "SublayerCell", for: indexPath)
         cell.textLabel?.text = sublayer.name
-        //accessory switch
+        // accessory switch
         let visibilitySwitch = UISwitch(frame: .zero)
         visibilitySwitch.tag = indexPath.row
         visibilitySwitch.isOn = sublayer.isVisible
@@ -64,7 +64,7 @@ class SublayersTableViewController: UITableViewController {
     @objc
     func switchChanged(_ sender: UISwitch) {
         let index = sender.tag
-        //change the visiblity
+        // change the visiblity
         let sublayer = self.sublayers[index]
         sublayer.isVisible = sender.isOn
     }

--- a/arcgis-ios-sdk-samples/Layers/Group layers/GroupLayersViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Group layers/GroupLayersViewController.swift
@@ -83,7 +83,7 @@ class GroupLayersViewController: UIViewController {
         let groupLayer = AGSGroupLayer()
         groupLayer.name = "Buildings group"
         
-        //Create layers for the buildings.
+        // Create layers for the buildings.
         let buildingsA = AGSArcGISSceneLayer(url: URL(string: "https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/DevA_BuildingShells/SceneServer")!)
         let buildingsB = AGSArcGISSceneLayer(url: URL(string: "https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/DevB_BuildingShells/SceneServer")!)
         

--- a/arcgis-ios-sdk-samples/Layers/Hillshade renderer/HillshadeRendererViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Hillshade renderer/HillshadeRendererViewController.swift
@@ -23,7 +23,7 @@ class HillshadeRendererViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = [
             "HillshadeRendererViewController",
             "HillshadeSettingsViewController",
@@ -38,7 +38,7 @@ class HillshadeRendererViewController: UIViewController {
         
         mapView.map = map
         
-        //initial renderer
+        // initial renderer
         setRenderer(altitude: 45, azimuth: 315, slopeType: .none)
     }
     

--- a/arcgis-ios-sdk-samples/Layers/Manage sublayers/ManageSublayersViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Manage sublayers/ManageSublayersViewController.swift
@@ -26,63 +26,63 @@ class ManageSublayersViewController: UIViewController, MapImageSublayersViewCont
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["ManageSublayersViewController", "MapImageSublayersViewController"]
         
-        //instantiate map with basemap
+        // instantiate map with basemap
         let map = AGSMap(basemapStyle: .arcGISStreets)
         
-        //initialize map image layer
+        // initialize map image layer
         let mapImageLayer = AGSArcGISMapImageLayer(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer")!)
         
-        //add layer to map
+        // add layer to map
         map.operationalLayers.add(mapImageLayer)
         
-        //initial viewpoint
+        // initial viewpoint
         let envelope = AGSEnvelope(xMin: -13834661.666904, yMin: 331181.323482, xMax: -8255704.998713, yMax: 9118038.075882, spatialReference: .webMercator())
         
-        //assign map to map view
+        // assign map to map view
         self.mapView.map = map
         
-        //set the viewpoint on map view
+        // set the viewpoint on map view
         self.mapView.setViewpoint(AGSViewpoint(targetExtent: envelope))
         
-        //create sublayers from tableSublayerSource
+        // create sublayers from tableSublayerSource
         self.createSublayers()
         
-        //store the map image layer for later use
+        // store the map image layer for later use
         self.mapImageLayer = mapImageLayer
     }
     
     private func createSublayers() {
-        //We will create 2 mapImageSublayers from tableSublayerSource with known workspaceID and dataSourceName
-        //These sublayers are not yet part of the mapImageLayer's sublayers, so will be shown as part of the 
-        //removed sublayers array at first
+        // We will create 2 mapImageSublayers from tableSublayerSource with known workspaceID and dataSourceName
+        // These sublayers are not yet part of the mapImageLayer's sublayers, so will be shown as part of the 
+        // removed sublayers array at first
         
-        //create tableSublayerSource from workspaceID and dataSourceName
+        // create tableSublayerSource from workspaceID and dataSourceName
         let tableSublayerSource1 = AGSTableSublayerSource(workspaceID: self.workspaceID, dataSourceName: "ss6.gdb.rivers")
         
-        //create mapImageSublayer from tableSublayerSource
+        // create mapImageSublayer from tableSublayerSource
         let mapImageSublayer1 = AGSArcGISMapImageSublayer(id: 4, source: tableSublayerSource1)
         
-        //assign a renderer to the sublayer
+        // assign a renderer to the sublayer
         let renderer1 = AGSSimpleRenderer(symbol: AGSSimpleLineSymbol(style: .solid, color: .blue, width: 1))
         mapImageSublayer1.renderer = renderer1
         
-        //name for the sublayer
+        // name for the sublayer
         mapImageSublayer1.name = "Rivers"
         
-        //create tableSublayerSource from workspaceID and dataSourceName
+        // create tableSublayerSource from workspaceID and dataSourceName
         let tableSublayerSource2 = AGSTableSublayerSource(workspaceID: self.workspaceID, dataSourceName: "ss6.gdb.lakes")
         
-        //create mapImageSublayer from tableSublayerSource
+        // create mapImageSublayer from tableSublayerSource
         let mapImageSublayer2 = AGSArcGISMapImageSublayer(id: 5, source: tableSublayerSource2)
         
-        //assign a renderer to the sublayer
+        // assign a renderer to the sublayer
         let renderer2 = AGSSimpleRenderer(symbol: AGSSimpleFillSymbol(style: .solid, color: .cyan, outline: nil))
         mapImageSublayer2.renderer = renderer2
         
-        //name for the sublayer
+        // name for the sublayer
         mapImageSublayer2.name = "Lakes"
         removedMapImageSublayers.append(contentsOf: [mapImageSublayer1, mapImageSublayer2])
     }

--- a/arcgis-ios-sdk-samples/Layers/Manage sublayers/MapImageSublayersViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Manage sublayers/MapImageSublayersViewController.swift
@@ -84,38 +84,38 @@ class MapImageSublayersViewController: UITableViewController {
         case .delete:
             tableView.beginUpdates()
             
-            //remove row from table view
+            // remove row from table view
             tableView.deleteRows(at: [indexPath], with: .automatic)
             
-            //remove sublayer from map image layer
+            // remove sublayer from map image layer
             let sublayer = self.mapImageLayer.mapImageSublayers[indexPath.row] as AnyObject as! AGSArcGISMapImageSublayer
             
             self.mapImageLayer.mapImageSublayers.removeObject(at: indexPath.row)
             
-            //add sublayer to the removed array
+            // add sublayer to the removed array
             self.removedMapImageSublayers.insert(sublayer, at: 0)
             
             let indexPath = IndexPath(row: 0, section: 1)
             
-            //add row to the removed sublayer sources section
+            // add row to the removed sublayer sources section
             tableView.insertRows(at: [indexPath], with: .automatic)
             
             tableView.endUpdates()
         case .insert:
             tableView.beginUpdates()
             
-            //remove row from table view
+            // remove row from table view
             tableView.deleteRows(at: [indexPath], with: .automatic)
             
-            //remove sublayerSource from the removed array
+            // remove sublayerSource from the removed array
             let sublayer = self.removedMapImageSublayers.remove(at: indexPath.row)
             
-            //add sublayerSource to the added array
+            // add sublayerSource to the added array
             self.mapImageLayer.mapImageSublayers.insert(sublayer, at: 0)
             
             let indexPath = IndexPath(row: 0, section: 0)
             
-            //add row to the removed sublayer sources section
+            // add row to the removed sublayer sources section
             tableView.insertRows(at: [indexPath], with: .automatic)
             
             tableView.endUpdates()
@@ -147,10 +147,10 @@ class MapImageSublayersViewController: UITableViewController {
     // MARK: - Actions
     
     @IBAction private func doneAction() {
-        //dismiss view controller
+        // dismiss view controller
         self.dismiss(animated: true)
         
-        //update the removed sublayers array on the delegate
+        // update the removed sublayers array on the delegate
         self.delegate?.mapImageSublayersViewController(self, didCloseWith: self.removedMapImageSublayers)
     }
 }

--- a/arcgis-ios-sdk-samples/Layers/OpenStreetMap layer/OpenStreetMapLayerViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/OpenStreetMap layer/OpenStreetMapLayerViewController.swift
@@ -21,14 +21,14 @@ class OpenStreetMapLayerViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //initialize map with an OpenStreetMap standard basemap
+        // initialize map with an OpenStreetMap standard basemap
         let map = AGSMap(basemapStyle: .osmStandard)
         
-        //assign the map to the map view
+        // assign the map to the map view
         mapView.map = map
         mapView.setViewpoint(AGSViewpoint(latitude: 34.056295, longitude: -117.195800, scale: 577790.554289))
     
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["OpenStreetMapLayerViewController"]
     }
 }

--- a/arcgis-ios-sdk-samples/Layers/RGB renderer/RGBRendererSettingsViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/RGB renderer/RGBRendererSettingsViewController.swift
@@ -72,7 +72,7 @@ class RGBRendererSettingsViewController: UITableViewController {
     }
     
     private func makeStretchParameters() -> AGSStretchParameters {
-        //get the values from textFields in rows based on the selected stretch type
+        // get the values from textFields in rows based on the selected stretch type
         switch stretchType {
         case .minMax:
             var minValue1 = 0, minValue2 = 0, minValue3 = 0, maxValue1 = 255, maxValue2 = 255, maxValue3 = 255
@@ -121,7 +121,7 @@ class RGBRendererSettingsViewController: UITableViewController {
     // MARK: - UITableViewDataSource
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        //return the rows based on the stretch type selected
+        // return the rows based on the stretch type selected
         switch self.stretchType {
         case .minMax, .percentClip:
             return 3
@@ -131,14 +131,14 @@ class RGBRendererSettingsViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        //first row cell is always RGBRendererStretchTypeCell
+        // first row cell is always RGBRendererStretchTypeCell
         if indexPath.row == 0 {
             let cell = tableView.dequeueReusableCell(withIdentifier: "RGBRendererStretchTypeCell", for: indexPath)
             stretchTypeCell = cell
             updateStretchTypeLabel()
             return cell
         } else {
-            //load the rest of the cells based on the stretch type selected
+            // load the rest of the cells based on the stretch type selected
             switch stretchType {
             case .minMax:
                  let cell = tableView.dequeueReusableCell(withIdentifier: "RGBRenderer3InputCell", for: indexPath) as! RGBRenderer3InputCell

--- a/arcgis-ios-sdk-samples/Layers/RGB renderer/RGBRendererViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/RGB renderer/RGBRendererViewController.swift
@@ -24,19 +24,19 @@ class RGBRendererViewController: UIViewController, RGBRendererSettingsViewContro
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["RGBRendererViewController", "RGBRendererSettingsViewController", "OptionsTableViewController"]
 
-        //create raster
+        // create raster
         let raster = AGSRaster(name: "Shasta", extension: "tif")
         
-        //create raster layer using the raster
+        // create raster layer using the raster
         let rasterLayer = AGSRasterLayer(raster: raster)
         self.rasterLayer = rasterLayer
         
-        //initialize a map with raster layer as the basemap
+        // initialize a map with raster layer as the basemap
         let map = AGSMap(basemap: AGSBasemap(baseLayer: rasterLayer))
-        //assign map to the map view
+        // assign map to the map view
         mapView.map = map
     }
     

--- a/arcgis-ios-sdk-samples/Layers/Raster layer (file)/RasterLayerViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Raster layer (file)/RasterLayerViewController.swift
@@ -27,25 +27,25 @@ class RasterLayerViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["RasterLayerViewController"]
         
-        //create raster
+        // create raster
         let raster = AGSRaster(name: "Shasta", extension: "tif")
         
-        //create raster layer using raster
+        // create raster layer using raster
         self.rasterLayer = AGSRasterLayer(raster: raster)
         
-        //initialize map with imagery basemap
+        // initialize map with imagery basemap
         self.map = AGSMap(basemapStyle: .arcGISImageryStandard)
         
-        //assign map to the map view
+        // assign map to the map view
         self.mapView.map = map
         
-        //add the raster layer to the operational layers of the map
+        // add the raster layer to the operational layers of the map
         self.mapView.map?.operationalLayers.add(rasterLayer!)
         
-        //set map view's viewpoint to the raster layer's full extent
+        // set map view's viewpoint to the raster layer's full extent
         self.rasterLayer.load { [weak self] (error) in
             if let error = error {
                self?.presentAlert(error: error)

--- a/arcgis-ios-sdk-samples/Layers/Raster layer (geopackage)/RasterLayerGPKGViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Raster layer (geopackage)/RasterLayerGPKGViewController.swift
@@ -22,7 +22,7 @@ class RasterLayerGPKGViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["RasterLayerGPKGViewController"]
         
         // Instantiate a map.
@@ -41,7 +41,7 @@ class RasterLayerGPKGViewController: UIViewController {
             // Add the first raster from the geopackage to the map.
             if let raster = self?.geoPackage?.geoPackageRasters.first {
                 let rasterLayer = AGSRasterLayer(raster: raster)
-                //make it semi-transparent so it doesn't obscure the contents under it
+                // make it semi-transparent so it doesn't obscure the contents under it
                 rasterLayer.opacity = 0.55
                 map.operationalLayers.add(rasterLayer)
             }

--- a/arcgis-ios-sdk-samples/Layers/Raster layer (service)/RasterLayerUsingServiceViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Raster layer (service)/RasterLayerUsingServiceViewController.swift
@@ -43,7 +43,7 @@ class RasterLayerUsingServiceViewController: UIViewController {
         // add raster layer as an operational layer to the map
         map.operationalLayers.add(rasterLayer)
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["RasterLayerUsingServiceViewController"]
     }
 }

--- a/arcgis-ios-sdk-samples/Layers/Show labels on layers/ShowLabelsOnLayersViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Show labels on layers/ShowLabelsOnLayersViewController.swift
@@ -21,7 +21,7 @@ class ShowLabelsOnLayersViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["ShowLabelsOnLayersViewController"]
         
         // create a map with a light gray canvas basemap.

--- a/arcgis-ios-sdk-samples/Layers/Stretch renderer/StretchRendererViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Stretch renderer/StretchRendererViewController.swift
@@ -24,19 +24,19 @@ class StretchRendererViewController: UIViewController, StretchRendererSettingsVi
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["StretchRendererViewController", "StretchRendererSettingsViewController", "StretchRendererInputCell", "OptionsTableViewController"]
         
-        //create raster
+        // create raster
         let raster = AGSRaster(name: "ShastaBW", extension: "tif")
         
-        //create raster layer using the raster
+        // create raster layer using the raster
         let rasterLayer = AGSRasterLayer(raster: raster)
         self.rasterLayer = rasterLayer
         
-        //initialize a map with raster layer as the basemap
+        // initialize a map with raster layer as the basemap
         let map = AGSMap(basemap: AGSBasemap(baseLayer: rasterLayer))
-        //assign map to the map view
+        // assign map to the map view
         mapView.map = map
     }
     

--- a/arcgis-ios-sdk-samples/Layers/WMS layer (URL)/WMSLayerUsingURLViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/WMS layer (URL)/WMSLayerUsingURLViewController.swift
@@ -21,10 +21,10 @@ class WMSLayerUsingURLViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //initialize the map with a light gray basemap
+        // initialize the map with a light gray basemap
         let map = AGSMap(basemapStyle: .arcGISLightGrayBase)
         
-        //assign the map to the map view
+        // assign the map to the map view
         mapView.map = map
         mapView.setViewpoint(AGSViewpoint(latitude: 39, longitude: -98, scale: 3.6978595474472E7))
         
@@ -33,20 +33,20 @@ class WMSLayerUsingURLViewController: UIViewController {
         // the names of the layers to load at the WMS service
         let wmsServiceLayerNames = ["1"]
         
-        //initialize the WMS layer with the service URL and uniquely identifying WMS layer names
+        // initialize the WMS layer with the service URL and uniquely identifying WMS layer names
         let wmsLayer = AGSWMSLayer(url: wmsServiceURL, layerNames: wmsServiceLayerNames)
         
-        //load the WMS layer
+        // load the WMS layer
         wmsLayer.load { [weak self] (error) in
             if let error = error {
                 self?.presentAlert(error: error)
             } else if wmsLayer.loadStatus == .loaded {
-                //add the WMS layer to the map
+                // add the WMS layer to the map
                 map.operationalLayers.add(wmsLayer)
             }
         }
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["WMSLayerUsingURLViewController"]
     }
 }

--- a/arcgis-ios-sdk-samples/Layers/WMTS layer/WMTSLayerViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/WMTS layer/WMTSLayerViewController.swift
@@ -26,16 +26,16 @@ class WMTSLayerViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //initialize the map
+        // initialize the map
         self.map = AGSMap()
         
-        //assign the map to the map view
+        // assign the map to the map view
         self.mapView.map = self.map
         
-        //create a WMTS service with the service URL
+        // create a WMTS service with the service URL
         self.wmtsService = AGSWMTSService(url: wmtsServiceURL)
         
-        //load the WMTS service to access the service information
+        // load the WMTS service to access the service information
         self.wmtsService.load { [weak self] (error) in
             guard let self = self else { return }
             if let error = error {
@@ -49,7 +49,7 @@ class WMTSLayerViewController: UIViewController {
             }
         }
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["WMTSLayerViewController"]
     }
 }

--- a/arcgis-ios-sdk-samples/Layers/Web tiled layer/WebTiledLayerViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Web tiled layer/WebTiledLayerViewController.swift
@@ -23,46 +23,46 @@ class WebTiledLayerViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["WebTiledLayerViewController"]
 
-        //add web tiled layer at index 0 at start
+        // add web tiled layer at index 0 at start
         self.applyWebTiledLayer(at: 0)
     }
     
     private func applyWebTiledLayer(at index: Int) {
-        //web tiled layer
+        // web tiled layer
         let webTiledLayer = self.webTiledLayer(for: index)
         
-        //initialize basemap with web tiled layer
+        // initialize basemap with web tiled layer
         let basemap = AGSBasemap(baseLayer: webTiledLayer)
         
-        //initialize map with the basemap
+        // initialize map with the basemap
         let map = AGSMap(basemap: basemap)
         
         self.mapView.map = map
     }
     
     private func webTiledLayer(for index: Int) -> AGSWebTiledLayer {
-        //url template for web tiled layer
+        // url template for web tiled layer
         let urlTemplate: String
         
         switch index {
         case 0:
-            //toner
+            // toner
             urlTemplate = "https://stamen-tiles-{subDomain}.a.ssl.fastly.net/toner/{level}/{col}/{row}.png"
         case 1:
-            //terrain
+            // terrain
             urlTemplate = "https://stamen-tiles-{subDomain}.a.ssl.fastly.net/terrain/{level}/{col}/{row}.jpg"
         default:
-            //water color
+            // water color
             urlTemplate = "https://stamen-tiles-{subDomain}.a.ssl.fastly.net/watercolor/{level}/{col}/{row}.jpg"
         }
         
-        //sub domains
+        // sub domains
         let subDomains = ["a", "b", "c", "d"]
         
-        //attribution
+        // attribution
         let attribution = """
             Map tiles by <a href="http://stamen.com/">Stamen Design</a>, \
             under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. \
@@ -70,17 +70,17 @@ class WebTiledLayerViewController: UIViewController {
             under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.
             """
         
-        //initialize web tiled layer
+        // initialize web tiled layer
         let webTiledLayer = AGSWebTiledLayer(urlTemplate: urlTemplate, subDomains: subDomains)
         
-        //assign attribution
+        // assign attribution
         webTiledLayer.attribution = attribution
         
         return webTiledLayer
     }
     
     @IBAction private func segmentedControlValueChanged(_ sender: UISegmentedControl) {
-        //update web tiled layer
+        // update web tiled layer
         self.applyWebTiledLayer(at: sender.selectedSegmentIndex)
     }
 }

--- a/arcgis-ios-sdk-samples/Maps/Apply scheduled updates to preplanned map area/ApplyScheduledUpdatesToPreplannedMapAreaViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Apply scheduled updates to preplanned map area/ApplyScheduledUpdatesToPreplannedMapAreaViewController.swift
@@ -182,7 +182,7 @@ class ApplyScheduledUpdatesToPreplannedMapAreaViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as? SourceCodeBarButtonItem)?.filenames = [
             "ApplyScheduledUpdatesToPreplannedMapAreaViewController"
         ]

--- a/arcgis-ios-sdk-samples/Maps/Change viewpoint/SetViewpointViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Change viewpoint/SetViewpointViewController.swift
@@ -27,13 +27,13 @@ class SetViewpointViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //initialize the map with imagery basemap
+        // initialize the map with imagery basemap
         self.map = AGSMap(basemapStyle: .arcGISImagery)
         
-        //assign the map to the mapview
+        // assign the map to the mapview
         self.mapView.map = self.map
         
-        //create a graphicsOverlay to show the graphics
+        // create a graphicsOverlay to show the graphics
         let graphicsOverlay = AGSGraphicsOverlay()
         
         self.londonCoordinate = AGSPoint(x: 0.1275, y: 51.5072, spatialReference: .wgs84())
@@ -70,7 +70,7 @@ class SetViewpointViewController: UIViewController {
             self.mapView.setViewpointCenter(self.londonCoordinate, scale: 40000, completion: nil)
         case 2:
             let currentScale = self.mapView.mapScale
-            let targetScale = currentScale / 2.5 //zoom in
+            let targetScale = currentScale / 2.5 // zoom in
             let currentCenter = self.mapView.visibleArea!.extent.center
             self.mapView.setViewpoint(AGSViewpoint(center: currentCenter, scale: targetScale), duration: 5, curve: AGSAnimationCurve.easeInOutSine) { (finishedWithoutInterruption) in
                 if finishedWithoutInterruption {

--- a/arcgis-ios-sdk-samples/Maps/Display a map/DisplayMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Display a map/DisplayMapViewController.swift
@@ -21,13 +21,13 @@ class DisplayMapViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //initialize map with a basemap
+        // initialize map with a basemap
         let map = AGSMap(basemapStyle: .arcGISImageryStandard)
         
-        //assign the map to the map view
+        // assign the map to the map view
         self.mapView.map = map
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["DisplayMapViewController"]
     }
 }

--- a/arcgis-ios-sdk-samples/Maps/Display device location/DisplayLocationViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Display device location/DisplayLocationViewController.swift
@@ -24,7 +24,7 @@ class DisplayLocationViewController: UIViewController {
         let map = AGSMap(basemapStyle: .arcGISImageryStandard)
         mapView.map = map
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = [
             "DisplayLocationViewController",
             "DisplayLocationSettingsViewController",

--- a/arcgis-ios-sdk-samples/Maps/Generate offline map (basemap by reference)/GenerateOfflineMapBasemapByReferenceViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map (basemap by reference)/GenerateOfflineMapBasemapByReferenceViewController.swift
@@ -189,7 +189,7 @@ class GenerateOfflineMapBasemapByReferenceViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as? SourceCodeBarButtonItem)?.filenames = [
             "GenerateOfflineMapBasemapByReferenceViewController"
         ]

--- a/arcgis-ios-sdk-samples/Maps/Generate offline map (overrides)/GenerateOfflineMapOverridesViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map (overrides)/GenerateOfflineMapOverridesViewController.swift
@@ -38,10 +38,10 @@ class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthentica
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["GenerateOfflineMapOverridesViewController", "OfflineMapParameterOverridesViewController"]
 
-        //prepare the authentication manager for user login (required for taking the sample's basemap offline)
+        // prepare the authentication manager for user login (required for taking the sample's basemap offline)
         let config = AGSOAuthConfiguration(portalURL: nil, clientID: "xHx4Nj7q1g19Wh6P", redirectURL: "iOSSamples://auth")
         AGSAuthenticationManager.shared().oAuthConfigurations.add(config)
         AGSAuthenticationManager.shared().credentialCache.removeAllCredentials()
@@ -58,22 +58,22 @@ class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthentica
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        //remove key-value observation
+        // remove key-value observation
         progressObservation = nil
     }
     
     private func addMap() {
-        //portal for the web map
+        // portal for the web map
         let portal = AGSPortal.arcGISOnline(withLoginRequired: true)
         
-        //portal item for web map
+        // portal item for web map
         let portalItem = AGSPortalItem(portal: portal, itemID: "acc027394bc84c2fb04d1ed317aac674")
         self.portalItem = portalItem
         
-        //map from portal item
+        // map from portal item
         let map = AGSMap(item: portalItem)
         
-        //assign map to the map view
+        // assign map to the map view
         mapView.map = map
         
         // load the map
@@ -85,7 +85,7 @@ class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthentica
             if let error = error {
                 // don't show an error if the user cancelled from the login screen
                 if (error as NSError).code != NSUserCancelledError {
-                    //show error
+                    // show error
                     self.presentAlert(error: error)
                 }
                 return
@@ -94,10 +94,10 @@ class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthentica
             self.generateButtonItem.isEnabled = true
         }
         
-        //instantiate offline map task
+        // instantiate offline map task
         offlineMapTask = AGSOfflineMapTask(portalItem: portalItem)
         
-        //setup extent view
+        // setup extent view
         extentView.layer.borderColor = UIColor.red.cgColor
         extentView.layer.borderWidth = 3
     }
@@ -122,28 +122,28 @@ class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthentica
                     return
                 }
                 
-                //update progress label
+                // update progress label
                 self.progressLabel.text = progress.localizedDescription
                 
-                //update progress view
+                // update progress view
                 self.progressView.progress = Float(progress.fractionCompleted)
             }
         }
         
-        //unhide the progress parent view
+        // unhide the progress parent view
         progressParentView.isHidden = false
         
-        //start the job
+        // start the job
         generateOfflineMapJob.start(statusHandler: nil) { [weak self] (result, error) in
             guard let self = self else {
                 return
             }
             
-            //remove key-value observation
+            // remove key-value observation
             self.progressObservation = nil
             
             if let error = error {    
-                //do not display error if user simply cancelled the request
+                // do not display error if user simply cancelled the request
                 if (error as NSError).code != NSUserCancelledError {
                     self.presentAlert(error: error)
                 }
@@ -167,15 +167,15 @@ class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthentica
                          message: "The following error(s) occurred while generating the offline map:\n\n\(errorMessages.joined(separator: "\n"))")
         }
         
-        //disable cancel button
+        // disable cancel button
         cancelButton.isEnabled = false
         
-        //assign offline map to map view
+        // assign offline map to map view
         mapView.map = result.offlineMap
     }
     
     func openParameterOverridesViewController() {
-        //instantiate the view controller
+        // instantiate the view controller
         let paramNavigationController = storyboard!.instantiateViewController(withIdentifier: "OfflineParametersNavigationController") as! UINavigationController
         let paramController = paramNavigationController.viewControllers.first as! OfflineMapParameterOverridesViewController
         paramController.parameterOverrides = parameterOverrides
@@ -194,7 +194,7 @@ class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthentica
             // close the view
             paramController.navigationController?.dismiss(animated: true)
         }
-        //display the parameters sheet
+        // display the parameters sheet
         present(paramNavigationController, animated: true)
     }
     
@@ -204,9 +204,9 @@ class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthentica
         progressView.progress = 0
         progressLabel.text = ""
         
-        //enable take map offline bar button item
+        // enable take map offline bar button item
         generateButtonItem.isEnabled = true
-        //unhide the extent view
+        // unhide the extent view
         extentView.isHidden = false
     }
     
@@ -217,20 +217,20 @@ class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthentica
             return
         }
         
-        //disable bar button item
+        // disable bar button item
         generateButtonItem.isEnabled = false
-        //hide the extent view
+        // hide the extent view
         extentView.isHidden = true
         
-        //show progress hud
+        // show progress hud
         SVProgressHUD.show(withStatus: "Getting default parameters")
         
-        //get the area outlined by the extent view
+        // get the area outlined by the extent view
         let areaOfInterest = extentViewFrameToEnvelope()
         
-        //default parameters for offline map task
+        // default parameters for offline map task
         offlineMapTask.defaultGenerateOfflineMapParameters(withAreaOfInterest: areaOfInterest) { [weak self] (parameters: AGSGenerateOfflineMapParameters?, error: Error?) in
-            //dismiss progress hud
+            // dismiss progress hud
             SVProgressHUD.dismiss()
             
             guard let self = self else {
@@ -246,10 +246,10 @@ class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthentica
                 return
             }
             
-            //will need the parameters for creating the job later
+            // will need the parameters for creating the job later
             self.parameters = parameters
             
-            //build the parameter overrides object to be configured by the user
+            // build the parameter overrides object to be configured by the user
             offlineMapTask.generateOfflineMapParameterOverrides(with: parameters) { [weak self] (parameterOverrides, error) in
                 guard let self = self else {
                     return
@@ -265,14 +265,14 @@ class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthentica
                 }
                 self.parameterOverrides = parameterOverrides
                 
-                //now that we have the override object, show the overrides UI
+                // now that we have the override object, show the overrides UI
                 self.openParameterOverridesViewController()
             }
         }
     }
     
     @IBAction func cancelAction() {
-        //cancel generate offline map job
+        // cancel generate offline map job
         generateOfflineMapJob?.progress.cancel()
         
         resetUIForOfflineMapGeneration()
@@ -297,21 +297,21 @@ class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthentica
     private func extentViewFrameToEnvelope() -> AGSEnvelope {
         let frame = mapView.convert(extentView.frame, from: view)
         
-        //the lower-left corner
+        // the lower-left corner
         let minPoint = mapView.screen(toLocation: frame.origin)
         
-        //the upper-right corner
+        // the upper-right corner
         let maxPoint = mapView.screen(toLocation: CGPoint(x: frame.maxX, y: frame.maxY))
         
-        //return the envenlope covering the entire extent frame
+        // return the envenlope covering the entire extent frame
         return AGSEnvelope(min: minPoint, max: maxPoint)
     }
     
     private func getNewOfflineGeodatabaseURL() -> URL {
-        //get a suitable directory to place files
+        // get a suitable directory to place files
         let directoryURL = FileManager.default.temporaryDirectory
         
-        //create a unique name for the geodatabase based on current timestamp
+        // create a unique name for the geodatabase based on current timestamp
         let formattedDate = ISO8601DateFormatter().string(from: Date())
         
         return directoryURL.appendingPathComponent("\(formattedDate).geodatabase")

--- a/arcgis-ios-sdk-samples/Maps/Generate offline map (overrides)/OfflineMapParameterOverridesViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map (overrides)/OfflineMapParameterOverridesViewController.swift
@@ -36,13 +36,13 @@ class OfflineMapParameterOverridesViewController: UITableViewController {
     
     /// Switch indicating if the system valves layer should be included in the download.
     @IBOutlet weak var includeSystemValvesSwitch: UISwitch!
-    ///Switch indicating if the service connections layer should be included in the download.
+    /// Switch indicating if the service connections layer should be included in the download.
     @IBOutlet weak var includeServiceConnectionsSwitch: UISwitch!
     
     /// The minimum flow rate by which to filter features in the Hydrants layer, in gallons per minute.
     @IBOutlet weak var minHydrantFlowRateSlider: UISlider!
     
-    ///Switch indicating if the pipe layers should be restricted to the extent frame.
+    /// Switch indicating if the pipe layers should be restricted to the extent frame.
     @IBOutlet weak var cropWaterPipesToExtentSwitch: UISwitch!
     
     @IBOutlet weak var minScaleLevelLabel: UILabel!

--- a/arcgis-ios-sdk-samples/Maps/Generate offline map/GenerateOfflineMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map/GenerateOfflineMapViewController.swift
@@ -37,10 +37,10 @@ class GenerateOfflineMapViewController: UIViewController, AGSAuthenticationManag
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["GenerateOfflineMapViewController"]
 
-        //prepare the authentication manager for user login (required for taking the sample's basemap offline)
+        // prepare the authentication manager for user login (required for taking the sample's basemap offline)
         let config = AGSOAuthConfiguration(portalURL: nil, clientID: "xHx4Nj7q1g19Wh6P", redirectURL: "iOSSamples://auth")
         AGSAuthenticationManager.shared().oAuthConfigurations.add(config)
         AGSAuthenticationManager.shared().credentialCache.removeAllCredentials()
@@ -56,20 +56,20 @@ class GenerateOfflineMapViewController: UIViewController, AGSAuthenticationManag
     }
     
     private func addMap() {
-        //portal for the web map
+        // portal for the web map
         let portal = AGSPortal.arcGISOnline(withLoginRequired: true)
         
-        //portal item for web map
+        // portal item for web map
         let portalItem = AGSPortalItem(portal: portal, itemID: "acc027394bc84c2fb04d1ed317aac674")
         self.portalItem = portalItem
         
-        //map from portal item
+        // map from portal item
         let map = AGSMap(item: portalItem)
         
-        //assign map to the map view
+        // assign map to the map view
         mapView.map = map
         
-        //disable the bar button item until the map loads
+        // disable the bar button item until the map loads
         mapView.map?.load { [weak self] (error) in
             guard let self = self else {
                 return
@@ -77,7 +77,7 @@ class GenerateOfflineMapViewController: UIViewController, AGSAuthenticationManag
             
             if let error = error {
                 if (error as NSError).code != NSUserCancelledError {
-                    //show error
+                    // show error
                     self.presentAlert(error: error)
                 }
                 return
@@ -86,10 +86,10 @@ class GenerateOfflineMapViewController: UIViewController, AGSAuthenticationManag
             self.barButtonItem.isEnabled = true
         }
         
-        //instantiate offline map task
+        // instantiate offline map task
         offlineMapTask = AGSOfflineMapTask(portalItem: portalItem)
         
-        //setup extent view
+        // setup extent view
         extentView.layer.borderColor = UIColor.red.cgColor
         extentView.layer.borderWidth = 3
     }
@@ -105,30 +105,30 @@ class GenerateOfflineMapViewController: UIViewController, AGSAuthenticationManag
         let generateOfflineMapJob = offlineMapTask.generateOfflineMapJob(with: parameters, downloadDirectory: downloadDirectory)
         self.generateOfflineMapJob = generateOfflineMapJob
         
-        //observe the job's progress
+        // observe the job's progress
         jobProgressObservation = generateOfflineMapJob.progress.observe(\.fractionCompleted, options: .new) { [weak self] (progress, _) in
             DispatchQueue.main.async { [weak self] in
-                //update progress label
+                // update progress label
                 self?.progressLabel.text = progress.localizedDescription
-                //update progress view
+                // update progress view
                 self?.progressView.progress = Float(progress.fractionCompleted)
             }
         }
         
-        //unhide the progress parent view
+        // unhide the progress parent view
         progressParentView.isHidden = false
         
-        //start the job
+        // start the job
         generateOfflineMapJob.start(statusHandler: nil) { [weak self] (result, error) in
             guard let self = self else {
                 return
             }
             
-            //remove KVO observer
+            // remove KVO observer
             self.jobProgressObservation = nil
             
             if let error = error {    
-                //do not display error if user simply cancelled the request
+                // do not display error if user simply cancelled the request
                 if (error as NSError).code != NSUserCancelledError {
                     self.presentAlert(error: error)
                 }
@@ -153,31 +153,31 @@ class GenerateOfflineMapViewController: UIViewController, AGSAuthenticationManag
                          message: "The following error(s) occurred while generating the offline map:\n\n\(errorMessages.joined(separator: "\n"))")
         }
         
-        //disable cancel button
+        // disable cancel button
         cancelButton.isEnabled = false
         
-        //assign offline map to map view
+        // assign offline map to map view
         mapView.map = result.offlineMap
     }
     
     // MARK: - Actions
     
     @IBAction func generateOfflineMapAction() {
-        //disable bar button item
+        // disable bar button item
         barButtonItem.isEnabled = false
         
-        //hide the extent view
+        // hide the extent view
         extentView.isHidden = true
         
-        //show progress hud
+        // show progress hud
         SVProgressHUD.show(withStatus: "Getting default parameters")
         
-        //get the area outlined by the extent view
+        // get the area outlined by the extent view
         let areaOfInterest = extentViewFrameToEnvelope()
         
-        //default parameters for offline map task
+        // default parameters for offline map task
         offlineMapTask?.defaultGenerateOfflineMapParameters(withAreaOfInterest: areaOfInterest) { [weak self] (parameters: AGSGenerateOfflineMapParameters?, error: Error?) in
-            //dismiss progress hud
+            // dismiss progress hud
             SVProgressHUD.dismiss()
             
             guard let parameters = parameters,
@@ -190,26 +190,26 @@ class GenerateOfflineMapViewController: UIViewController, AGSAuthenticationManag
                 return
             }
             
-            //will need the parameters for creating the job later
+            // will need the parameters for creating the job later
             self.parameters = parameters
             
-            //take map offline
+            // take map offline
             self.takeMapOffline()
         }
     }
     
     @IBAction func cancelAction() {
-        //cancel generate offline map job
+        // cancel generate offline map job
         generateOfflineMapJob?.progress.cancel()
         
         progressParentView.isHidden = true
         progressView.progress = 0
         progressLabel.text = ""
         
-        //enable take map offline bar button item
+        // enable take map offline bar button item
         barButtonItem.isEnabled = true
         
-        //unhide the extent view
+        // unhide the extent view
         extentView.isHidden = false
     }
     
@@ -232,21 +232,21 @@ class GenerateOfflineMapViewController: UIViewController, AGSAuthenticationManag
     private func extentViewFrameToEnvelope() -> AGSEnvelope {
         let frame = mapView.convert(extentView.frame, from: view)
         
-        //the lower-left corner
+        // the lower-left corner
         let minPoint = mapView.screen(toLocation: frame.origin)
         
-        //the upper-right corner
+        // the upper-right corner
         let maxPoint = mapView.screen(toLocation: CGPoint(x: frame.maxX, y: frame.maxY))
         
-        //return the envenlope covering the entire extent frame
+        // return the envenlope covering the entire extent frame
         return AGSEnvelope(min: minPoint, max: maxPoint)
     }
     
     private func getNewOfflineMapDirectoryURL() -> URL {
-        //get a suitable directory to place files
+        // get a suitable directory to place files
         let documentDirectoryURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
         
-        //create a unique name based on current timestamp
+        // create a unique name based on current timestamp
         let formattedDate = ISO8601DateFormatter().string(from: Date())
         
         return documentDirectoryURL.appendingPathComponent("\(formattedDate)")

--- a/arcgis-ios-sdk-samples/Maps/Identify layers/IdentifyLayersViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Identify layers/IdentifyLayersViewController.swift
@@ -30,7 +30,7 @@ class IdentifyLayersViewController: UIViewController, AGSGeoViewTouchDelegate {
         // Map image layer.
         let mapImageLayer = AGSArcGISMapImageLayer(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer")!)
         
-        //hide Continent and World layers
+        // hide Continent and World layers
         mapImageLayer.load { [weak mapImageLayer] (error: Error?) in
             if error == nil {
                 mapImageLayer?.subLayerContents[1].isVisible = false

--- a/arcgis-ios-sdk-samples/Maps/Manage bookmarks/BookmarksListViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Manage bookmarks/BookmarksListViewController.swift
@@ -16,13 +16,13 @@ import UIKit
 import ArcGIS
 
 class BookmarksListViewController: UITableViewController {
-    //list of bookmarks
+    // list of bookmarks
     var bookmarks = [AGSBookmark]()
     
-    //private property to store selection action for table cell
+    // private property to store selection action for table cell
     private var selectAction: ((AGSViewpoint) -> Void)?
     
-    //executed for tableview row selection
+    // executed for tableview row selection
     func setSelectAction(_ action : @escaping ((AGSViewpoint) -> Void)) {
         self.selectAction = action
     }
@@ -41,9 +41,9 @@ class BookmarksListViewController: UITableViewController {
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "BookmarkCell", for: indexPath)
-        //get the respective bookmark
+        // get the respective bookmark
         let bookmark = self.bookmarks[indexPath.row]
-        //assign the bookmark's name as the title for the cell
+        // assign the bookmark's name as the title for the cell
         cell.textLabel?.text = bookmark.name
         
         return cell
@@ -51,7 +51,7 @@ class BookmarksListViewController: UITableViewController {
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let bookmark = self.bookmarks[indexPath.row]
-        //execute the closure if it exists
+        // execute the closure if it exists
         selectAction?(bookmark.viewpoint!)
         tableView.deselectRow(at: indexPath, animated: true)
     }

--- a/arcgis-ios-sdk-samples/Maps/Manage bookmarks/BookmarksViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Manage bookmarks/BookmarksViewController.swift
@@ -25,56 +25,56 @@ class BookmarksViewController: UIViewController, UIAdaptivePresentationControlle
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //initialize map using imagery with labels basemap
+        // initialize map using imagery with labels basemap
         self.map = AGSMap(basemapStyle: .arcGISImagery)
         
-        //assign map to the mapView
+        // assign map to the mapView
         self.mapView.map = self.map
 
-        //add default bookmarks
+        // add default bookmarks
         self.addDefaultBookmarks()
         
-        //zoom to the last bookmark
+        // zoom to the last bookmark
         self.map.initialViewpoint = (self.map.bookmarks.lastObject as AnyObject).viewpoint
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["BookmarksViewController", "BookmarksListViewController"]
     }
     
     private func addDefaultBookmarks() {
-        //create a few bookmarks and add them to the map
+        // create a few bookmarks and add them to the map
         var viewpoint: AGSViewpoint, bookmark: AGSBookmark
         
-        //Mysterious Desert Pattern
+        // Mysterious Desert Pattern
         viewpoint = AGSViewpoint(latitude: 27.3805833, longitude: 33.6321389, scale: 6e3)
         bookmark = AGSBookmark()
         bookmark.name = "Mysterious Desert Pattern"
         bookmark.viewpoint = viewpoint
-        //add the bookmark to the map
+        // add the bookmark to the map
         self.map.bookmarks.add(bookmark)
         
-        //Strange Symbol
+        // Strange Symbol
         viewpoint = AGSViewpoint(latitude: 37.401573, longitude: -116.867808, scale: 6e3)
         bookmark = AGSBookmark()
         bookmark.name = "Strange Symbol"
         bookmark.viewpoint = viewpoint
-        //add the bookmark to the map
+        // add the bookmark to the map
         self.map.bookmarks.add(bookmark)
         
-        //Guitar-Shaped Forest
+        // Guitar-Shaped Forest
         viewpoint = AGSViewpoint(latitude: -33.867886, longitude: -63.985, scale: 4e4)
         bookmark = AGSBookmark()
         bookmark.name = "Guitar-Shaped Forest"
         bookmark.viewpoint = viewpoint
-        //add the bookmark to the map
+        // add the bookmark to the map
         self.map.bookmarks.add(bookmark)
         
-        //Grand Prismatic Spring
+        // Grand Prismatic Spring
         viewpoint = AGSViewpoint(latitude: 44.525049, longitude: -110.83819, scale: 6e3)
         bookmark = AGSBookmark()
         bookmark.name = "Grand Prismatic Spring"
         bookmark.viewpoint = viewpoint
-        //add the bookmark to the map
+        // add the bookmark to the map
         self.map.bookmarks.add(bookmark)
     }
     
@@ -109,13 +109,13 @@ class BookmarksViewController: UIViewController, UIAdaptivePresentationControlle
     }
     
     private func addBookmark(withName name: String) {
-        //instantiate a bookmark and set the properties
+        // instantiate a bookmark and set the properties
         let bookmark = AGSBookmark()
         bookmark.name = name
         bookmark.viewpoint = self.mapView.currentViewpoint(with: AGSViewpointType.boundingGeometry)
-        //add the bookmark to the map
+        // add the bookmark to the map
         self.map.bookmarks.add(bookmark)
-        //refresh the table view if it exists
+        // refresh the table view if it exists
         self.bookmarksListViewController?.tableView.reloadData()
     }
     
@@ -123,14 +123,14 @@ class BookmarksViewController: UIViewController, UIAdaptivePresentationControlle
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if let controller = segue.destination as? BookmarksListViewController {
-            //store a weak reference in order to update the table view when adding new bookmark
+            // store a weak reference in order to update the table view when adding new bookmark
             self.bookmarksListViewController = controller
-            //popover presentation logic
+            // popover presentation logic
             controller.presentationController?.delegate = self
             controller.preferredContentSize = CGSize(width: 300, height: 200)
-            //assign the bookmarks to be shown
+            // assign the bookmarks to be shown
             controller.bookmarks = self.map.bookmarks as! [AGSBookmark]
-            //set the closure to be executed when the user selects a bookmark
+            // set the closure to be executed when the user selects a bookmark
             controller.setSelectAction { [weak self] (viewpoint: AGSViewpoint) in
                 self?.mapView.setViewpoint(viewpoint)
             }
@@ -140,7 +140,7 @@ class BookmarksViewController: UIViewController, UIAdaptivePresentationControlle
     // MARK: - UIAdaptivePresentationControllerDelegate
     
     func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
-        //for popover or non modal presentation
+        // for popover or non modal presentation
         return UIModalPresentationStyle.none
     }
 }

--- a/arcgis-ios-sdk-samples/Maps/Map loaded/MapLoadedViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Map loaded/MapLoadedViewController.swift
@@ -27,14 +27,14 @@ class MapLoadedViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        //setup source code bar button item
+        // setup source code bar button item
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["MapLoadedViewController"]
         
-        //assign map to map view
+        // assign map to map view
         mapView.map = map
         
         mapLoadStatusObservation = map.observe(\.loadStatus, options: .initial) { [weak self] (_, _) in
-            //update the banner label on main thread
+            // update the banner label on main thread
             DispatchQueue.main.async { [weak self] in
                 self?.updateLoadStatusLabel()
             }

--- a/arcgis-ios-sdk-samples/Maps/Map reference scale/MapReferenceScaleViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Map reference scale/MapReferenceScaleViewController.swift
@@ -41,7 +41,7 @@ class MapReferenceScaleViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as? SourceCodeBarButtonItem)?.filenames = [
             "MapReferenceScaleViewController",
             "MapReferenceScaleSettingsViewController",

--- a/arcgis-ios-sdk-samples/Maps/Mobile map (search and route)/MapPackageCell.swift
+++ b/arcgis-ios-sdk-samples/Maps/Mobile map (search and route)/MapPackageCell.swift
@@ -46,7 +46,7 @@ class MapPackageCell: UITableViewCell, UICollectionViewDataSource, UICollectionV
             if let error = error {
                 print(error.localizedDescription)
             } else {
-                //update title label
+                // update title label
                 self?.titleLabel.text = self?.mapPackage.item?.title
                 
                 self?.collectionView.reloadData()
@@ -73,24 +73,24 @@ class MapPackageCell: UITableViewCell, UICollectionViewDataSource, UICollectionV
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "MobileMapCell", for: indexPath)
         
-        //label
+        // label
         let label = cell.viewWithTag(11) as! UILabel
         label.text = "Map \(indexPath.item + 1)"
         
-        //border
+        // border
         cell.layer.borderColor = UIColor.black.cgColor
         cell.layer.borderWidth = 1
         
-        //search image view
+        // search image view
         let searchImageView = cell.viewWithTag(12) as! UIImageView
         searchImageView.isHidden = (self.mapPackage.locatorTask == nil)
         
         let map = self.mapPackage.maps[indexPath.item]
-        //route image view
+        // route image view
         let routeImageView = cell.viewWithTag(13) as! UIImageView
         routeImageView.isHidden = map.transportationNetworks.isEmpty
         
-        //thumbnail
+        // thumbnail
         let imageView = cell.viewWithTag(14) as! UIImageView
         imageView.image = map.item?.thumbnail?.image
         imageView.layer.borderColor = UIColor.gray.cgColor

--- a/arcgis-ios-sdk-samples/Maps/Mobile map (search and route)/MapPackagesListViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Mobile map (search and route)/MapPackagesListViewController.swift
@@ -26,7 +26,7 @@ class MapPackagesListViewController: UITableViewController, MapPackageCellDelega
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["MapPackagesListViewController", "MobileMapViewController", "MapPackageCell"]
         
         tableView.rowHeight = UITableView.automaticDimension
@@ -42,8 +42,8 @@ class MapPackagesListViewController: UITableViewController, MapPackageCellDelega
             mapPackagesInBundle = bundleMobileMapPackageURLs.map(AGSMobileMapPackage.init(fileURL:))
         }
         
-        //load map packages from the documents directory
-        //added using iTunes
+        // load map packages from the documents directory
+        // added using iTunes
         let documentDirectoryURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
         let subpaths = FileManager.default.subpaths(atPath: documentDirectoryURL.path)!
         
@@ -51,7 +51,7 @@ class MapPackagesListViewController: UITableViewController, MapPackageCellDelega
         let mmpks = subpaths.filter { predicate.evaluate(with: $0) }
         let documentMobileMapPackageURLs = mmpks.map { documentDirectoryURL.appendingPathComponent($0) }
         
-        //create map packages from the paths
+        // create map packages from the paths
         mapPackagesInDocumentsDir = documentMobileMapPackageURLs.map(AGSMobileMapPackage.init(fileURL:))
         
         self.tableView.reloadData()
@@ -96,13 +96,13 @@ class MapPackagesListViewController: UITableViewController, MapPackageCellDelega
     // MARK: - UITableViewDelegate
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        //collapse previously expanded cell
+        // collapse previously expanded cell
         var indexPathsArray = [IndexPath]()
         indexPathsArray.append(indexPath)
         
         if self.selectedRowIndexPath != nil {
             if self.selectedRowIndexPath == indexPath {
-                //collapse
+                // collapse
                 self.selectedRowIndexPath = nil
             } else {
                 indexPathsArray.append(self.selectedRowIndexPath)

--- a/arcgis-ios-sdk-samples/Maps/Mobile map (search and route)/MobileMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Mobile map (search and route)/MobileMapViewController.swift
@@ -36,21 +36,21 @@ class MobileMapViewController: UIViewController, AGSGeoViewTouchDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //initialize reverse geocode params
+        // initialize reverse geocode params
         self.reverseGeocodeParameters = AGSReverseGeocodeParameters()
         self.reverseGeocodeParameters.maxResults = 1
         self.reverseGeocodeParameters.resultAttributeNames.append(contentsOf: ["*"])
 
-        //set the map on to the map view
+        // set the map on to the map view
         self.mapView.map = self.map
         
-        //touch delegate
+        // touch delegate
         self.mapView.touchDelegate = self
         
-        //add graphic overlays
+        // add graphic overlays
         self.mapView.graphicsOverlays.addObjects(from: [self.routeGraphicsOverlay, self.markerGraphicsOverlay])
         
-        //route task
+        // route task
         self.setupRouteTask()
     }
     
@@ -77,13 +77,13 @@ class MobileMapViewController: UIViewController, AGSGeoViewTouchDelegate {
         return graphic
     }
     
-    //method returns the symbol for the route graphic
+    // method returns the symbol for the route graphic
     func routeSymbol() -> AGSSimpleLineSymbol {
         let symbol = AGSSimpleLineSymbol(style: .solid, color: .blue, width: 5)
         return symbol
     }
     
-    //method to show the callout for the provided graphic, with tap location details
+    // method to show the callout for the provided graphic, with tap location details
     private func showCalloutForGraphic(_ graphic: AGSGraphic, tapLocation: AGSPoint, animated: Bool, offset: Bool) {
         self.mapView.callout.title = graphic.attributes["Match_addr"] as? String
         self.mapView.callout.isAccessoryButtonHidden = true
@@ -97,23 +97,23 @@ class MobileMapViewController: UIViewController, AGSGeoViewTouchDelegate {
         if self.routeTask == nil && self.locatorTask == nil {
             return
         } else if routeTask == nil {
-            //if routing is not possible, then clear previous graphics
+            // if routing is not possible, then clear previous graphics
             self.markerGraphicsOverlay.graphics.removeAllObjects()
         }
         
-        //identify to check if a graphic is present
-        //if yes, then show callout with geocoding
-        //else add a graphic and route if more than one graphic
+        // identify to check if a graphic is present
+        // if yes, then show callout with geocoding
+        // else add a graphic and route if more than one graphic
         
         self.mapView.identify(self.markerGraphicsOverlay, screenPoint: screenPoint, tolerance: 12, returnPopupsOnly: false) { [weak self] (result: AGSIdentifyGraphicsOverlayResult) in
             if let error = result.error {
                 self?.presentAlert(error: error)
             } else {
                 if let graphic = result.graphics.first {
-                    //reverse geocode
+                    // reverse geocode
                     self?.reverseGeocode(point: mapPoint, withGraphic: graphic)
                 } else {
-                    //add a graphic
+                    // add a graphic
                     var graphic: AGSGraphic
                     
                     if self?.routeTask != nil {
@@ -125,10 +125,10 @@ class MobileMapViewController: UIViewController, AGSGeoViewTouchDelegate {
                     
                     self?.markerGraphicsOverlay.graphics.add(graphic)
                     
-                    //reverse geocode
+                    // reverse geocode
                     self?.reverseGeocode(point: mapPoint, withGraphic: graphic)
                     
-                    //find route
+                    // find route
                     self?.route()
                 }
             }
@@ -142,7 +142,7 @@ class MobileMapViewController: UIViewController, AGSGeoViewTouchDelegate {
             return
         }
         
-        //cancel previous request if any
+        // cancel previous request if any
         if self.locatorTaskCancelable != nil {
             self.locatorTaskCancelable.cancel()
         }
@@ -151,18 +151,18 @@ class MobileMapViewController: UIViewController, AGSGeoViewTouchDelegate {
             if let error = error {
                 self?.presentAlert(error: error)
             } else {
-                //assign the label property of result as an attributes to the graphic
-                //and show the callout
+                // assign the label property of result as an attributes to the graphic
+                // and show the callout
                 if let results = results,
                     !results.isEmpty {
                     graphic.attributes["Match_addr"] = results.first!.formattedAddressString
                     self?.showCalloutForGraphic(graphic, tapLocation: point, animated: false, offset: false)
                     return
                 } else {
-                    //no result was found
+                    // no result was found
                     self?.presentAlert(message: "No address found")
                     
-                    //dismiss the callout if already visible
+                    // dismiss the callout if already visible
                     self?.mapView.callout.dismiss()
                 }
             }
@@ -172,17 +172,17 @@ class MobileMapViewController: UIViewController, AGSGeoViewTouchDelegate {
     // MARK: - Route
     
     private func setupRouteTask() {
-        //if map contains network data
+        // if map contains network data
         if let transportationNetwork = map.transportationNetworks.first {
             self.routeTask = AGSRouteTask(dataset: transportationNetwork)
             
-            //get default parameters
+            // get default parameters
             self.getDefaultParameters()
         }
     }
     
     private func getDefaultParameters() {
-        //get the default parameters
+        // get the default parameters
         self.routeTask.defaultRouteParameters { [weak self] (params: AGSRouteParameters?, error: Error?) in
             if let error = error {
                 self?.presentAlert(error: error)
@@ -197,26 +197,26 @@ class MobileMapViewController: UIViewController, AGSGeoViewTouchDelegate {
             return
         }
         
-        //cancel previous request if any
+        // cancel previous request if any
         if self.routeTaskCancelable != nil {
             self.routeTaskCancelable.cancel()
         }
         
-        //create stops for last and second last graphic
+        // create stops for last and second last graphic
         let count = self.markerGraphicsOverlay.graphics.count
         let lastGraphic = self.markerGraphicsOverlay.graphics[count - 1] as! AGSGraphic
         let secondLastGraphic = self.markerGraphicsOverlay.graphics[count - 2] as! AGSGraphic
         let stops = self.stopsForGraphics([secondLastGraphic, lastGraphic])
         
-        //add stops to the parameters
+        // add stops to the parameters
         self.routeParameters.clearStops()
         self.routeParameters.setStops(stops)
         
-        //route
+        // route
         self.routeTaskCancelable = self.routeTask.solveRoute(with: self.routeParameters) { [weak self] (routeResult: AGSRouteResult?, error: Error?) in
             if let error = error {
                 self?.presentAlert(error: error)
-                //remove the last marker
+                // remove the last marker
                 self?.markerGraphicsOverlay.graphics.removeLastObject()
             } else if let route = routeResult?.routes.first {
                 let routeGraphic = AGSGraphic(geometry: route.routeGeometry, symbol: self?.routeSymbol(), attributes: nil)
@@ -237,16 +237,16 @@ class MobileMapViewController: UIViewController, AGSGeoViewTouchDelegate {
     // MARK: - actions
     
     @IBAction private func trashAction() {
-        //remove all markers
+        // remove all markers
         self.markerGraphicsOverlay.graphics.removeAllObjects()
-        //remove route graphics
+        // remove route graphics
         self.routeGraphicsOverlay.graphics.removeAllObjects()
-        //dismiss callout
+        // dismiss callout
         self.mapView.callout.dismiss()
     }
 }
 
-//extension for extracting the right attributes if available
+// extension for extracting the right attributes if available
 private extension AGSGeocodeResult {
     var formattedAddressString: String? {
         if !label.isEmpty {

--- a/arcgis-ios-sdk-samples/Maps/Open map (URL)/OpenMapURLViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Open map (URL)/OpenMapURLViewController.swift
@@ -55,7 +55,7 @@ class OpenMapURLViewController: UIViewController {
         // create the map for the url and add it to the map view
         showMap(at: initialMapURL)
 
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = [
             "OpenMapURLViewController",
             "OpenMapURLSettingsViewController"

--- a/arcgis-ios-sdk-samples/Maps/Open mobile map (map package)/OpenMobileMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Open mobile map (map package)/OpenMobileMapViewController.swift
@@ -25,13 +25,13 @@ class OpenMobileMapViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["OpenMobileMapViewController"]
         
-        //initialize map package
+        // initialize map package
         self.mapPackage = AGSMobileMapPackage(name: "Yellowstone")
         
-        //load map package
+        // load map package
         self.mapPackage.load { [weak self] (error: Error?) in
             guard let self = self else {
                 return
@@ -40,7 +40,7 @@ class OpenMobileMapViewController: UIViewController {
             if let error = error {
                 self.presentAlert(error: error)
             } else if let map = self.mapPackage.maps.first {
-                //assign the first map from the map package to the map view
+                // assign the first map from the map package to the map view
                 self.mapView.map = map
             } else {
                 self.presentAlert(message: "No mobile maps found in the map package")

--- a/arcgis-ios-sdk-samples/Maps/Read a geopackage/ReadGeopackageViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Read a geopackage/ReadGeopackageViewController.swift
@@ -42,7 +42,7 @@ class ReadGeopackageViewController: UIViewController, UIPopoverPresentationContr
             // Create raster layers for each raster in the geopackage.
             let rasterLayers = geoPackage.geoPackageRasters.map { raster -> AGSLayer in
                 let rasterLayer = AGSRasterLayer(raster: raster)
-                //make it semi-transparent so it doesn't obscure the contents under it
+                // make it semi-transparent so it doesn't obscure the contents under it
                 rasterLayer.opacity = 0.55
                 return rasterLayer
             }

--- a/arcgis-ios-sdk-samples/Maps/Set map spatial reference/SetMapsSRViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Set map spatial reference/SetMapsSRViewController.swift
@@ -23,18 +23,18 @@ class SetMapsSRViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["SetMapsSRViewController"]
         
-        //initialize the map, spatial reference as world bonne (54024) or goode (54052)
+        // initialize the map, spatial reference as world bonne (54024) or goode (54052)
         self.map = AGSMap(spatialReference: AGSSpatialReference(wkid: 54024)!)
         
-        //Adding a map image layer which can reproject itself to the map's spatial reference
-        //Note: Some layer such as tiled layer cannot reproject and will fail to draw if their spatial 
-        //reference is not the same as the map's spatial reference
+        // Adding a map image layer which can reproject itself to the map's spatial reference
+        // Note: Some layer such as tiled layer cannot reproject and will fail to draw if their spatial 
+        // reference is not the same as the map's spatial reference
         self.map.operationalLayers.add(AGSArcGISMapImageLayer(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer")!))
         
-        //assing the map to the map view
+        // assing the map to the map view
         self.mapView.map = self.map
     }
 }

--- a/arcgis-ios-sdk-samples/Maps/Set min-max scale/SetMinMaxScaleViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Set min-max scale/SetMinMaxScaleViewController.swift
@@ -43,7 +43,7 @@ class SetMinMaxScaleViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as? SourceCodeBarButtonItem)?.filenames = ["SetMinMaxScaleViewController"]
     }
 }

--- a/arcgis-ios-sdk-samples/Maps/Show magnifier/ShowMagnifierViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Show magnifier/ShowMagnifierViewController.swift
@@ -23,20 +23,20 @@ class ShowMagnifierViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //instantiate map with topographic basemap
+        // instantiate map with topographic basemap
         self.map = AGSMap(basemapStyle: .arcGISImageryStandard)
         
-        //asssign map to the map view
+        // asssign map to the map view
         self.mapView.map = self.map
         
-        //enable magnifier
+        // enable magnifier
         self.mapView.interactionOptions.isMagnifierEnabled = true
         
-        //zoom to custom viewpoint
+        // zoom to custom viewpoint
         let viewpoint = AGSViewpoint(center: AGSPoint(x: -110.8258, y: 32.1545089, spatialReference: .wgs84()), scale: 2e4)
         self.mapView.setViewpoint(viewpoint)
         
-        //setup source code BBI
+        // setup source code BBI
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["ShowMagnifierViewController"]
     }
 }

--- a/arcgis-ios-sdk-samples/Maps/Take screenshot/MapViewScreenshotViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Take screenshot/MapViewScreenshotViewController.swift
@@ -29,78 +29,78 @@ class MapViewScreenshotViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["MapViewScreenshotViewController"]
         
-        //instantiate map with imagegry basemap
+        // instantiate map with imagegry basemap
         self.map = AGSMap(basemapStyle: .arcGISImageryStandard)
         
-        //assign the map to the map view
+        // assign the map to the map view
         self.mapView.map = self.map
         
-        //initialize and assign tap gesture to hide overlay parent view
+        // initialize and assign tap gesture to hide overlay parent view
         self.tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(MapViewScreenshotViewController.hideOverlayParentView))
         self.overlayParentView.addGestureRecognizer(self.tapGestureRecognizer)
         
-        //add border to the overlay image view
+        // add border to the overlay image view
         self.overlayImageView.layer.borderColor = UIColor.white.cgColor
         self.overlayImageView.layer.borderWidth = 2
     }
     
     // MARK: - Actions
     
-    //hide the screenshot overlay view
+    // hide the screenshot overlay view
     @objc
     func hideOverlayParentView() {
         self.overlayParentView.isHidden = true
     }
     
-    //show the screenshot overlay view
+    // show the screenshot overlay view
     private func showOverlayParentView() {
         self.overlayParentView.isHidden = false
     }
     
-    //called when the user taps on the screenshot button
+    // called when the user taps on the screenshot button
     @IBAction private func screenshotAction(_ sender: AnyObject) {
-        //hide the screenshot view if currently visible
+        // hide the screenshot view if currently visible
         self.hideOverlayParentView()
         
-        //the method on map view we can use to get the screenshot image
+        // the method on map view we can use to get the screenshot image
         self.mapView.exportImage { [weak self] (image: UIImage?, error: Error?) in
             if let error = error {
                 self?.presentAlert(error: error)
             }
             if let image = image {
-                //on completion imitate flash
+                // on completion imitate flash
                 self?.imitateFlashAndPreviewImage(image)
             }
         }
     }
     
-    //imitate the white flash screen when the user taps on the screenshot button
+    // imitate the white flash screen when the user taps on the screenshot button
     private func imitateFlashAndPreviewImage(_ image: UIImage) {
         let flashView = UIView(frame: self.mapView.bounds)
         flashView.backgroundColor = .white
         self.mapView.addSubview(flashView)
         
-        //animate the white flash view on and off to show the flash effect
+        // animate the white flash view on and off to show the flash effect
         UIView.animate(
             withDuration: 0.3,
             animations: {
                 flashView.alpha = 0
             },
             completion: { [weak self] (_) in
-                //On completion play the shutter sound
+                // On completion play the shutter sound
                 self?.playShutterSound()
                 flashView.removeFromSuperview()
-                //show the screenshot on screen
+                // show the screenshot on screen
                 self?.overlayImageView.image = image
                 self?.showOverlayParentView()
             }
         )
     }
     
-    //to play the shutter sound once the screenshot is taken
+    // to play the shutter sound once the screenshot is taken
     func playShutterSound() {
         if self.shutterSound == 0 {
             if let filepath = Bundle.main.path(forResource: "Camera Shutter", ofType: "caf") {

--- a/arcgis-ios-sdk-samples/Route and directions/Find route/FindRouteViewController.swift
+++ b/arcgis-ios-sdk-samples/Route and directions/Find route/FindRouteViewController.swift
@@ -39,27 +39,27 @@ class FindRouteViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["FindRouteViewController", "DirectionsViewController"]
         
-        //initialize map with topographic basemap
+        // initialize map with topographic basemap
         let map = AGSMap(basemapStyle: .arcGISTopographic)
         self.mapView.map = map
         
-        //add graphicsOverlays to the map view
+        // add graphicsOverlays to the map view
         self.mapView.graphicsOverlays.addObjects(from: [routeGraphicsOverlay, stopGraphicsOverlay])
         
-        //zoom to viewpoint
+        // zoom to viewpoint
         self.mapView.setViewpointCenter(AGSPoint(x: -13041154.715252, y: 3858170.236806, spatialReference: .webMercator()), scale: 1e5)
         
-        //initialize route task
+        // initialize route task
         self.routeTask = AGSRouteTask(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/NetworkAnalysis/SanDiego/NAServer/Route")!)
         
-        //get default parameters
+        // get default parameters
         self.getDefaultParameters()
     }
     
-    //add hard coded stops to the map view
+    // add hard coded stops to the map view
     func addStops() {
         self.stop1Geometry = AGSPoint(x: -13041171.537945, y: 3860988.271378, spatialReference: .webMercator())
         self.stop2Geometry = AGSPoint(x: -13041693.562570, y: 3856006.859684, spatialReference: .webMercator())
@@ -70,12 +70,12 @@ class FindRouteViewController: UIViewController {
         self.stopGraphicsOverlay.graphics.addObjects(from: [startStopGraphic, endStopGraphic])
     }
     
-    //method provides a text symbol for stop with specified parameters
+    // method provides a text symbol for stop with specified parameters
     func stopSymbol(withName name: String, textColor: UIColor) -> AGSTextSymbol {
         return AGSTextSymbol(text: name, color: textColor, size: 20, horizontalAlignment: .center, verticalAlignment: .middle)
     }
     
-    //method provides a line symbol for the route graphic
+    // method provides a line symbol for the route graphic
     func routeSymbol() -> AGSSimpleLineSymbol {
         let symbol = AGSSimpleLineSymbol(style: .solid, color: .yellow, width: 5)
         return symbol
@@ -83,38 +83,38 @@ class FindRouteViewController: UIViewController {
     
     // MARK: - Route logic
     
-    //method to get the default parameters for the route task
+    // method to get the default parameters for the route task
     func getDefaultParameters() {
         self.routeTask.defaultRouteParameters { [weak self] (params: AGSRouteParameters?, error: Error?) in
             if let error = error {
                 print(error)
             } else {
-                //on completion store the parameters
+                // on completion store the parameters
                 self?.routeParameters = params
-                //add stops
+                // add stops
                 self?.addStops()
-                //enable bar button item
+                // enable bar button item
                 self?.routeBBI.isEnabled = true
             }
         }
     }
     
     @IBAction func route() {
-        //route only if default parameters are fetched successfully
+        // route only if default parameters are fetched successfully
         if self.routeParameters == nil {
             print("Default route parameters not loaded")
         }
         
-        //set parameters to return directions
+        // set parameters to return directions
         self.routeParameters.returnDirections = true
         
-        //clear previous routes
+        // clear previous routes
         self.routeGraphicsOverlay.graphics.removeAllObjects()
         
-        //clear previous stops
+        // clear previous stops
         self.routeParameters.clearStops()
         
-        //set the stops
+        // set the stops
         let stop1 = AGSStop(point: self.stop1Geometry)
         stop1.name = "Origin"
         let stop2 = AGSStop(point: self.stop2Geometry)
@@ -125,9 +125,9 @@ class FindRouteViewController: UIViewController {
             if let error = error {
                 print(error)
             } else if let route = routeResult?.routes.first {
-                //show the resulting route on the map
-                //also save a reference to the route object
-                //in order to access directions
+                // show the resulting route on the map
+                // also save a reference to the route object
+                // in order to access directions
                 self.generatedRoute = route
                 let routeGraphic = AGSGraphic(geometry: self.generatedRoute.routeGeometry, symbol: self.routeSymbol(), attributes: nil)
                 self.routeGraphicsOverlay.graphics.add(routeGraphic)

--- a/arcgis-ios-sdk-samples/Route and directions/Route around barriers/RouteAroundBarriersViewController.swift
+++ b/arcgis-ios-sdk-samples/Route and directions/Route around barriers/RouteAroundBarriersViewController.swift
@@ -46,7 +46,7 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["RouteAroundBarriersViewController", "DirectionsListViewController", "RouteParametersViewController"]
         
         let map = AGSMap(basemapStyle: .arcGISTopographic)
@@ -54,23 +54,23 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
         self.mapView.map = map
         self.mapView.touchDelegate = self
         
-        //add the graphics overlays to the map view
+        // add the graphics overlays to the map view
         self.mapView.graphicsOverlays.addObjects(from: [routeGraphicsOverlay, directionsGraphicsOverlay, barrierGraphicsOverlay, stopGraphicsOverlay])
         
-        //zoom to viewpoint
+        // zoom to viewpoint
         self.mapView.setViewpointCenter(AGSPoint(x: -13042254.715252, y: 3857970.236806, spatialReference: .webMercator()), scale: 1e5)
         
-        //initialize route task
+        // initialize route task
         self.routeTask = AGSRouteTask(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/NetworkAnalysis/SanDiego/NAServer/Route")!)
         
-        //get default parameters
+        // get default parameters
         self.getDefaultParameters()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        //hide directions list
+        // hide directions list
         self.setRouteDetailsVisibility(visible: generatedRoute != nil, animated: false)
     }
 
@@ -82,26 +82,26 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
                 self?.presentAlert(error: error)
             } else {
                 self?.routeParameters = params
-                //enable bar button item
+                // enable bar button item
                 self?.routeParametersBBI.isEnabled = true
             }
         }
     }
     
     @IBAction func route() {
-        //add check
+        // add check
         if self.routeParameters == nil || self.stopGraphicsOverlay.graphics.count < 2 {
             presentAlert(message: "Either parameters not loaded or not sufficient stops")
             return
         }
         
-        //clear routes
+        // clear routes
         self.routeGraphicsOverlay.graphics.removeAllObjects()
         
         self.routeParameters.returnStops = true
         self.routeParameters.returnDirections = true
         
-        //add stops
+        // add stops
         var stops = [AGSStop]()
         for graphic in self.stopGraphicsOverlay.graphics as AnyObject as! [AGSGraphic] {
             let stop = AGSStop(point: graphic.geometry as! AGSPoint)
@@ -111,7 +111,7 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
         self.routeParameters.clearStops()
         self.routeParameters.setStops(stops)
         
-        //add barriers
+        // add barriers
         var barriers = [AGSPolygonBarrier]()
         for graphic in self.barrierGraphicsOverlay.graphics as AnyObject as! [AGSGraphic] {
             let polygon = graphic.geometry as! AGSPolygon
@@ -171,17 +171,17 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
     // MARK: - AGSGeoViewTouchDelegate
     
     func geoView(_ geoView: AGSGeoView, didTapAtScreenPoint screenPoint: CGPoint, mapPoint: AGSPoint) {
-        //normalize geometry
+        // normalize geometry
         let normalizedPoint = AGSGeometryEngine.normalizeCentralMeridian(of: mapPoint)!
         
         if segmentedControl.selectedSegmentIndex == 0 {
-            //create a graphic for stop and add to the graphics overlay
+            // create a graphic for stop and add to the graphics overlay
             let graphicsCount = self.stopGraphicsOverlay.graphics.count
             let symbol = self.symbolForStopGraphic(withIndex: graphicsCount + 1)
             let graphic = AGSGraphic(geometry: normalizedPoint, symbol: symbol, attributes: nil)
             self.stopGraphicsOverlay.graphics.add(graphic)
             
-            //enable route button
+            // enable route button
             if graphicsCount > 0 {
                 self.routeBBI.isEnabled = true
             }
@@ -246,7 +246,7 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
         }
     }
     
-    //MARk: - UIAdaptivePresentationControllerDelegate
+    // MARk: - UIAdaptivePresentationControllerDelegate
     
     func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
         return .none
@@ -261,14 +261,14 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
     }
     
     func directionsListViewController(_ directionsListViewController: DirectionsListViewController, didSelectDirectionManuever directionManeuver: AGSDirectionManeuver) {
-        //remove previous directions
+        // remove previous directions
         self.directionsGraphicsOverlay.graphics.removeAllObjects()
         
-        //show the maneuver geometry on the map view
+        // show the maneuver geometry on the map view
         let directionGraphic = AGSGraphic(geometry: directionManeuver.geometry!, symbol: self.directionSymbol(), attributes: nil)
         self.directionsGraphicsOverlay.graphics.add(directionGraphic)
         
-        //zoom to the direction
+        // zoom to the direction
         self.mapView.setViewpointGeometry(directionManeuver.geometry!.extent, padding: 100, completion: nil)
     }
 }

--- a/arcgis-ios-sdk-samples/Scenes/Add a point scene layer/AddPointSceneLayerViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Add a point scene layer/AddPointSceneLayerViewController.swift
@@ -41,7 +41,7 @@ class AddPointSceneLayerViewController: UIViewController {
         
         /// Add a point scene layer with points at world airport locations
         let pointSceneLayerURL = URL(string: "https://tiles.arcgis.com/tiles/V6ZHFr6zdgNZuVG0/arcgis/rest/services/Airports_PointSceneLayer/SceneServer/layers/0")!
-        //scene layer
+        // scene layer
         let sceneLayer = AGSArcGISSceneLayer(url: pointSceneLayerURL)
         scene.operationalLayers.add(sceneLayer)
         
@@ -51,7 +51,7 @@ class AddPointSceneLayerViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["AddPointSceneLayerViewController"]
     }
 }

--- a/arcgis-ios-sdk-samples/Scenes/Animate 3D graphic/Animate3DGraphicViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Animate 3D graphic/Animate3DGraphicViewController.swift
@@ -45,10 +45,10 @@ class Animate3DGraphicViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["Animate3DGraphicViewController", "MissionSettingsViewController", "CameraSettingsViewController", "PlaneStatsViewController", "OptionsTableViewController"]
         
-        //map
+        // map
         let map = AGSMap(basemapStyle: .arcGISStreets)
         mapView.map = map
         mapView.interactionOptions.isEnabled = false
@@ -56,49 +56,49 @@ class Animate3DGraphicViewController: UIViewController {
         mapView.layer.borderColor = UIColor.white.cgColor
         mapView.layer.borderWidth = 2
         
-        //hide attribution text for map view
+        // hide attribution text for map view
         mapView.isAttributionTextVisible = false
         
-        //initalize scene with imagery basemap
+        // initalize scene with imagery basemap
         let scene = AGSScene(basemap: .imagery())
         
-        //assign scene to scene view
+        // assign scene to scene view
         sceneView.scene = scene
         
         /// The url of the Terrain 3D ArcGIS REST Service.
         let worldElevationServiceURL = URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!
-        //elevation source
+        // elevation source
         let elevationSource = AGSArcGISTiledElevationSource(url: worldElevationServiceURL)
         
-        //surface
+        // surface
         let surface = AGSSurface()
         surface.elevationSources.append(elevationSource)
         scene.baseSurface = surface
         
-        //graphics overlay for scene view
+        // graphics overlay for scene view
         sceneGraphicsOverlay.sceneProperties?.surfacePlacement = .absolute
         sceneView.graphicsOverlays.add(sceneGraphicsOverlay)
         
-        //renderer for scene graphics overlay
+        // renderer for scene graphics overlay
         let renderer = AGSSimpleRenderer()
         
-        //expressions
+        // expressions
         renderer.sceneProperties?.headingExpression = "[HEADING]"
         renderer.sceneProperties?.pitchExpression = "[PITCH]"
         renderer.sceneProperties?.rollExpression = "[ROLL]"
         
-        //set renderer on the overlay
+        // set renderer on the overlay
         sceneGraphicsOverlay.renderer = renderer
         
-        //graphics overlay for map view
+        // graphics overlay for map view
         mapView.graphicsOverlays.add(mapGraphicsOverlay)
         
-        //renderer for map graphics overlay
+        // renderer for map graphics overlay
         let renderer2D = AGSSimpleRenderer()
         renderer2D.rotationExpression = "[ANGLE]"
         mapGraphicsOverlay.renderer = renderer2D
         
-        //route graphic
+        // route graphic
         let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: .blue, width: 1)
         let routeGraphic = AGSGraphic(geometry: nil, symbol: lineSymbol, attributes: nil)
         self.routeGraphic = routeGraphic
@@ -106,13 +106,13 @@ class Animate3DGraphicViewController: UIViewController {
         
         addPlane2D()
         
-        //add the plane model
+        // add the plane model
         addPlane3D()
         
-        //setup camera to follow the plane
+        // setup camera to follow the plane
         setupCamera()
         
-        //select the first mission by default
+        // select the first mission by default
         changeMissionAction()
     }
     
@@ -124,20 +124,20 @@ class Animate3DGraphicViewController: UIViewController {
     }
     
     private func addPlane3D() {
-        //model symbol
+        // model symbol
         let planeModelSymbol = AGSModelSceneSymbol(name: "Bristol", extension: "dae", scale: 20)
         planeModelSymbol.anchorPosition = .center
         
-        //arbitrary geometry for time being, the geometry will update with animation
+        // arbitrary geometry for time being, the geometry will update with animation
         let point = AGSPoint(x: 0, y: 0, z: 0, spatialReference: .wgs84())
         
-        //create graphic for the model
+        // create graphic for the model
         let planeModelGraphic = AGSGraphic()
         self.planeModelGraphic = planeModelGraphic
         planeModelGraphic.geometry = point
         planeModelGraphic.symbol = planeModelSymbol
         
-        //add graphic to the graphics overlay
+        // add graphic to the graphics overlay
         sceneGraphicsOverlay.graphics.add(planeModelGraphic)
     }
     
@@ -146,36 +146,36 @@ class Animate3DGraphicViewController: UIViewController {
             return
         }
         
-        //AGSOrbitGeoElementCameraController to follow plane graphic
-        //initialize object specifying the target geo element and distance to keep from it
+        // AGSOrbitGeoElementCameraController to follow plane graphic
+        // initialize object specifying the target geo element and distance to keep from it
         let orbitGeoElementCameraController = AGSOrbitGeoElementCameraController(targetGeoElement: planeModelGraphic, distance: 1000)
         self.orbitGeoElementCameraController = orbitGeoElementCameraController
         
-        //set camera to align its heading with the model
+        // set camera to align its heading with the model
         orbitGeoElementCameraController.isAutoHeadingEnabled = true
         
-        //will keep the camera still while the model pitches or rolls
+        // will keep the camera still while the model pitches or rolls
         orbitGeoElementCameraController.isAutoPitchEnabled = false
         orbitGeoElementCameraController.isAutoRollEnabled = false
         
-        //min and max distance values between the model and the camera
+        // min and max distance values between the model and the camera
         orbitGeoElementCameraController.minCameraDistance = 500
         orbitGeoElementCameraController.maxCameraDistance = 8000
         
-        //set the camera controller on scene view
+        // set the camera controller on scene view
         sceneView.cameraController = orbitGeoElementCameraController
     }
     
     private func loadMissionData(_ name: String) {
-        //get the path of the specified file in the bundle
+        // get the path of the specified file in the bundle
         if let path = Bundle.main.path(forResource: name, ofType: nil) {
-            //get content of the file
+            // get content of the file
             if let content = try? String(contentsOfFile: path) {
-                //split content into array of lines separated by new line character
-                //each line is one frame
+                // split content into array of lines separated by new line character
+                // each line is one frame
                 let lines = content.components(separatedBy: CharacterSet.newlines)
                 
-                //create a frame object for each line
+                // create a frame object for each line
                 frames = lines.map { (line) -> Frame in
                     let details = line.components(separatedBy: ",")
                     precondition(details.count == 6)
@@ -185,7 +185,7 @@ class Animate3DGraphicViewController: UIViewController {
                                             z: Double(details[2])!,
                                             spatialReference: .wgs84())
                     
-                    //load position, heading, pitch and roll for each frame
+                    // load position, heading, pitch and roll for each frame
                     return Frame(position: position,
                                  heading: Measurement(value: Double(details[3])!, unit: UnitAngle.degrees),
                                  pitch: Measurement(value: Double(details[4])!, unit: UnitAngle.degrees),
@@ -198,13 +198,13 @@ class Animate3DGraphicViewController: UIViewController {
     }
     
     private func startAnimation() {
-        //invalidate timer to stop previous ongoing animation
+        // invalidate timer to stop previous ongoing animation
         self.animationTimer?.invalidate()
         
-        //duration or interval
+        // duration or interval
         let duration = 1 / Double(animationSpeed)
         
-        //new timer
+        // new timer
         let animationTimer = Timer(timeInterval: duration, repeats: true) { [weak self] _ in
             self?.animate()
         }
@@ -213,67 +213,67 @@ class Animate3DGraphicViewController: UIViewController {
     }
     
     private func animate() {
-        //validations
+        // validations
         guard !frames.isEmpty,
             let planeModelGraphic = planeModelGraphic,
             let triangleGraphic = triangleGraphic else {
             return
         }
         
-        //if animation is complete
+        // if animation is complete
         if currentFrameIndex >= frames.count {
-            //invalidate timer
+            // invalidate timer
             animationTimer?.invalidate()
             
-            //update state
+            // update state
             isAnimating = false
             
-            //reset index
+            // reset index
             currentFrameIndex = 0
             
             return
         }
         
-        //else get the frame
+        // else get the frame
         let frame = frames[currentFrameIndex]
         
-        //update the properties on the model
+        // update the properties on the model
         planeModelGraphic.geometry = frame.position
         planeModelGraphic.attributes["HEADING"] = frame.heading.value
         planeModelGraphic.attributes["PITCH"] = frame.pitch.value
         planeModelGraphic.attributes["ROLL"] = frame.roll.value
         
-        //2D plane
+        // 2D plane
         triangleGraphic.geometry = frame.position
         
-        //set viewpoint for map view
+        // set viewpoint for map view
         let viewpoint = AGSViewpoint(center: frame.position, scale: 100000, rotation: 360 + frame.heading.value)
         mapView.setViewpoint(viewpoint)
         
-        //update progress
+        // update progress
         missionSettingsViewController?.progress = Float(currentFrameIndex) / Float(frames.count)
         
-        //update stats
+        // update stats
         planeStatsViewController?.frame = frame
         
-        //increment current frame index
+        // increment current frame index
         currentFrameIndex += 1
     }
     
     // MARK: - Actions
     
     @IBAction func changeMissionAction() {
-        //invalidate timer
+        // invalidate timer
         animationTimer?.invalidate()
         
-        //set play button
+        // set play button
         isAnimating = false
         
-        //new mission name
+        // new mission name
         let missionFileName = missionFileNames[selectedMissionIndex]
         loadMissionData(missionFileName)
         
-        //create a polyline from position in each frame to be used as path
+        // create a polyline from position in each frame to be used as path
         let points = frames.map { (frame) -> AGSPoint in
             return frame.position
         }
@@ -281,10 +281,10 @@ class Animate3DGraphicViewController: UIViewController {
         let polylineBuilder = AGSPolylineBuilder(points: points)
         routeGraphic?.geometry = polylineBuilder.toGeometry()
         
-        //set current frame to zero
+        // set current frame to zero
         currentFrameIndex = 0
         
-        //animate to first frame
+        // animate to first frame
         animate()
     }
     
@@ -307,10 +307,10 @@ class Animate3DGraphicViewController: UIViewController {
         if let controller = segue.destination as? CameraSettingsViewController {
             controller.orbitGeoElementCameraController = orbitGeoElementCameraController
             
-            //pop over settings
+            // pop over settings
             controller.presentationController?.delegate = self
             
-            //preferred content size
+            // preferred content size
             if traitCollection.horizontalSizeClass == .regular,
                 traitCollection.verticalSizeClass == .regular {
                 controller.preferredContentSize = CGSize(width: 300, height: 380)
@@ -320,18 +320,18 @@ class Animate3DGraphicViewController: UIViewController {
         } else if let planeStatsViewController = segue.destination as? PlaneStatsViewController {
             self.planeStatsViewController = planeStatsViewController
             
-            //pop over settings
+            // pop over settings
             planeStatsViewController.presentationController?.delegate = self
         } else if let navController = segue.destination as? UINavigationController,
             let controller = navController.viewControllers.first as? MissionSettingsViewController {
             self.missionSettingsViewController = controller
-            //initial values
+            // initial values
             controller.missionFileNames = missionFileNames
             controller.selectedMissionIndex = selectedMissionIndex
             controller.animationSpeed = animationSpeed
             controller.progress = Float(currentFrameIndex) / Float(frames.count)
             
-            //pop over settings
+            // pop over settings
             navController.presentationController?.delegate = self
             controller.preferredContentSize = CGSize(width: 300, height: 200)
             controller.delegate = self
@@ -357,7 +357,7 @@ extension Animate3DGraphicViewController: MissionSettingsViewControllerDelegate 
 
 extension Animate3DGraphicViewController: UIAdaptivePresentationControllerDelegate {
     func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
-        //for popover or non modal presentation
+        // for popover or non modal presentation
         return .none
     }
 }

--- a/arcgis-ios-sdk-samples/Scenes/Animate 3D graphic/CameraSettingsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Animate 3D graphic/CameraSettingsViewController.swift
@@ -105,41 +105,41 @@ class CameraSettingsViewController: UITableViewController {
     // MARK: - Actions
     
     @IBAction private func distanceValueChanged(sender: UISlider) {
-        //update property
+        // update property
         orbitGeoElementCameraController?.cameraDistance = Double(sender.value)
         
-        //update label
+        // update label
         updateUIForDistance()
     }
     
     @IBAction private func headingOffsetValueChanged(sender: UISlider) {
-        //update property
+        // update property
         orbitGeoElementCameraController?.cameraHeadingOffset = Double(sender.value)
         
-        //update label
+        // update label
         updateUIForHeadingOffset()
     }
     
     @IBAction private func pitchOffsetValueChanged(sender: UISlider) {
-        //update property
+        // update property
         orbitGeoElementCameraController?.cameraPitchOffset = Double(sender.value)
         
-        //update label
+        // update label
         updateUIForPitchOffset()
     }
     
     @IBAction private func autoHeadingEnabledValueChanged(sender: UISwitch) {
-        //update property
+        // update property
         orbitGeoElementCameraController?.isAutoHeadingEnabled = sender.isOn
     }
     
     @IBAction private func autoPitchEnabledValueChanged(sender: UISwitch) {
-        //update property
+        // update property
         orbitGeoElementCameraController?.isAutoPitchEnabled = sender.isOn
     }
     
     @IBAction private func autoRollEnabledValueChanged(sender: UISwitch) {
-        //update property
+        // update property
         orbitGeoElementCameraController?.isAutoRollEnabled = sender.isOn
     }
 }

--- a/arcgis-ios-sdk-samples/Scenes/Display a scene/DisplaySceneViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Display a scene/DisplaySceneViewController.swift
@@ -23,15 +23,15 @@ class DisplaySceneViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["DisplaySceneViewController"]
         
-        //initialize scene with topographic basemap
+        // initialize scene with topographic basemap
         let scene = AGSScene(basemap: .imagery())
-        //assign scene to the scene view
+        // assign scene to the scene view
         self.sceneView.scene = scene
         
-        //set the viewpoint camera
+        // set the viewpoint camera
         let camera = AGSCamera(latitude: 45.74, longitude: 6.88, altitude: 4500, heading: 10, pitch: 70, roll: 0)
         self.sceneView.setViewpointCamera(camera)
         

--- a/arcgis-ios-sdk-samples/Scenes/Distance composite symbol/DistanceCompositeSymbolViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Distance composite symbol/DistanceCompositeSymbolViewController.swift
@@ -23,12 +23,12 @@ class DistanceCompositeSymbolViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["DistanceCompositeSymbolViewController"]
         
-        //initialize scene with topographic basemap
+        // initialize scene with topographic basemap
         let scene = AGSScene(basemap: .imagery())
-        //assign scene to the scene view
+        // assign scene to the scene view
         self.sceneView.scene = scene
         
         // add base surface for elevation data

--- a/arcgis-ios-sdk-samples/Scenes/Extrude graphics/ExtrudeGraphicsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Extrude graphics/ExtrudeGraphicsViewController.swift
@@ -30,23 +30,23 @@ class ExtrudeGraphicsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["ExtrudeGraphicsViewController"]
         
-        //initialize scene with topographic basemap
+        // initialize scene with topographic basemap
         let scene = AGSScene(basemap: .topographic())
-        //assign scene to the scene view
+        // assign scene to the scene view
         self.sceneView.scene = scene
         
-        //set the viewpoint camera
+        // set the viewpoint camera
         let camera = AGSCamera(location: self.cameraStartingPoint, heading: 10, pitch: 70, roll: 0)
         self.sceneView.setViewpointCamera(camera)
         
-        //add graphics overlay
+        // add graphics overlay
         graphicsOverlay.sceneProperties?.surfacePlacement = .drapedBillboarded
         self.sceneView.graphicsOverlays.add(graphicsOverlay)
         
-        //simple renderer with extrusion property
+        // simple renderer with extrusion property
         let renderer = AGSSimpleRenderer()
         let lineSymbol = AGSSimpleLineSymbol(style: .solid, color: .white, width: 1)
         renderer.symbol = AGSSimpleFillSymbol(style: .solid, color: .accentColor, outline: lineSymbol)
@@ -62,16 +62,16 @@ class ExtrudeGraphicsViewController: UIViewController {
         surface.elevationSources.append(elevationSource)
         scene.baseSurface = surface
         
-        //add the graphics
+        // add the graphics
         self.addGraphics()
     }
     
     private func addGraphics() {
-        //starting point
+        // starting point
         let x = cameraStartingPoint.x - 0.01
         let y = cameraStartingPoint.y + 0.25
         
-        //creating a grid of polygon graphics
+        // creating a grid of polygon graphics
         for column in stride(from: 0.0, through: 6.0, by: 1.0) {
             for row in stride(from: 0.0, through: 4.0, by: 1.0) {
                 let startingX = x + column * (squareSize + spacing)
@@ -83,8 +83,8 @@ class ExtrudeGraphicsViewController: UIViewController {
         }
     }
     
-    //the function returns a polygon starting at the given point
-    //with size equal to squareSize
+    // the function returns a polygon starting at the given point
+    // with size equal to squareSize
     private func polygonForStartingPoint(_ point: AGSPoint) -> AGSPolygon {
         let polygon = AGSPolygonBuilder(spatialReference: .wgs84())
         polygon.addPointWith(x: point.x, y: point.y)
@@ -94,7 +94,7 @@ class ExtrudeGraphicsViewController: UIViewController {
         return polygon.toGeometry()
     }
     
-    //add a graphic to the graphics overlay for the given polygon
+    // add a graphic to the graphics overlay for the given polygon
     private func addGraphicForPolygon(_ polygon: AGSPolygon) {
         let rand = Int.random(in: 0...maxHeight)
         

--- a/arcgis-ios-sdk-samples/Scenes/Scene layer (URL)/SceneLayerURLViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Scene layer (URL)/SceneLayerURLViewController.swift
@@ -23,16 +23,16 @@ class SceneLayerURLViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["SceneLayerURLViewController"]
         
-        //initialize scene with topographic basemap
+        // initialize scene with topographic basemap
         let scene = AGSScene(basemap: .imagery())
         
-        //assign scene to the scene view
+        // assign scene to the scene view
         self.sceneView.scene = scene
         
-        //set the viewpoint camera
+        // set the viewpoint camera
         let point = AGSPoint(x: -4.49779155626782, y: 48.38282454039932, z: 62.013264927081764, spatialReference: .wgs84())
         let camera = AGSCamera(location: point, heading: 41.64729875588979, pitch: 71.2017391571523, roll: 0)
         self.sceneView.setViewpointCamera(camera)
@@ -47,7 +47,7 @@ class SceneLayerURLViewController: UIViewController {
         
         /// The url of the scene service for buildings in Brest, France.
         let brestBuildingsServiceURL = URL(string: "https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0")!
-        //scene layer
+        // scene layer
         let sceneLayer = AGSArcGISSceneLayer(url: brestBuildingsServiceURL)
         self.sceneView.scene?.operationalLayers.add(sceneLayer)
     }

--- a/arcgis-ios-sdk-samples/Scenes/Scene properties expressions/ScenePropertiesExpressionsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Scene properties expressions/ScenePropertiesExpressionsViewController.swift
@@ -26,35 +26,35 @@ class ScenePropertiesExpressionsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["ScenePropertiesExpressionsViewController"]
         
-        //initialize scene with streets basemap
+        // initialize scene with streets basemap
         let scene = AGSScene(basemap: .streets())
-        //assign scene to the scene view
+        // assign scene to the scene view
         self.sceneView.scene = scene
         
-        //set the viewpoint camera
+        // set the viewpoint camera
         let point = AGSPoint(x: 83.9, y: 28.4, z: 5200, spatialReference: .wgs84())
         let camera = AGSCamera(lookAt: point, distance: 1000, heading: 0, pitch: 50, roll: 0)
         self.sceneView.setViewpointCamera(camera)
         
-        //create a graphics overlay
+        // create a graphics overlay
         let graphicsOverlay = AGSGraphicsOverlay()
         graphicsOverlay.sceneProperties?.surfacePlacement = .relative
         
-        //add it to the scene view
+        // add it to the scene view
         self.sceneView.graphicsOverlays.add(graphicsOverlay)
         
-        //add renderer using rotation expressions
+        // add renderer using rotation expressions
         let renderer = AGSSimpleRenderer()
         renderer.sceneProperties?.headingExpression = "[HEADING]"
         renderer.sceneProperties?.pitchExpression = "[PITCH]"
         graphicsOverlay.renderer = renderer
         
-        //create a red cone graphic
+        // create a red cone graphic
         let coneSymbol = AGSSimpleMarkerSceneSymbol(style: .cone, color: .red, height: 200, width: 100, depth: 100, anchorPosition: .center)
-        coneSymbol.pitch = -90  //correct symbol's default pitch
+        coneSymbol.pitch = -90  // correct symbol's default pitch
         let conePoint = AGSPoint(x: 83.9, y: 28.404, z: 5000, spatialReference: .wgs84())
         let coneAttributes = ["HEADING": 0, "PITCH": 0]
         let coneGraphic = AGSGraphic(geometry: conePoint, symbol: coneSymbol, attributes: coneAttributes)
@@ -64,13 +64,13 @@ class ScenePropertiesExpressionsViewController: UIViewController {
     
     @IBAction func headingSliderValueChanged(_ slider: UISlider) {
         coneGraphic.attributes["HEADING"] = slider.value
-        //update label
+        // update label
         self.headingLabel.text = "\(Int(slider.value))"
     }
     
     @IBAction func pitchSliderValueChanged(_ slider: UISlider) {
         coneGraphic.attributes["PITCH"] = slider.value
-        //update label
+        // update label
         self.pitchLabel.text = "\(Int(slider.value))"
     }
 }

--- a/arcgis-ios-sdk-samples/Scenes/Terrain exaggeration/TerrainExaggerationViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Terrain exaggeration/TerrainExaggerationViewController.swift
@@ -20,34 +20,34 @@ class TerrainExaggerationViewController: UIViewController {
     @IBOutlet weak var exaggerationSlider: UISlider!
     @IBOutlet weak var sceneView: AGSSceneView!
     
-    //initialize scene with streets basemap
+    // initialize scene with streets basemap
     let scene = AGSScene(basemapStyle: .arcGISStreets)
     
-    //initialize surface
+    // initialize surface
     let surface = AGSSurface()
     
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["TerrainExaggerationViewController"]
         
         /// The url of the Terrain 3D ArcGIS REST Service.
         let worldElevationServiceURL = URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!
-        //initialize surface and add it to scene
+        // initialize surface and add it to scene
         let elevation = AGSArcGISTiledElevationSource(url: worldElevationServiceURL)
         surface.elevationSources.append(elevation)
         scene.baseSurface = surface
         
-        //assign scene to scene view
+        // assign scene to scene view
         self.sceneView.scene = scene
         
-        //set up initial camera location
+        // set up initial camera location
         let initialLocation = AGSPoint(x: -119.94891542688772, y: 46.75792111605992, spatialReference: sceneView.spatialReference)
         let camera = AGSCamera(lookAt: initialLocation, distance: 15000.0, heading: 40.0, pitch: 60.0, roll: 0.0)
         sceneView.setViewpointCamera(camera)
         
-        //set up initial slider values
+        // set up initial slider values
         exaggerationSlider.minimumValue = 1
         exaggerationSlider.maximumValue = 10
         exaggerationSlider.isContinuous = true
@@ -55,10 +55,10 @@ class TerrainExaggerationViewController: UIViewController {
     }
 
     @IBAction func sliderValueChanged(_ sender: UISlider) {
-        //assign slider value to elevation exaggeration
+        // assign slider value to elevation exaggeration
         surface.elevationExaggeration = sender.value
         
-        //display current exaggeration value
+        // display current exaggeration value
         exaggerationValue.text = String(format: "%.1fx", sender.value)
     }
 }

--- a/arcgis-ios-sdk-samples/Scenes/View content beneath the terrain surface/ViewContentBeneathTerrainSurfaceViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/View content beneath the terrain surface/ViewContentBeneathTerrainSurfaceViewController.swift
@@ -26,10 +26,10 @@ class ViewContentBeneathTerrainSurfaceViewController: UIViewController {
     ///
     /// - Returns: A new `AGSScene` object.
     func makeScene() -> AGSScene {
-        //initialize portal with AGOL
+        // initialize portal with AGOL
         let portal = AGSPortal.arcGISOnline(withLoginRequired: false)
         
-        //get the portal item
+        // get the portal item
         let portalItem = AGSPortalItem(portal: portal, itemID: "91a4fafd747a47c7bab7797066cb9272")
         
         let scene = AGSScene(item: portalItem)
@@ -44,7 +44,7 @@ class ViewContentBeneathTerrainSurfaceViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["ViewContentBeneathTerrainSurfaceViewController"]
     }
 }

--- a/arcgis-ios-sdk-samples/Scenes/View point cloud data offline/ViewPointCloudDataOfflineViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/View point cloud data offline/ViewPointCloudDataOfflineViewController.swift
@@ -71,7 +71,7 @@ class ViewPointCloudDataOfflineViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["ViewPointCloudDataOfflineViewController"]
     }
 }

--- a/arcgis-ios-sdk-samples/Search/Find address/FindAddressViewController.swift
+++ b/arcgis-ios-sdk-samples/Search/Find address/FindAddressViewController.swift
@@ -29,32 +29,32 @@ class FindAddressViewController: UIViewController, AGSGeoViewTouchDelegate, UISe
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["FindAddressViewController", "WorldAddressesViewController"]
         
-        //instantiate a map with an imagery with labels basemap
+        // instantiate a map with an imagery with labels basemap
         let map = AGSMap(basemapStyle: .arcGISImagery)
         self.mapView.map = map
         self.mapView.touchDelegate = self
         
-        //add the graphics overlay to the map view
+        // add the graphics overlay to the map view
         self.mapView.graphicsOverlays.add(self.graphicsOverlay)
         
-        //initialize locator task
+        // initialize locator task
         self.locatorTask = AGSLocatorTask(url: URL(string: self.locatorURL)!)
         
-        //initialize geocode parameters
+        // initialize geocode parameters
         self.geocodeParameters = AGSGeocodeParameters()
         self.geocodeParameters.resultAttributeNames.append(contentsOf: ["*"])
         self.geocodeParameters.minScore = 75
         
-        //register self for the keyboard show notification
-        //in order to un hide the cancel button for search
+        // register self for the keyboard show notification
+        // in order to un hide the cancel button for search
         NotificationCenter.default.addObserver(self, selector: #selector(FindAddressViewController.keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
     }
     
-    //method that returns a graphic object for the specified point and attributes
-    //also sets the leader offset and offset
+    // method that returns a graphic object for the specified point and attributes
+    // also sets the leader offset and offset
     private func graphicForPoint(_ point: AGSPoint, attributes: [String: AnyObject]?) -> AGSGraphic {
         let markerImage = UIImage(named: "RedMarker")!
         let symbol = AGSPictureMarkerSymbol(image: markerImage)
@@ -65,13 +65,13 @@ class FindAddressViewController: UIViewController, AGSGeoViewTouchDelegate, UISe
     }
     
     private func geocodeSearchText(_ text: String) {
-        //clear already existing graphics
+        // clear already existing graphics
         self.graphicsOverlay.graphics.removeAllObjects()
         
-        //dismiss the callout if already visible
+        // dismiss the callout if already visible
         self.mapView.callout.dismiss()
         
-        //perform geocode with input text
+        // perform geocode with input text
         self.locatorTask.geocode(withSearchText: text, parameters: self.geocodeParameters) { [weak self] (results: [AGSGeocodeResult]?, error: Error?) in
             guard let self = self else {
                 return
@@ -80,15 +80,15 @@ class FindAddressViewController: UIViewController, AGSGeoViewTouchDelegate, UISe
             if let error = error {
                 self.presentAlert(error: error)
             } else if let result = results?.first {
-                //create a graphic for the first result and add to the graphics overlay
+                // create a graphic for the first result and add to the graphics overlay
                 let graphic = self.graphicForPoint(result.displayLocation!, attributes: result.attributes as [String: AnyObject]?)
                 self.graphicsOverlay.graphics.add(graphic)
-                //zoom to the extent of the result
+                // zoom to the extent of the result
                 if let extent = result.extent {
                     self.mapView.setViewpointGeometry(extent, completion: nil)
                 }
             } else {
-                //provide feedback in case of failure
+                // provide feedback in case of failure
                 self.presentAlert(message: "No results found")
             }
         }
@@ -96,9 +96,9 @@ class FindAddressViewController: UIViewController, AGSGeoViewTouchDelegate, UISe
     
     // MARK: - Callout
     
-    //method shows the callout for the specified graphic,
-    //populates the title and detail of the callout with specific attributes
-    //hides the accessory button
+    // method shows the callout for the specified graphic,
+    // populates the title and detail of the callout with specific attributes
+    // hides the accessory button
     private func showCalloutForGraphic(_ graphic: AGSGraphic, tapLocation: AGSPoint) {
         let addressType = graphic.attributes["Addr_type"] as! String
         self.mapView.callout.title = graphic.attributes["Match_addr"] as? String ?? ""
@@ -116,15 +116,15 @@ class FindAddressViewController: UIViewController, AGSGeoViewTouchDelegate, UISe
     // MARK: - AGSGeoViewTouchDelegate
     
     func geoView(_ geoView: AGSGeoView, didTapAtScreenPoint screenPoint: CGPoint, mapPoint: AGSPoint) {
-        //dismiss the callout
+        // dismiss the callout
         self.mapView.callout.dismiss()
         
-        //identify graphics at the tapped location
+        // identify graphics at the tapped location
         self.mapView.identify(self.graphicsOverlay, screenPoint: screenPoint, tolerance: 12, returnPopupsOnly: false, maximumResults: 1) { (result: AGSIdentifyGraphicsOverlayResult) in
             if let error = result.error {
                 self.presentAlert(error: error)
             } else if let graphic = result.graphics.first {
-                //show callout for the graphic
+                // show callout for the graphic
                 self.showCalloutForGraphic(graphic, tapLocation: mapPoint)
             }
         }

--- a/arcgis-ios-sdk-samples/Search/Find place/FindPlaceViewController.swift
+++ b/arcgis-ios-sdk-samples/Search/Find place/FindPlaceViewController.swift
@@ -57,27 +57,27 @@ class FindPlaceViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["FindPlaceViewController"]
         
-        //create an instance of a map with ESRI topographic basemap
+        // create an instance of a map with ESRI topographic basemap
         self.map = AGSMap(basemapStyle: .arcGISTopographic)
         
-        //assign the map to the map view
+        // assign the map to the map view
         self.mapView.map = self.map
         self.mapView.touchDelegate = self
         
-        //start location display
+        // start location display
         self.mapView.locationDisplay.autoPanMode = .recenter
         self.mapView.locationDisplay.start { [weak self] (error: Error?) in
             if error == nil {
-                //if the location display starts, update the preferred search location
-                //textfield's text
+                // if the location display starts, update the preferred search location
+                // textfield's text
                 self?.preferredSearchLocationTextField.text = self!.currentLocationText
             }
         }
         
-        //logic to show the extent search button
+        // logic to show the extent search button
         self.mapView.viewpointChangedHandler = { [weak self] in
             DispatchQueue.main.async {
                 if self?.canDoExtentSearch ?? false {
@@ -86,27 +86,27 @@ class FindPlaceViewController: UIViewController {
             }
         }
         
-        //add the graphicsOverlay to the map view
+        // add the graphicsOverlay to the map view
         self.mapView.graphicsOverlays.add(graphicsOverlay)
         
-        //initialize locator task
+        // initialize locator task
         self.locatorTask = AGSLocatorTask(url: URL(string: "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer")!)
         
-        //hide suggest result table view by default
+        // hide suggest result table view by default
         self.animateTableView(expand: false)
         
-        //hide the overlay view by default
+        // hide the overlay view by default
         self.overlayView.isHidden = true
         
-        //register for keyboard notification in order to toggle overlay view on and off
+        // register for keyboard notification in order to toggle overlay view on and off
         NotificationCenter.default.addObserver(self, selector: #selector(FindPlaceViewController.showOverlayView), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(FindPlaceViewController.hideOverlayView), name: UIResponder.keyboardWillHideNotification, object: nil)
         
-        //add the left view images for both the textfields
+        // add the left view images for both the textfields
         self.setupTextFieldLeftViews()
     }
     
-    //method to show search icon and pin icon for the textfields
+    // method to show search icon and pin icon for the textfields
     private func setupTextFieldLeftViews() {
         var leftView = self.textFieldViewWithImage("SearchIcon")
         self.poiTextField.leftView = leftView
@@ -117,8 +117,8 @@ class FindPlaceViewController: UIViewController {
         self.preferredSearchLocationTextField.leftViewMode = .always
     }
     
-    //method returns a UIView with an imageView as the subview
-    //with an image instantiated using the name provided
+    // method returns a UIView with an imageView as the subview
+    // with an image instantiated using the name provided
     private func textFieldViewWithImage(_ imageName: String) -> UIView {
         let view = UIView(frame: CGRect(x: 0, y: 0, width: 25, height: 30))
         let imageView = UIImageView(image: UIImage(named: imageName))
@@ -127,7 +127,7 @@ class FindPlaceViewController: UIViewController {
         return view
     }
     
-    //method to toggle the suggestions table view on and off
+    // method to toggle the suggestions table view on and off
     private func animateTableView(expand: Bool) {
         if (expand != self.isTableViewVisible) && !self.isTableViewAnimating {
             self.isTableViewAnimating = true
@@ -145,16 +145,16 @@ class FindPlaceViewController: UIViewController {
         }
     }
     
-    //method to clear prefered location information
-    //hide the suggestions table view, empty previously selected
-    //suggest result and previously fetch search location
+    // method to clear prefered location information
+    // hide the suggestions table view, empty previously selected
+    // suggest result and previously fetch search location
     private func clearPreferredLocationInfo() {
         self.animateTableView(expand: false)
         self.selectedSuggestResult = nil
         self.preferredSearchLocation = nil
     }
     
-    //method to show callout for a graphic
+    // method to show callout for a graphic
     private func showCalloutForGraphic(_ graphic: AGSGraphic, tapLocation: AGSPoint) {
         let addressType = graphic.attributes["Addr_type"] as! String
         self.mapView.callout.title = graphic.attributes["Match_addr"] as? String ?? ""
@@ -168,7 +168,7 @@ class FindPlaceViewController: UIViewController {
         self.mapView.callout.show(for: graphic, tapLocation: tapLocation, animated: true)
     }
     
-    //method returns a graphic object for the specified point and attributes
+    // method returns a graphic object for the specified point and attributes
     private func graphicForPoint(_ point: AGSPoint, attributes: [String: AnyObject]?) -> AGSGraphic {
         let markerImage = UIImage(named: "RedMarker")!
         let symbol = AGSPictureMarkerSymbol(image: markerImage)
@@ -178,7 +178,7 @@ class FindPlaceViewController: UIViewController {
         return graphic
     }
     
-    //method to zoom to an array of graphics
+    // method to zoom to an array of graphics
     func zoomToGraphics(_ graphics: [AGSGraphic]) {
         if let spatialReference = graphics.first?.geometry?.spatialReference {
             let multipoint = AGSMultipointBuilder(spatialReference: spatialReference)
@@ -199,37 +199,37 @@ class FindPlaceViewController: UIViewController {
     }
     
     private func fetchSuggestions(_ string: String, suggestionType: SuggestionType, textField: UITextField) {
-        //cancel previous requests
+        // cancel previous requests
         if self.suggestRequestOperation != nil {
             self.suggestRequestOperation.cancel()
         }
         
-        //initialize suggest parameters
+        // initialize suggest parameters
         let suggestParameters = AGSSuggestParameters()
         let flag: Bool = (suggestionType == SuggestionType.poi)
         suggestParameters.categories = flag ? ["POI"] : ["Populated Place"]
         suggestParameters.preferredSearchLocation = flag ? nil : self.mapView.locationDisplay.mapLocation
         
-        //get suggestions
+        // get suggestions
         self.suggestRequestOperation = self.locatorTask.suggest(withSearchText: string, parameters: suggestParameters) { [weak self] (suggestResults, error) in
-            //check if the search string has not changed in the meanwhile
+            // check if the search string has not changed in the meanwhile
             guard string == textField.text else { return }
             
             if let error = error {
                 print(error.localizedDescription)
             } else if let suggestResults = suggestResults {
-                //update the suggest results and reload the table
+                // update the suggest results and reload the table
                 self?.suggestResults = suggestResults
             }
         }
     }
     
     private func geocodeUsingSuggestResult(_ suggestResult: AGSSuggestResult, completion: @escaping () -> Void) {
-        //create geocode params
+        // create geocode params
         let params = AGSGeocodeParameters()
         params.outputSpatialReference = self.mapView.spatialReference
         
-        //geocode with selected suggest result
+        // geocode with selected suggest result
         self.locatorTask.geocode(with: suggestResult, parameters: params) { [weak self] (result: [AGSGeocodeResult]?, error: Error?) in
             if let error = error {
                 print(error.localizedDescription)
@@ -243,24 +243,24 @@ class FindPlaceViewController: UIViewController {
     }
     
     private func geocodePOIs(_ poi: String, location: AGSPoint?, extent: AGSGeometry?) {
-        //hide callout if already visible
+        // hide callout if already visible
         self.mapView.callout.dismiss()
         
-        //hide extent search button
+        // hide extent search button
         self.canDoExtentSearch = false
         self.extentSearchButton.isHidden = true
         
-        //remove all previous graphics
+        // remove all previous graphics
         self.graphicsOverlay.graphics.removeAllObjects()
         
-        //parameters for geocoding POIs
+        // parameters for geocoding POIs
         let params = AGSGeocodeParameters()
         params.preferredSearchLocation = location
         params.searchArea = extent
         params.outputSpatialReference = self.mapView.spatialReference
         params.resultAttributeNames.append(contentsOf: ["*"])
             
-        //geocode using the search text and params
+        // geocode using the search text and params
         self.locatorTask.geocode(withSearchText: poi, parameters: params) { [weak self] (results: [AGSGeocodeResult]?, error: Error?) in
             if let error = error {
                 print(error.localizedDescription)
@@ -274,26 +274,26 @@ class FindPlaceViewController: UIViewController {
     func handleGeocodeResultsForPOIs(_ geocodeResults: [AGSGeocodeResult]?, areExtentBased: Bool) {
         if let results = geocodeResults,
             !results.isEmpty {
-            //show the graphics on the map
+            // show the graphics on the map
             for result in results {
                 let graphic = self.graphicForPoint(result.displayLocation!, attributes: result.attributes as [String: AnyObject]?)
                 
                 self.graphicsOverlay.graphics.add(graphic)
             }
             
-            //extent search button display logic
-            //if search was not based on extent, then zoom to the graphics. On completion
-            //set the canDoExtentSearch flag to true
-            //else if search is based on extent, no need to zoom, simply set the flag to true
+            // extent search button display logic
+            // if search was not based on extent, then zoom to the graphics. On completion
+            // set the canDoExtentSearch flag to true
+            // else if search is based on extent, no need to zoom, simply set the flag to true
             if !areExtentBased {
                 self.zoomToGraphics(self.graphicsOverlay.graphics as AnyObject as! [AGSGraphic])
             } else {
                 self.canDoExtentSearch = true
             }
         } else {
-            //show alert for no results
+            // show alert for no results
             print("No results found")
-            //set canDoExtentSearch flag to true, so that if the user pans, the button becomes visible
+            // set canDoExtentSearch flag to true, so that if the user pans, the button becomes visible
             self.canDoExtentSearch = true
         }
     }
@@ -301,28 +301,28 @@ class FindPlaceViewController: UIViewController {
     // MARK: - Actions
     
     private func search() {
-        //validation
+        // validation
         guard let poi = self.poiTextField.text, !poi.isEmpty else {
             print("Point of interest required")
             return
         }
         
-        //cancel previous requests
+        // cancel previous requests
         if self.suggestRequestOperation != nil {
             self.suggestRequestOperation.cancel()
         }
         
-        //hide the table view
+        // hide the table view
         self.animateTableView(expand: false)
         
-        //check if a suggestion is present
+        // check if a suggestion is present
         if self.selectedSuggestResult != nil {
-            //since a suggestion is selected, check if it was already geocoded to a location
-            //if no, then goecode the suggestion
-            //else use the geocoded location, to find the POIs
+            // since a suggestion is selected, check if it was already geocoded to a location
+            // if no, then goecode the suggestion
+            // else use the geocoded location, to find the POIs
             if self.preferredSearchLocation == nil {
                 self.geocodeUsingSuggestResult(self.selectedSuggestResult) { [weak self] in
-                    //find the POIs wrt location
+                    // find the POIs wrt location
                     self?.geocodePOIs(poi, location: self!.preferredSearchLocation, extent: nil)
                 }
             } else {
@@ -413,15 +413,15 @@ extension FindPlaceViewController: UITableViewDelegate {
 
 extension FindPlaceViewController: AGSGeoViewTouchDelegate {
     func geoView(_ geoView: AGSGeoView, didTapAtScreenPoint screenPoint: CGPoint, mapPoint: AGSPoint) {
-        //dismiss the callout if already visible
+        // dismiss the callout if already visible
         self.mapView.callout.dismiss()
         
-        //identify graphics at the tapped location
+        // identify graphics at the tapped location
         self.mapView.identify(self.graphicsOverlay, screenPoint: screenPoint, tolerance: 12, returnPopupsOnly: false, maximumResults: 1) { (result: AGSIdentifyGraphicsOverlayResult) in
             if let error = result.error {
                 print(error)
             } else if let graphic = result.graphics.first {
-                //show callout for the first graphic in the array
+                // show callout for the first graphic in the array
                 self.showCalloutForGraphic(graphic, tapLocation: mapPoint)
             }
         }

--- a/arcgis-ios-sdk-samples/Search/Offline geocode/SanDiegoAddressesViewController.swift
+++ b/arcgis-ios-sdk-samples/Search/Offline geocode/SanDiegoAddressesViewController.swift
@@ -21,7 +21,7 @@ protocol SanDiegoAddressesViewControllerDelegate: AnyObject {
 class SanDiegoAddressesViewController: UITableViewController {
     weak var delegate: SanDiegoAddressesViewControllerDelegate?
     
-    //prepopulated list of addresses
+    // prepopulated list of addresses
     private var addresses = [
         "910 N Harbor Dr, San Diego, CA 92101",
         "2920 Zoo Dr, San Diego, CA 92101",

--- a/arcgis-ios-sdk-samples/Search/Reverse geocode/ReverseGeocodeViewController.swift
+++ b/arcgis-ios-sdk-samples/Search/Reverse geocode/ReverseGeocodeViewController.swift
@@ -29,51 +29,51 @@ class ReverseGeocodeViewController: UIViewController, AGSGeoViewTouchDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["ReverseGeocodeViewController"]
         
-        //create an instance of a map with ESRI topographic basemap
+        // create an instance of a map with ESRI topographic basemap
         self.map = AGSMap(basemapStyle: .arcGISTopographic)
         
         self.mapView.map = self.map
         self.mapView.touchDelegate = self
         
-        //add the graphics overlay
+        // add the graphics overlay
         self.mapView.graphicsOverlays.add(self.graphicsOverlay)
         
-        //zoom to a specific extent
+        // zoom to a specific extent
         self.mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: -117.195, y: 34.058, spatialReference: .wgs84()), scale: 5e4))
         
-        //initialize locator task
+        // initialize locator task
         self.locatorTask = AGSLocatorTask(url: URL(string: self.locatorURL)!)
         
-        //initialize parameters
+        // initialize parameters
         self.reverseGeocodeParameters = AGSReverseGeocodeParameters()
         self.reverseGeocodeParameters.maxResults = 1
     }
     
     private func reverseGeocode(_ point: AGSPoint) {
-        //cancel previous request
+        // cancel previous request
         if self.cancelable != nil {
             self.cancelable.cancel()
         }
         
-        //hide the callout
+        // hide the callout
         self.mapView.callout.dismiss()
         
-        //remove already existing graphics
+        // remove already existing graphics
         self.graphicsOverlay.graphics.removeAllObjects()
         
-        //normalize point
+        // normalize point
         let normalizedPoint = AGSGeometryEngine.normalizeCentralMeridian(of: point) as! AGSPoint
         
         let graphic = self.graphicForPoint(normalizedPoint)
         self.graphicsOverlay.graphics.add(graphic)
             
-        //reverse geocode
+        // reverse geocode
         self.cancelable = self.locatorTask.reverseGeocode(withLocation: normalizedPoint, parameters: self.reverseGeocodeParameters) { [weak self] (results: [AGSGeocodeResult]?, error: Error?) in
             if let error = error as NSError? {
-                if error.code != NSUserCancelledError { //user canceled error
+                if error.code != NSUserCancelledError { // user canceled error
                     self?.presentAlert(error: error)
                 }
             } else if let result = results?.first {
@@ -87,7 +87,7 @@ class ReverseGeocodeViewController: UIViewController, AGSGeoViewTouchDelegate {
         }
     }
     
-    //method returns a graphic object for the specified point and attributes
+    // method returns a graphic object for the specified point and attributes
     private func graphicForPoint(_ point: AGSPoint) -> AGSGraphic {
         let markerImage = UIImage(named: "RedMarker")!
         let symbol = AGSPictureMarkerSymbol(image: markerImage)
@@ -97,9 +97,9 @@ class ReverseGeocodeViewController: UIViewController, AGSGeoViewTouchDelegate {
         return graphic
     }
     
-    //method to show callout for the graphic
-    //it gets the attributes from the graphic and populates the title
-    //and detail for the callout
+    // method to show callout for the graphic
+    // it gets the attributes from the graphic and populates the title
+    // and detail for the callout
     private func showCalloutForGraphic(_ graphic: AGSGraphic, tapLocation: AGSPoint) {
         let cityString = graphic.attributes["City"] as? String ?? ""
         let addressString = graphic.attributes["Address"] as? String ?? ""

--- a/arcgis-ios-sdk-samples/Utility network/Trace utility network/TraceUtilityNetworkViewController.swift
+++ b/arcgis-ios-sdk-samples/Utility network/Trace utility network/TraceUtilityNetworkViewController.swift
@@ -100,7 +100,7 @@ class TraceUtilityNetworkViewController: UIViewController, AGSGeoViewTouchDelega
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //add the source code button item to the right of navigation bar
+        // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["TraceUtilityNetworkViewController"]
         
         // Initialize the UI


### PR DESCRIPTION
In SwiftLint 0.42.0 the new `comment_spacing` rule (Prefer at least one space after slashes for comments) gives hundreds of warnings. This PR runs `swiftlint autocorrect` in the root directory to correct these issues.

Initially I tried to batch find and replace the comment strings, but it introduced too many unwanted changes. For example, when I replace `//set up the map` by finding `//s` and replace it to `// S`, it will also replace the string `https://sampleserver6...`. So I retreat to the built-in autocorrect tool in SwiftLint.

I don't know if we want to go with this for now, because it only addresses the spacing, but not capitalization or punctuation formatting. 

@philium can you weigh in here? We have a few options
- Don't make this fix, and temporarily disable the rule
- ✅  Apply this PR, and wait for future improvements to the comment strings
- Use this PR as a base branch, and incrementally fix all the comment manually