### PR TITLE
[Fix] Slider default value bug in iOS 14

### DIFF
--- a/arcgis-ios-sdk-samples/Analysis/Line of sight (geoelement)/LineOfSightGeoElement.storyboard
+++ b/arcgis-ios-sdk-samples/Analysis/Line of sight (geoelement)/LineOfSightGeoElement.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="beF-yn-MU6">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="beF-yn-MU6">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -70,7 +70,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="381" minValue="20" maxValue="1500" translatesAutoresizingMaskIntoConstraints="NO" id="nca-Dg-BTg">
+                                            <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="380" minValue="20" maxValue="1500" translatesAutoresizingMaskIntoConstraints="NO" id="nca-Dg-BTg">
                                                 <rect key="frame" x="59" y="0.0" width="264" height="31"/>
                                                 <connections>
                                                     <action selector="observerHeightChanged:" destination="beF-yn-MU6" eventType="valueChanged" id="Tvd-k4-ESh"/>

--- a/arcgis-ios-sdk-samples/Analysis/Line of sight (geoelement)/LineOfSightGeoElementViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Line of sight (geoelement)/LineOfSightGeoElementViewController.swift
@@ -34,6 +34,8 @@ class LineOfSightGeoElementViewController: UIViewController {
     
     private let observerZMin = 20.0
     private let observerZMax = 1500.0
+    /// The roof height in meters of Empire State Building.
+    private let observerZ = 380.0
     
     private let observerPoint: AGSPoint
 
@@ -58,7 +60,7 @@ class LineOfSightGeoElementViewController: UIViewController {
         // set up the scene, layers and overlay
         // ====================================
         
-        observerPoint = AGSPoint(x: -73.984988, y: 40.748131, z: observerZMin, spatialReference: .wgs84())
+        observerPoint = AGSPoint(x: -73.984988, y: 40.748131, z: observerZ, spatialReference: .wgs84())
 
         // initialize the scene with an imagery basemap
         scene = AGSScene(basemap: .imageryWithLabels())

--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/Color Picker/ColorPicker.storyboard
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/Color Picker/ColorPicker.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="WKq-Wo-x9z">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="WKq-Wo-x9z">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,33 +13,33 @@
             <objects>
                 <tableViewController id="WKq-Wo-x9z" customClass="ColorPickerViewController" customModule="ArcGIS_Runtime_SDK_Samples" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="0CM-vF-q8p">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <sections>
                             <tableViewSection id="oyW-a0-Njj">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="x0t-Ui-vFs">
-                                        <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="28" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="x0t-Ui-vFs" id="jOo-N7-oCq">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Hue" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gDm-BC-Hek">
-                                                    <rect key="frame" x="16" y="12" width="31" height="9"/>
+                                                    <rect key="frame" x="20" y="12" width="31" height="9"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="k5P-Xz-PeO">
-                                                    <rect key="frame" x="317" y="12" width="42" height="21"/>
+                                                    <rect key="frame" x="352" y="12" width="42" height="21"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <slider opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="999" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="HLw-Qo-tVg">
-                                                    <rect key="frame" x="14" y="29" width="347" height="1"/>
+                                                <slider opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="999" contentHorizontalAlignment="center" contentVerticalAlignment="center" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="HLw-Qo-tVg">
+                                                    <rect key="frame" x="18" y="29" width="378" height="1"/>
                                                     <connections>
                                                         <action selector="hueSliderAction:" destination="WKq-Wo-x9z" eventType="valueChanged" id="cFy-3J-0iN"/>
                                                     </connections>
@@ -59,26 +59,26 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="heC-tV-mXW">
-                                        <rect key="frame" x="0.0" y="72" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="72" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="heC-tV-mXW" id="SnP-CO-BV8">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Saturation" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QdS-Kb-OB8">
-                                                    <rect key="frame" x="16" y="12" width="79" height="9"/>
+                                                    <rect key="frame" x="20" y="12" width="79" height="9"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TTb-cd-zc1">
-                                                    <rect key="frame" x="317" y="12" width="42" height="20.5"/>
+                                                    <rect key="frame" x="352" y="12" width="42" height="20.5"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <slider opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="999" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="Y3M-rT-AhN">
-                                                    <rect key="frame" x="14" y="29" width="347" height="1"/>
+                                                <slider opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="999" contentHorizontalAlignment="center" contentVerticalAlignment="center" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="Y3M-rT-AhN">
+                                                    <rect key="frame" x="18" y="29" width="378" height="1"/>
                                                     <connections>
                                                         <action selector="saturationSliderAction:" destination="WKq-Wo-x9z" eventType="valueChanged" id="HVq-IT-mCE"/>
                                                     </connections>
@@ -98,26 +98,26 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="MpW-jO-m6P">
-                                        <rect key="frame" x="0.0" y="116" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="116" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="MpW-jO-m6P" id="NPL-Pf-2Uf">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Brightness" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aJb-2D-rB7">
-                                                    <rect key="frame" x="16" y="12" width="82" height="9"/>
+                                                    <rect key="frame" x="20" y="12" width="82" height="9"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aaP-E4-Gg6">
-                                                    <rect key="frame" x="317" y="12" width="42" height="20.5"/>
+                                                    <rect key="frame" x="352" y="12" width="42" height="20.5"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <slider opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="999" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="M3K-G5-aWc">
-                                                    <rect key="frame" x="14" y="29" width="347" height="1"/>
+                                                <slider opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="999" contentHorizontalAlignment="center" contentVerticalAlignment="center" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="M3K-G5-aWc">
+                                                    <rect key="frame" x="18" y="29" width="378" height="1"/>
                                                     <connections>
                                                         <action selector="brightnessSliderAction:" destination="WKq-Wo-x9z" eventType="valueChanged" id="Ydl-JB-VCx"/>
                                                     </connections>
@@ -137,26 +137,26 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="X8W-cO-tPJ">
-                                        <rect key="frame" x="0.0" y="160" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="160" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="X8W-cO-tPJ" id="bub-Y5-2DS">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Alpha" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WQO-tg-7s4">
-                                                    <rect key="frame" x="16" y="12" width="44" height="9"/>
+                                                    <rect key="frame" x="20" y="12" width="44" height="9"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QO8-Kt-kzf">
-                                                    <rect key="frame" x="317" y="12" width="42" height="20.5"/>
+                                                    <rect key="frame" x="352" y="12" width="42" height="20.5"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <slider opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="999" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="hOR-cl-uqK">
-                                                    <rect key="frame" x="14" y="29" width="347" height="1"/>
+                                                <slider opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="999" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="1" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="hOR-cl-uqK">
+                                                    <rect key="frame" x="18" y="29" width="378" height="1"/>
                                                     <connections>
                                                         <action selector="alphaSliderAction:" destination="WKq-Wo-x9z" eventType="valueChanged" id="cas-9t-WER"/>
                                                     </connections>

--- a/arcgis-ios-sdk-samples/Maps/Generate offline map (overrides)/OfflineMapParameterOverridesViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map (overrides)/OfflineMapParameterOverridesViewController.swift
@@ -29,7 +29,11 @@ class OfflineMapParameterOverridesViewController: UITableViewController {
     
     /// The max scale level for the output. Note that higher values are zoomed further in,
     /// i.e. 23 has the most detail, but each tile covers a tiny area.
-    @IBOutlet weak var maxScaleLevelSlider: UISlider!
+    @IBOutlet weak var maxScaleLevelSlider: UISlider! {
+        didSet {
+            maxScaleLevelSlider.value = maxScaleLevelSlider.maximumValue
+        }
+    }
     
     /// The extra padding added to the extent rect to fetch a larger area, in meters.
     @IBOutlet weak var basemapExtentBufferSlider: UISlider!

--- a/arcgis-ios-sdk-samples/Scenes/Surface placements/SurfacePlacementsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Surface placements/SurfacePlacementsViewController.swift
@@ -27,7 +27,7 @@ class SurfacePlacementsViewController: UIViewController {
     /// The slider to change z-value of `AGSPoint` geometries, from 0 to 140 in meters.
     @IBOutlet weak var zValueSlider: UISlider! {
         didSet {
-            zValueSlider.value = 70
+            zValueSlider.value = (zValueSlider.maximumValue + zValueSlider.minimumValue) / 2
         }
     }
     /// The segmented control to toggle the visibility of two draped mode graphics overlays.

--- a/arcgis-ios-sdk-samples/Scenes/Surface placements/SurfacePlacementsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Surface placements/SurfacePlacementsViewController.swift
@@ -25,7 +25,11 @@ class SurfacePlacementsViewController: UIViewController {
     /// A label to show the value of the slider.
     @IBOutlet weak var zValueLabel: UILabel!
     /// The slider to change z-value of `AGSPoint` geometries, from 0 to 140 in meters.
-    @IBOutlet weak var zValueSlider: UISlider!
+    @IBOutlet weak var zValueSlider: UISlider! {
+        didSet {
+            zValueSlider.value = 70
+        }
+    }
     /// The segmented control to toggle the visibility of two draped mode graphics overlays.
     @IBOutlet weak var drapedModeSegmentedControl: UISegmentedControl!
     


### PR DESCRIPTION
This PR fixes the bug in `common-samples/issues/2148` - slider doesn't honor the default value set in storyboard, in iOS 14.

![image](https://user-images.githubusercontent.com/9660181/106067618-ec038c00-60b3-11eb-9b2d-b468d6025812.png)

There is no official bug reporting thread found on Apple forum, but the same issue was spotted by other developers. See section 2 in this post: https://fahimfarook.medium.com/xcode-12-and-ios-14-developer-bugs-and-issues-ada35920a104

This issue only affects iOS 14.

- [x] Generate offline map (overrides) > Max scale level slider
    Fixed by setting the slider's value to max in code
- [x] Line of sight (geoelement)
    Fixed by setting the default value to the height of ESB
- [x] Surface placements
    Fixed by setting the value to the half of min + max
- [x] ColorPickerViewController (display grid, change map background, etc.)
    - not changed, the expected behavior is set to 0 each time. Reset the values in storyboard.