### PR TITLE
Fix: 404 links

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To learn more about `masquerade`, consult the [documentation](https://github.com
 ## Additional Resources
 
 * Want to start a new project? [Setup](https://developers.arcgis.com/ios/get-started) your dev environment
-* New to the API? Explore the documentation : [Guide](https://developers.arcgis.com/ios/swift/guide/introduction.htm) | [API Reference](https://developers.arcgis.com/ios/api-reference/)
+* New to the API? Explore the documentation : [Guide](https://developers.arcgis.com/ios/) | [API Reference](https://developers.arcgis.com/ios/api-reference/)
 * Got a question? Ask the community on our [forum](https://community.esri.com/community/developers/native-app-developers/arcgis-runtime-sdk-for-ios/)
 
 ## Issues

--- a/arcgis-ios-sdk-samples/Augmented reality/Explore scenes in flyover AR/README.md
+++ b/arcgis-ios-sdk-samples/Augmented reality/Explore scenes in flyover AR/README.md
@@ -36,7 +36,7 @@ The [world elevation service](https://elevation3d.arcgis.com/arcgis/rest/service
 
 This sample requires a device that is compatible with ARKit 1.0 on iOS.
 
-**Flyover AR** is one of three main patterns for working with geographic information in augmented reality. See the topic [Display scenes in augmented reality](https://developers.arcgis.com/ios/latest/swift/guide/display-scenes-in-augmented-reality.htm) in the iOS Guide for more information.
+**Flyover AR** is one of three main patterns for working with geographic information in augmented reality.
 
 This sample uses the ArcGIS Runtime Toolkit. See the section [Enable your app for AR using AR Toolkit](https://developers.arcgis.com/ios/latest/swift/guide/display-scenes-in-augmented-reality.htm) in the iOS Guide to learn about the toolkit and how to add it to your app.
 

--- a/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/README.md
+++ b/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/README.md
@@ -68,7 +68,7 @@ Unlike other scene samples, there's no need for a basemap while navigating, beca
 
 A digital elevation model is used to ensure that the displayed route is positioned appropriately relative to the terrain of the route. If you don't want to display the route line floating, you could show the line draped on the surface instead.
 
-**World-scale AR** is one of three main patterns for working with geographic information in augmented reality. 
+**World-scale AR** is one of three main patterns for working with geographic information in augmented reality.
 
 Because most navigation scenarios involve traveling beyond the accurate range for ARKit positioning, this sample relies on **continuous location updates** from the location data source. Because the origin camera is constantly being reset by the location data source, the sample doesn't allow the user to pan to calibrate or adjust the altitude with a slider. The location data source doesn't provide a heading, so it isn't overwritten when the location refreshes.
 

--- a/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/README.md
+++ b/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/README.md
@@ -68,7 +68,7 @@ Unlike other scene samples, there's no need for a basemap while navigating, beca
 
 A digital elevation model is used to ensure that the displayed route is positioned appropriately relative to the terrain of the route. If you don't want to display the route line floating, you could show the line draped on the surface instead.
 
-**World-scale AR** is one of three main patterns for working with geographic information in augmented reality. See the topic [Display scenes in augmented reality](https://developers.arcgis.com/ios/latest/swift/guide/display-scenes-in-augmented-reality.htm) in the iOS Guide for more information.
+**World-scale AR** is one of three main patterns for working with geographic information in augmented reality. 
 
 Because most navigation scenarios involve traveling beyond the accurate range for ARKit positioning, this sample relies on **continuous location updates** from the location data source. Because the origin camera is constantly being reset by the location data source, the sample doesn't allow the user to pan to calibrate or adjust the altitude with a slider. The location data source doesn't provide a heading, so it isn't overwritten when the location refreshes.
 

--- a/arcgis-ios-sdk-samples/Augmented reality/View hidden infrastructure in AR/README.md
+++ b/arcgis-ios-sdk-samples/Augmented reality/View hidden infrastructure in AR/README.md
@@ -55,7 +55,7 @@ Note that unlike other scene samples, a basemap isn't shown most of the time, be
 
 You may notice that pipes you draw underground appear to float more than you would expect. That floating is a normal result of the parallax effect that looks unnatural because you're not used to being able to see underground/obscured objects. Compare the behavior of underground pipes with equivalent pipes drawn above the surface - the behavior is the same, but probably feels more natural above ground because you see similar scenes day-to-day (e.g. utility wires).
 
-**World-scale AR** is one of three main patterns for working with geographic information in augmented reality. See the topic [Display scenes in augmented reality](https://developers.arcgis.com/ios/latest/swift/guide/display-scenes-in-augmented-reality.htm) in the iOS Guide for more information.
+**World-scale AR** is one of three main patterns for working with geographic information in augmented reality. 
 
 This sample uses a combination of two location data source modes: continuous update and one-time update, presented as "roaming" and "local" calibration modes in the app. The error in the position provided by ARKit increases as you move further from the origin, resulting in a poor experience when you move more than a few meters away. The location provided by GPS is more useful over large areas, but not good enough for a convincing AR experience on a small scale. With this sample, you can use "roaming" mode to maintain good enough accuracy for basic context while navigating a large area. When you want to see a more precise visualization, you can switch to "local" (ARKit-only) mode and manually calibrate for best results.
 

--- a/arcgis-ios-sdk-samples/Augmented reality/View hidden infrastructure in AR/README.md
+++ b/arcgis-ios-sdk-samples/Augmented reality/View hidden infrastructure in AR/README.md
@@ -55,7 +55,7 @@ Note that unlike other scene samples, a basemap isn't shown most of the time, be
 
 You may notice that pipes you draw underground appear to float more than you would expect. That floating is a normal result of the parallax effect that looks unnatural because you're not used to being able to see underground/obscured objects. Compare the behavior of underground pipes with equivalent pipes drawn above the surface - the behavior is the same, but probably feels more natural above ground because you see similar scenes day-to-day (e.g. utility wires).
 
-**World-scale AR** is one of three main patterns for working with geographic information in augmented reality. 
+**World-scale AR** is one of three main patterns for working with geographic information in augmented reality.
 
 This sample uses a combination of two location data source modes: continuous update and one-time update, presented as "roaming" and "local" calibration modes in the app. The error in the position provided by ARKit increases as you move further from the origin, resulting in a poor experience when you move more than a few meters away. The location provided by GPS is more useful over large areas, but not good enough for a convincing AR experience on a small scale. With this sample, you can use "roaming" mode to maintain good enough accuracy for basic context while navigating a large area. When you want to see a more precise visualization, you can switch to "local" (ARKit-only) mode and manually calibrate for best results.
 

--- a/arcgis-ios-sdk-samples/Display information/Custom dictionary style/README.md
+++ b/arcgis-ios-sdk-samples/Display information/Custom dictionary style/README.md
@@ -29,7 +29,7 @@ The data used in this sample is from a feature layer showing a subset of [restau
 
 ## Additional information
 
-To learn more about how styles in dictionary renderers work, see the topic [Display symbols from a style with a dictionary renderer](https://developers.arcgis.com/ios/latest/swift/guide/display-military-symbols-with-a-dictionary-renderer.htm) in the *ArcGIS Runtime SDK for iOS* guide. For information about creating your own custom dictionary style, see the open source [dictionary renderer toolkit](https://esriurl.com/DictionaryToolkit) on *GitHub*.
+For information about creating your own custom dictionary style, see the open source [dictionary renderer toolkit](https://esriurl.com/DictionaryToolkit) on *GitHub*.
 
 ## Tags
 

--- a/arcgis-ios-sdk-samples/Display information/Custom dictionary style/README.md
+++ b/arcgis-ios-sdk-samples/Display information/Custom dictionary style/README.md
@@ -29,7 +29,7 @@ The data used in this sample is from a feature layer showing a subset of [restau
 
 ## Additional information
 
-For information about creating your own custom dictionary style, see the open source [dictionary renderer toolkit](https://esriurl.com/DictionaryToolkit) on *GitHub*.
+For information about creating your own custom dictionary style, see the open source [dictionary renderer toolkit](https://github.com/Esri/dictionary-renderer-toolkit) on *GitHub*.
 
 ## Tags
 

--- a/arcgis-ios-sdk-samples/Features/Service feature table (cache)/README.md
+++ b/arcgis-ios-sdk-samples/Features/Service feature table (cache)/README.md
@@ -6,7 +6,7 @@ Display a feature layer from a service using the **on interaction cache** featur
 
 ## Use case
 
-`AGSServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **On interaction cache** in scenarios with large amounts of infrequently edited data. See [Table performance concepts](https://developers.arcgis.com/ios/latest/swift/guide/layers.htm#ESRI_SECTION1_40F10593308A4718971C9A8F5FB9EC7D) to learn more.
+`AGSServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **On interaction cache** in scenarios with large amounts of infrequently edited data.
 
 ## How to use the sample
 

--- a/arcgis-ios-sdk-samples/Features/Service feature table (manual cache)/README.md
+++ b/arcgis-ios-sdk-samples/Features/Service feature table (manual cache)/README.md
@@ -6,7 +6,7 @@ Display a feature layer from a service using the **manual cache** feature reques
 
 ## Use case
 
-`AGSServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **manual cache** in scenarios where you want to explicitly control requests for features. See [Table performance concepts](https://developers.arcgis.com/ios/latest/swift/guide/layers.htm#ESRI_SECTION1_40F10593308A4718971C9A8F5FB9EC7D) to learn more.
+`AGSServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **manual cache** in scenarios where you want to explicitly control requests for features.
 
 ## How to use the sample
 

--- a/arcgis-ios-sdk-samples/Features/Service feature table (no cache)/README.md
+++ b/arcgis-ios-sdk-samples/Features/Service feature table (no cache)/README.md
@@ -6,7 +6,7 @@ Display a feature layer from a service using the **no cache** feature request mo
 
 ## Use case
 
-`AGSServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **no cache** in scenarios where you always want the freshest data. See [Table performance concepts](https://developers.arcgis.com/ios/latest/swift/guide/layers.htm#ESRI_SECTION1_40F10593308A4718971C9A8F5FB9EC7D) to learn more.
+`AGSServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **no cache** in scenarios where you always want the freshest data.
 
 ## How to use the sample
 

--- a/arcgis-ios-sdk-samples/Layers/Add ENC exchange set/README.md
+++ b/arcgis-ios-sdk-samples/Layers/Add ENC exchange set/README.md
@@ -36,7 +36,7 @@ The latest [hydrography package](https://developers.arcgis.com/downloads/data) c
 
 ## Additional information
 
-Read more about [Display electronic navigational charts](https://developers.arcgis.com/ios/latest/swift/guide/display-electronic-navigational-charts.htm) on *ArcGIS for Developers*.
+Read more about [Electronic Navigational Charts](https://developers.arcgis.com/ios/license-and-deployment/deployment/#enc-electronic-navigational-charts-style-directory) on the developers guide.
 
 ## Tags
 

--- a/arcgis-ios-sdk-samples/Layers/Export tiles/README.md
+++ b/arcgis-ios-sdk-samples/Layers/Export tiles/README.md
@@ -32,7 +32,7 @@ Pan and zoom into the desired area, making sure the area is within the red bound
 
 ## Additional information
 
-ArcGIS tiled layers do not support reprojection, query, select, identify, or editing. Visit the [ArcGiS Online Developer's portal](https://developers.arcgis.com/ios/latest/swift/guide/layer-types-described.htm#ESRI_SECTION1_30E7379BE7FE4EC2AF7D8FBFEA7BB4CC) to learn more about the characteristics of ArcGIS tiled layers.
+ArcGIS tiled layers do not support reprojection, query, select, identify, or editing. See the [layer types](https://developers.arcgis.com/ios/layers/#layer-types) discussion in the developers guide to learn more about the characteristics of ArcGIS tiled layers.
 
 The sample first tries to export the tiles using the CompactV2 (.tpkx) format. If it isn't supported, it will fallback to the CompactV1 (.tpk) format. Refer to the [Tile Package Specification](https://github.com/Esri/tile-package-spec) on GitHub for more information on the tile package format.
 

--- a/arcgis-ios-sdk-samples/Layers/OpenStreetMap layer/README.md
+++ b/arcgis-ios-sdk-samples/Layers/OpenStreetMap layer/README.md
@@ -28,7 +28,7 @@ When the sample opens, it will automatically display the map with the OpenStreet
 
 The attribution text will be set to the required OpenStreetMap attribution automatically.
 
-Apps that expect to make many requests to OpenStreetMap should consider using an alternative tile server via the `WebTiledLayer` class.
+Apps that expect to make many requests to OpenStreetMap should consider using an alternative tile server via the `AGSWebTiledLayer` class.
 
 Esri now hosts an [OpenStreetMap vector layer on ArcGIS Online](https://www.arcgis.com/home/item.html?id=3e1a00aeae81496587988075fe529f71) that uses recent OpenStreetMap data in conjunction with a style matching the default OpenStreetMap style. This layer is not subject to the tile access restrictions that apply to tiles fetched from OpenStreetMap.org.
 

--- a/arcgis-ios-sdk-samples/Layers/OpenStreetMap layer/README.md
+++ b/arcgis-ios-sdk-samples/Layers/OpenStreetMap layer/README.md
@@ -28,7 +28,7 @@ When the sample opens, it will automatically display the map with the OpenStreet
 
 The attribution text will be set to the required OpenStreetMap attribution automatically.
 
-Apps that expect to make many requests to OpenStreetMap should consider using an alternative tile server via the `WebTiledLayer` class. See [layer types described](https://developers.arcgis.com/ios/latest/swift/guide/layer-types-described.htm#ESRI_SECTION1_B995CCAB20584F91890B3614CF16CF43) in the *ArcGIS Runtime SDK for iOS* documentation for more information on OpenStreetMap usage restrictions and alternatives.
+Apps that expect to make many requests to OpenStreetMap should consider using an alternative tile server via the `WebTiledLayer` class.
 
 Esri now hosts an [OpenStreetMap vector layer on ArcGIS Online](https://www.arcgis.com/home/item.html?id=3e1a00aeae81496587988075fe529f71) that uses recent OpenStreetMap data in conjunction with a style matching the default OpenStreetMap style. This layer is not subject to the tile access restrictions that apply to tiles fetched from OpenStreetMap.org.
 

--- a/arcgis-ios-sdk-samples/Maps/Apply scheduled updates to preplanned map area/README.md
+++ b/arcgis-ios-sdk-samples/Maps/Apply scheduled updates to preplanned map area/README.md
@@ -40,7 +40,7 @@ The data in this sample shows the roads and trails in the Canyonlands National P
 
 ## Additional information
 
-**Note:** Preplanned areas using the Scheduled Updates workflow are read-only. For preplanned areas that can be edited on the end-user device, see [Take a map offline - preplanned](https://developers.arcgis.com/ios/latest/swift/guide/take-map-offline-preplanned.htm) in the *ArcGIS Runtime SDK for iOS* guide.
+For more information about offline workflows, see [Offline maps, scenes, and data](https://developers.arcgis.com/ios/offline-maps-scenes-and-data/) in the *ArcGIS Developers* guide.
 
 ## Tags
 

--- a/arcgis-ios-sdk-samples/Maps/Download preplanned map/README.md
+++ b/arcgis-ios-sdk-samples/Maps/Download preplanned map/README.md
@@ -45,7 +45,7 @@ The [Naperville stormwater network map](https://arcgisruntime.maps.arcgis.com/ho
 * `syncWithFeatureServices`: Changes, including local edits, will be synced directly with the underlying feature services. This is the default update mode.
 * `downloadScheduledUpdates`: Scheduled, read-only updates will be downloaded from the online map area and applied to the local mobile geodatabases.
 
-See [Take a map offline - preplanned](https://developers.arcgis.com/ios/latest/swift/guide/take-map-offline-preplanned.htm) to learn about preplanned workflows, including how to define preplanned areas in ArcGIS Online. Alternatively, visit [Take a map offline - on demand](https://developers.arcgis.com/ios/latest/swift/guide/take-map-offline-on-demand.htm) or refer to the sample "Generate Offline Map" to learn about the on-demand workflow and see how the workflows differ.
+For more information about offline workflows, see [Offline maps, scenes, and data](https://developers.arcgis.com/ios/offline-maps-scenes-and-data/) in the *ArcGIS Developers* guide.
 
 ## Tags
 


### PR DESCRIPTION
Because of the launch of the new website, a few links that include `/guide/` lead to 404 errors. This PR updates those links. Please note that some of the old documentation is not on the new site so I couldn't find the new links and they had to be removed completely. 