### PR TITLE
Fix: Revert basemap change to the scene

### DIFF
--- a/arcgis-ios-sdk-samples/Scenes/Terrain exaggeration/TerrainExaggerationViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Terrain exaggeration/TerrainExaggerationViewController.swift
@@ -21,7 +21,7 @@ class TerrainExaggerationViewController: UIViewController {
     @IBOutlet weak var sceneView: AGSSceneView!
     
     // initialize scene with streets basemap
-    let scene = AGSScene(basemapStyle: .arcGISStreets)
+    let scene = AGSScene(basemap: .streets())
     
     // initialize surface
     let surface = AGSSurface()


### PR DESCRIPTION
This PR fixes `common-samples/issues/2571` where we accidentally introduced a basemap constructor change to the scene.