### PR TITLE
Fix: remove redundant weakly captured `self`

### DIFF
--- a/arcgis-ios-sdk-samples/Maps/Generate offline map (overrides)/GenerateOfflineMapOverridesViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map (overrides)/GenerateOfflineMapOverridesViewController.swift
@@ -117,7 +117,7 @@ class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthentica
         self.generateOfflineMapJob = generateOfflineMapJob
         
         progressObservation = generateOfflineMapJob.progress.observe(\.fractionCompleted, options: .initial) { [weak self] (progress, _) in
-            DispatchQueue.main.async { [weak self] in
+            DispatchQueue.main.async {
                 guard let self = self else {
                     return
                 }

--- a/arcgis-ios-sdk-samples/Maps/Generate offline map/GenerateOfflineMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map/GenerateOfflineMapViewController.swift
@@ -107,7 +107,7 @@ class GenerateOfflineMapViewController: UIViewController, AGSAuthenticationManag
         
         // observe the job's progress
         jobProgressObservation = generateOfflineMapJob.progress.observe(\.fractionCompleted, options: .new) { [weak self] (progress, _) in
-            DispatchQueue.main.async { [weak self] in
+            DispatchQueue.main.async {
                 // update progress label
                 self?.progressLabel.text = progress.localizedDescription
                 // update progress view

--- a/arcgis-ios-sdk-samples/Maps/Map loaded/MapLoadedViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Map loaded/MapLoadedViewController.swift
@@ -35,7 +35,7 @@ class MapLoadedViewController: UIViewController {
         
         mapLoadStatusObservation = map.observe(\.loadStatus, options: .initial) { [weak self] (_, _) in
             // update the banner label on main thread
-            DispatchQueue.main.async { [weak self] in
+            DispatchQueue.main.async {
                 self?.updateLoadStatusLabel()
             }
         }

--- a/arcgis-ios-sdk-samples/Route and directions/Navigate route/NavigateRouteViewController.swift
+++ b/arcgis-ios-sdk-samples/Route and directions/Navigate route/NavigateRouteViewController.swift
@@ -218,7 +218,7 @@ class NavigateRouteViewController: UIViewController {
         mapView.locationDisplay.autoPanMode = .navigation
         recenterBarButtonItem.isEnabled = false
         mapView.locationDisplay.autoPanModeChangedHandler = { [weak self] _ in
-            DispatchQueue.main.async { [weak self] in
+            DispatchQueue.main.async {
                 self?.recenterBarButtonItem.isEnabled = true
             }
             self?.mapView.locationDisplay.autoPanModeChangedHandler = nil


### PR DESCRIPTION
This PR fixes the issue mentioned here: 

- https://github.com/Esri/arcgis-runtime-samples-ios/pull/1037#discussion_r584211266
- https://github.com/Esri/arcgis-runtime-samples-ios/pull/988#discussion_r516696201

to remove the redundant weak capture of self within already weak scope.

Here is a SO thread to read more on when and where to use `[weak self]` https://stackoverflow.com/a/41992442/14369688

I don't know if we should make these kind of changes, but since we spotted them in new sample PRs, I tend to fix all existing ones in the codebase, so that we don't get confused by the inconsistency when revisiting those samples. 😳 