### PR TITLE
Fix: Change reference to the raster used in raster cell sample to fix build error

### DIFF
--- a/arcgis-ios-sdk-samples.xcodeproj/project.pbxproj
+++ b/arcgis-ios-sdk-samples.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		008D175A24EF35800001BB8F /* EditWithBranchVersioningViewController.swift in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008D175624EEF3FE0001BB8F /* EditWithBranchVersioningViewController.swift */; };
 		009D8BEF24F9AC8D00FD7E76 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 009D8BEE24F9AC8D00FD7E76 /* LaunchScreen.storyboard */; };
 		00A3766A256C932800EC433A /* AppSecrets.swift.masque in Sources */ = {isa = PBXBuildFile; fileRef = 007A4250256C7A400025F582 /* AppSecrets.swift.masque */; };
+		00A9CFF625DF3ED7009A483A /* SA_EVI_8Day_03May20 in Resources */ = {isa = PBXBuildFile; fileRef = 00A9CFF525DF3ED7009A483A /* SA_EVI_8Day_03May20 */; settings = {ASSET_TAGS = (NDVIRaster, ); }; };
 		00ADC3BD2464D45C00A3B88D /* AnimateImagesWithImageOverlay.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 00ADC3B82464D45B00A3B88D /* AnimateImagesWithImageOverlay.storyboard */; };
 		00ADC3BF2464D45C00A3B88D /* AnimateImagesWithImageOverlayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00ADC3BA2464D45B00A3B88D /* AnimateImagesWithImageOverlayViewController.swift */; };
 		00ADC3C32464D59200A3B88D /* PacificSouthWest2 in Resources */ = {isa = PBXBuildFile; fileRef = 00ADC3C22464D59200A3B88D /* PacificSouthWest2 */; settings = {ASSET_TAGS = (PacificSouthWest, ); }; };
@@ -56,10 +57,6 @@
 		00BA068525311B0D0039EF4D /* hydrography in Resources */ = {isa = PBXBuildFile; fileRef = 00BA068325311B0D0039EF4D /* hydrography */; settings = {ASSET_TAGS = (Hydrography, ); }; };
 		00C024E52475E4AB00E1DA8D /* NavigateARRoutePlannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C024E42475E4AB00E1DA8D /* NavigateARRoutePlannerViewController.swift */; };
 		00C024E72475E54A00E1DA8D /* NavigateAR.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 00C024E62475E54A00E1DA8D /* NavigateAR.storyboard */; };
-		00C6D420246CA8FD00C63EAF /* SA_EVI_8Day_03May20.tif.ovr in Resources */ = {isa = PBXBuildFile; fileRef = 00C6D32A246CA8FC00C63EAF /* SA_EVI_8Day_03May20.tif.ovr */; settings = {ASSET_TAGS = (NDVIRaster, ); }; };
-		00C6D421246CA8FD00C63EAF /* SA_EVI_8Day_03May20.tif.aux.xml in Resources */ = {isa = PBXBuildFile; fileRef = 00C6D32B246CA8FC00C63EAF /* SA_EVI_8Day_03May20.tif.aux.xml */; settings = {ASSET_TAGS = (NDVIRaster, ); }; };
-		00C6D422246CA8FD00C63EAF /* SA_EVI_8Day_03May20.tif in Resources */ = {isa = PBXBuildFile; fileRef = 00C6D32C246CA8FC00C63EAF /* SA_EVI_8Day_03May20.tif */; settings = {ASSET_TAGS = (NDVIRaster, ); }; };
-		00C6D423246CA8FD00C63EAF /* SA_EVI_8Day_03May20.tfw in Resources */ = {isa = PBXBuildFile; fileRef = 00C6D32D246CA8FC00C63EAF /* SA_EVI_8Day_03May20.tfw */; settings = {ASSET_TAGS = (NDVIRaster, ); }; };
 		00C94676244509B8000B6C6D /* DisplayLocationSettingsViewController.swift in CopyFiles */ = {isa = PBXBuildFile; fileRef = C7237D0D2190F07500A72C76 /* DisplayLocationSettingsViewController.swift */; };
 		00D4E8DE241AA18E002689DB /* ConvexHull.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 00D4E8D9241AA18E002689DB /* ConvexHull.storyboard */; };
 		00D4E8E0241AA18E002689DB /* ConvexHullViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D4E8DB241AA18E002689DB /* ConvexHullViewController.swift */; };
