### PR TITLE
Enable trailing_whitespace linting rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -22,7 +22,6 @@ disabled_rules: # rule identifiers to exclude from running
   - force_cast
   - line_length
   - notification_center_detachment
-  - trailing_whitespace
   - type_body_length
   - type_name
 
@@ -78,6 +77,8 @@ identifier_name:
     warning: 0 # do not flag short identifiers
 trailing_closure:
   only_single_muted_parameter: true
+trailing_whitespace:
+  ignores_empty_lines: true
 
 excluded:
 - Pods

--- a/arcgis-ios-sdk-samples/Display information/Identify graphics/GOIdentifyViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Identify graphics/GOIdentifyViewController.swift
@@ -38,7 +38,7 @@ class GOIdentifyViewController: UIViewController, AGSGeoViewTouchDelegate {
         self.mapView.map = self.map
         
         // add self as the touch delegate of the mapview
-        // we will be using a method on the delegate to know 
+        // we will be using a method on the delegate to know
         // when the user tapped on the map view
         self.mapView.touchDelegate = self
     }

--- a/arcgis-ios-sdk-samples/Display information/Show legend/MILLegendTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Display information/Show legend/MILLegendTableViewController.swift
@@ -67,7 +67,7 @@ class MILLegendTableViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "MILLegendCell", for: indexPath) 
+        let cell = tableView.dequeueReusableCell(withIdentifier: "MILLegendCell", for: indexPath)
 
         let layer = self.orderArray[indexPath.section]
         let legendInfos = self.legendInfosDict[self.hashString(for: layer)]!

--- a/arcgis-ios-sdk-samples/Features/Feature collection layer/FeatureCollectionLayerViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature collection layer/FeatureCollectionLayerViewController.swift
@@ -60,7 +60,7 @@ class FeatureCollectionLayerViewController: UIViewController {
         let placeField = AGSField(fieldType: .text, name: "Place", alias: "Place name", length: 40, domain: nil, editable: true, allowNull: false)
         fields.append(placeField)
         
-        // initialize feature collection table with the fields created 
+        // initialize feature collection table with the fields created
         // and geometry type as Point
         let pointsCollectionTable = AGSFeatureCollectionTable(fields: fields, geometryType: .point, spatialReference: .wgs84())
         

--- a/arcgis-ios-sdk-samples/Layers/Manage sublayers/ManageSublayersViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Manage sublayers/ManageSublayersViewController.swift
@@ -56,7 +56,7 @@ class ManageSublayersViewController: UIViewController, MapImageSublayersViewCont
     
     private func createSublayers() {
         // We will create 2 mapImageSublayers from tableSublayerSource with known workspaceID and dataSourceName
-        // These sublayers are not yet part of the mapImageLayer's sublayers, so will be shown as part of the 
+        // These sublayers are not yet part of the mapImageLayer's sublayers, so will be shown as part of the
         // removed sublayers array at first
         
         // create tableSublayerSource from workspaceID and dataSourceName

--- a/arcgis-ios-sdk-samples/Maps/Generate offline map (overrides)/GenerateOfflineMapOverridesViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map (overrides)/GenerateOfflineMapOverridesViewController.swift
@@ -142,7 +142,7 @@ class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthentica
             // remove key-value observation
             self.progressObservation = nil
             
-            if let error = error {    
+            if let error = error {
                 // do not display error if user simply cancelled the request
                 if (error as NSError).code != NSUserCancelledError {
                     self.presentAlert(error: error)

--- a/arcgis-ios-sdk-samples/Maps/Generate offline map/GenerateOfflineMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map/GenerateOfflineMapViewController.swift
@@ -127,7 +127,7 @@ class GenerateOfflineMapViewController: UIViewController, AGSAuthenticationManag
             // remove KVO observer
             self.jobProgressObservation = nil
             
-            if let error = error {    
+            if let error = error {
                 // do not display error if user simply cancelled the request
                 if (error as NSError).code != NSUserCancelledError {
                     self.presentAlert(error: error)

--- a/arcgis-ios-sdk-samples/Maps/Set map spatial reference/SetMapsSRViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Set map spatial reference/SetMapsSRViewController.swift
@@ -30,7 +30,7 @@ class SetMapsSRViewController: UIViewController {
         self.map = AGSMap(spatialReference: AGSSpatialReference(wkid: 54024)!)
         
         // Adding a map image layer which can reproject itself to the map's spatial reference
-        // Note: Some layer such as tiled layer cannot reproject and will fail to draw if their spatial 
+        // Note: Some layer such as tiled layer cannot reproject and will fail to draw if their spatial
         // reference is not the same as the map's spatial reference
         self.map.operationalLayers.add(AGSArcGISMapImageLayer(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer")!))
         


### PR DESCRIPTION
Enables the `trailing_whitespace` [rule](https://realm.github.io/SwiftLint/trailing_whitespace.html), but ignores it for blank lines to match Xcode's default style of not trimming trailing whitespace from whitespace only lines. Also addresses all violations using `swiftlint autocorrect`.