### PR TITLE
Fix: Empty balloon for placemarks in Identify KML features

### DIFF
--- a/arcgis-ios-sdk-samples/Layers/Identify KML features/IdentifyKMLFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Identify KML features/IdentifyKMLFeaturesViewController.swift
@@ -66,9 +66,15 @@ extension IdentifyKMLFeaturesViewController: AGSGeoViewTouchDelegate {
         geoView.callout.dismiss()
         geoView.identifyLayer(forecastLayer, screenPoint: screenPoint, tolerance: 15, returnPopupsOnly: false) { [weak self] (result) in
             if let error = result.error {
-                print("Error identifying layer: \(error)")
+                self?.presentAlert(error: error)
             } else if let placemarkIndex = result.geoElements.firstIndex(where: { $0 is AGSKMLPlacemark }) {
                 let placemark = result.geoElements[placemarkIndex] as! AGSKMLPlacemark
+                // Google Earth only displays the placemarks with description
+                // or extended data. To match its behavior, add a description
+                // placeholder if it doesn't exist in the data source.
+                if placemark.attributes["description"] == nil {
+                    placemark.attributes["description"] = "Weather condition"
+                }
                 self?.showCallout(for: placemark, at: mapPoint)
             }
         }

--- a/arcgis-ios-sdk-samples/Layers/Identify KML features/IdentifyKMLFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Identify KML features/IdentifyKMLFeaturesViewController.swift
@@ -56,7 +56,7 @@ class IdentifyKMLFeaturesViewController: UIViewController {
             mapView.callout.customView = textView
             mapView.callout.show(at: point, screenOffset: .zero, rotateOffsetWithMap: false, animated: true)
         } catch {
-            print("Error converting balloon content to attributed string: \(error)")
+            presentAlert(error: error)
         }
     }
 }

--- a/arcgis-ios-sdk-samples/Layers/Identify KML features/IdentifyKMLFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Identify KML features/IdentifyKMLFeaturesViewController.swift
@@ -67,13 +67,12 @@ extension IdentifyKMLFeaturesViewController: AGSGeoViewTouchDelegate {
         geoView.identifyLayer(forecastLayer, screenPoint: screenPoint, tolerance: 15, returnPopupsOnly: false) { [weak self] (result) in
             if let error = result.error {
                 self?.presentAlert(error: error)
-            } else if let placemarkIndex = result.geoElements.firstIndex(where: { $0 is AGSKMLPlacemark }) {
-                let placemark = result.geoElements[placemarkIndex] as! AGSKMLPlacemark
+            } else if let placemark = result.geoElements.first(where: { $0 is AGSKMLPlacemark }) as? AGSKMLPlacemark {
                 // Google Earth only displays the placemarks with description
                 // or extended data. To match its behavior, add a description
-                // placeholder if it doesn't exist in the data source.
-                if placemark.attributes["description"] == nil {
-                    placemark.attributes["description"] = "Weather condition"
+                // placeholder if it is empty in the data source.
+                if placemark.nodeDescription.isEmpty {
+                    placemark.nodeDescription = "Weather condition"
                 }
                 self?.showCallout(for: placemark, at: mapPoint)
             }

--- a/arcgis-ios-sdk-samples/Layers/Identify KML features/README.md
+++ b/arcgis-ios-sdk-samples/Layers/Identify KML features/README.md
@@ -24,7 +24,7 @@ Note: the KML layer used in this sample contains a screen overlay. The screen ov
   * Create a callout at the calculated map point and populate the callout content with text from the placemark's `balloonContent`. NOTE: KML supports defining HTML for balloon content and may need to be converted from HTML to text.
   * Show the callout.
 
-Note: There are several types of KML features. This sample only identifies features of type `KMLPlacemark`.
+Note: There are several types of KML features. This sample only identifies features of type `AGSKMLPlacemark`.
 
 ## Relevant API
 
@@ -35,7 +35,7 @@ Note: There are several types of KML features. This sample only identifies featu
 
 ## About the data
 
-This sample shows a forecast for significant weather within the U.S. Regions of severe thunderstorms, flooding, snowfall, and freezing rain are shown. Tap the features to see details.
+This sample shows a forecast for [significant weather within the U.S. Regions](https://www.wpc.ncep.noaa.gov/kml/kmlproducts.php#sigwx) of severe thunderstorms, flooding, snowfall, and freezing rain are shown.
 
 ## Additional information
 


### PR DESCRIPTION
This PR proposes a fix for `common-samples/issues/2542`. 

## Background

In recent updates, core introduced a condition to return an empty string for the balloons/KML nodes that doesn't have description or extended data. The data source in the `Identify KML features` doesn't provide a description for each significant weather condition, thus empty balloons are displayed in the callout.

## Fix

If description is absent for a placemark, add a placeholder so that the content of the balloon can be displayed.

The fix is for U11, but adding the attribute doesn't conflict with U10, so it can go into `v.next`.

## Test

Please note: the sample can only be tested if the data source contains significant weather in the US. Also, the issue only appears in the recent U11 daily builds.

- Before: the popup for any feature in the map is empty
- After: the popup should show HTML content