@@ -1249,6 +1246,7 @@
 		008D175624EEF3FE0001BB8F /* EditWithBranchVersioningViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditWithBranchVersioningViewController.swift; sourceTree = "<group>"; };
 		008D175824EEF4390001BB8F /* EditWithBranchVersioning.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = EditWithBranchVersioning.storyboard; sourceTree = "<group>"; };
 		009D8BEE24F9AC8D00FD7E76 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		00A9CFF525DF3ED7009A483A /* SA_EVI_8Day_03May20 */ = {isa = PBXFileReference; lastKnownFileType = folder; path = SA_EVI_8Day_03May20; sourceTree = "<group>"; };
 		00ADC3B82464D45B00A3B88D /* AnimateImagesWithImageOverlay.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = AnimateImagesWithImageOverlay.storyboard; sourceTree = "<group>"; };
 		00ADC3BA2464D45B00A3B88D /* AnimateImagesWithImageOverlayViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimateImagesWithImageOverlayViewController.swift; sourceTree = "<group>"; };
 		00ADC3C22464D59200A3B88D /* PacificSouthWest2 */ = {isa = PBXFileReference; lastKnownFileType = folder; path = PacificSouthWest2; sourceTree = "<group>"; };
@@ -1257,10 +1255,6 @@
 		00BA068325311B0D0039EF4D /* hydrography */ = {isa = PBXFileReference; lastKnownFileType = folder; path = hydrography; sourceTree = "<group>"; };
 		00C024E42475E4AB00E1DA8D /* NavigateARRoutePlannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigateARRoutePlannerViewController.swift; sourceTree = "<group>"; };
 		00C024E62475E54A00E1DA8D /* NavigateAR.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = NavigateAR.storyboard; sourceTree = "<group>"; };
-		00C6D32A246CA8FC00C63EAF /* SA_EVI_8Day_03May20.tif.ovr */ = {isa = PBXFileReference; lastKnownFileType = file; path = SA_EVI_8Day_03May20.tif.ovr; sourceTree = "<group>"; };
-		00C6D32B246CA8FC00C63EAF /* SA_EVI_8Day_03May20.tif.aux.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = SA_EVI_8Day_03May20.tif.aux.xml; sourceTree = "<group>"; };
-		00C6D32C246CA8FC00C63EAF /* SA_EVI_8Day_03May20.tif */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; path = SA_EVI_8Day_03May20.tif; sourceTree = "<group>"; };
-		00C6D32D246CA8FC00C63EAF /* SA_EVI_8Day_03May20.tfw */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SA_EVI_8Day_03May20.tfw; sourceTree = "<group>"; };
 		00D4E8D9241AA18E002689DB /* ConvexHull.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = ConvexHull.storyboard; sourceTree = "<group>"; };
 		00D4E8DB241AA18E002689DB /* ConvexHullViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConvexHullViewController.swift; sourceTree = "<group>"; };
 		00DAE5B22421321300D51281 /* NearestVertex.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = NearestVertex.storyboard; sourceTree = "<group>"; };
@@ -1962,20 +1956,9 @@
 				00BA068325311B0D0039EF4D /* hydrography */,
 				003D256F2513FBB5007527C2 /* ExchangeSetWithoutUpdates */,
 				00ADC3C22464D59200A3B88D /* PacificSouthWest2 */,
-				00C6D329246CA8FC00C63EAF /* SA_EVI_8Day_03May20 */,
+				00A9CFF525DF3ED7009A483A /* SA_EVI_8Day_03May20 */,
 			);
 			path = Archives;
-			sourceTree = "<group>";
-		};
-		00C6D329246CA8FC00C63EAF /* SA_EVI_8Day_03May20 */ = {
-			isa = PBXGroup;
-			children = (
-				00C6D32A246CA8FC00C63EAF /* SA_EVI_8Day_03May20.tif.ovr */,
-				00C6D32B246CA8FC00C63EAF /* SA_EVI_8Day_03May20.tif.aux.xml */,
-				00C6D32C246CA8FC00C63EAF /* SA_EVI_8Day_03May20.tif */,
-				00C6D32D246CA8FC00C63EAF /* SA_EVI_8Day_03May20.tfw */,
-			);
-			path = SA_EVI_8Day_03May20;
 			sourceTree = "<group>";
 		};
 		00D4E8D8241AA18E002689DB /* Convex hull */ = {
@@ -4776,7 +4759,6 @@
 				3ED028E11B8E3AA500ACA70D /* OverrideRenderer.storyboard in Resources */,
 				3EA15C751ED89EAE00B1F816 /* ChangeSublayerRenderer.storyboard in Resources */,
 				3ED028731B8E3A8500ACA70D /* MapViewDrawStatus.storyboard in Resources */,
-				00C6D422246CA8FD00C63EAF /* SA_EVI_8Day_03May20.tif in Resources */,
 				3ED028881B8E3A8500ACA70D /* OpenMapURL.storyboard in Resources */,
 				09587FF91FD8B63100FCF9A5 /* RasterLayerUsingService.storyboard in Resources */,
 				4C0CBFFD22F9D36D00D3F1DB /* FindClosestFacilityMultipleIncidentsService.storyboard in Resources */,
@@ -4823,7 +4805,6 @@
 				3E0D3AD21AFD1C7500FC60D6 /* ContentPList.plist in Resources */,
 				3EABC7B91DB183E600C161C6 /* ShastaBW.tif.ovr in Resources */,
 				3E5E093E1EF4567A00FF3454 /* AddDeleteRelatedFeatures.storyboard in Resources */,
-				00C6D420246CA8FD00C63EAF /* SA_EVI_8Day_03May20.tif.ovr in Resources */,
 				3EEE1D6F1E4935FC003263FC /* GroupUsers.storyboard in Resources */,
 				003D25702513FBB5007527C2 /* ExchangeSetWithoutUpdates in Resources */,
 				123AC27D20E58CFA0026A7D6 /* GeodesicOperations.storyboard in Resources */,
@@ -4936,7 +4917,6 @@
 				3EABC7B01DB17B2C00C161C6 /* Shasta.tif.aux.xml in Resources */,
 				4C783F422252DBAC00609B9C /* philadelphia.mspk in Resources */,
 				F4159C6F20925AAE0016E53D /* OpenScene.storyboard in Resources */,
-				00C6D421246CA8FD00C63EAF /* SA_EVI_8Day_03May20.tif.aux.xml in Resources */,
 				F1F651AC2498485C006DF277 /* ShowPopup.storyboard in Resources */,
 				00D4E8DE241AA18E002689DB /* ConvexHull.storyboard in Resources */,
 				4CCA30CF22399A91009D2AEF /* AddIntegratedMeshLayer.storyboard in Resources */,
@@ -4997,6 +4977,7 @@
 				C768170C2163E31700EC82F4 /* US_State_Capitals.kml in Resources */,
 				3EEA06131D21C44000E03774 /* SurfacePlacements.storyboard in Resources */,
 				3ED0292C1B8E3AB300ACA70D /* GOIdentify.storyboard in Resources */,
+				00A9CFF625DF3ED7009A483A /* SA_EVI_8Day_03May20 in Resources */,
 				D9ED2DA51FD758910043BFE1 /* FeatureLayerGPKG.storyboard in Resources */,
 				F1D1E2C12409AB8A006B2801 /* CreateAndSaveKML.storyboard in Resources */,
 				3E5E09371EF2E8E200FF3454 /* GenerateOfflineMap.storyboard in Resources */,
@@ -5057,7 +5038,6 @@
 				4C0F27B12152CA2400496666 /* IdentifyKMLFeatures.storyboard in Resources */,
 				3ED029691B8E3ACD00ACA70D /* UpdateAttributes.storyboard in Resources */,
 				3ECCFE3B1BD0401A00CE256D /* LayerStatus.storyboard in Resources */,
-				00C6D423246CA8FD00C63EAF /* SA_EVI_8Day_03May20.tfw in Resources */,
 				3ED028831B8E3A8500ACA70D /* MapRotation.storyboard in Resources */,
 				4C1EF2D3221232C500F73EAE /* IntegratedWindowsAuthenticationMapViewController.xib in Resources */,
 			);


### PR DESCRIPTION
This PR fixes the issue in

- `runtime/common-samples/issues/2004`
- `runtime/devops/issues/823`
- #1024 

by adjusting the on-demand raster used in `Identify raster cell` (#866) from `Create Groups` to `Create Folder References`, since the resource files come as a whole zip archive.

## How to review

- Do a fresh clone of the project from this [branch](https://github.com/Esri/arcgis-runtime-samples-ios/tree/Ting/Try-ReplaceRaster) and do a clean build. 
- On the first build, `v.next` will give an `Build input file cannot be found: '$SRCROOT/Portal Data/Archives/SA_EVI_8Day_03May20/SA_EVI_8Day_03May20.tif'` error. The following builds won't give error since no additional portal item is added.
- This branch won't give any error

The error is hard to replicate because it only happens on the very first build of the project, or when the `Portal Data` folder is deleted or partially changed.

<details><summary>Below attach some details</summary>

1. Initially I thought this problem come when we made changes to the `download-portal-item-data.swift` script in #865 where we included better zip archive support for the download script.
2. Later we found out the problem is actually with the build system upgrade that [came with Xcode 10](http://www.gietal.net/blog/xcode10-and-prebuild-script-output-files-xcfilelist). In Xcode 10 we need to explicitly provide the build system a list of file paths, if those files are generated by one of the build phase. Otherwise the build system won't pick them up during the current build, which result in a `Build input file cannot be found` error.
3. In #1024 Ting tried to move the `Download Portal Item Data` from build phase to a `Pre-Action` in the build scheme. But Phil indicated that is even worse than having an one-time error.
4. Ting then tried to use `xcfilelist` to actually log the file paths downloaded. However, when going down this path, Ting found out the only files that cause this error are the rasters used in `Identify raster cell`. Adjusting their references and re-tag the on-demand resource tag solve the error.
5. Therefore, we are not adding additional patches to the project in case the problem is solved.

</details>