### PR TITLE
Fix: Linter warnings

### DIFF
--- a/arcgis-ios-sdk-samples/Analysis/Viewshed (location)/ViewshedLocationViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Viewshed (location)/ViewshedLocationViewController.swift
@@ -22,7 +22,7 @@ class ViewshedLocationViewController: UIViewController {
     
     private weak var viewshed: AGSLocationViewshed?
     
-    private var canMoveViewshed: Bool = false {
+    private var canMoveViewshed = false {
         didSet {
             setObserverOnTapInstruction.isHidden = canMoveViewshed
             updateObserverOnDragInstruction.isHidden = !canMoveViewshed

--- a/arcgis-ios-sdk-samples/Augmented reality/Collect data in AR/CollectDataAR.swift
+++ b/arcgis-ios-sdk-samples/Augmented reality/Collect data in AR/CollectDataAR.swift
@@ -362,7 +362,7 @@ class CollectDataARCalibrationViewController: UIViewController {
     
     /// Determines whether continuous positioning is in use
     /// Showing the elevation slider is only appropriate when using local positioning
-    var useContinuousPositioning: Bool = true {
+    var useContinuousPositioning = true {
         didSet {
             if useContinuousPositioning {
                 elevationSlider.isEnabled = false

--- a/arcgis-ios-sdk-samples/Content Display Logic/Cells/ContentTableCell.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Cells/ContentTableCell.swift
@@ -19,7 +19,7 @@ class ContentTableCell: UITableViewCell {
     @IBOutlet var titleLabel: UILabel!
     @IBOutlet var detailLabel: UILabel!
     
-    var isExpanded: Bool = false {
+    var isExpanded = false {
         didSet {
             detailLabel.isHidden = !isExpanded
         }

--- a/arcgis-ios-sdk-samples/Maps/Show location history/LocationHistoryViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Show location history/LocationHistoryViewController.swift
@@ -93,7 +93,7 @@ class LocationHistoryViewController: UIViewController {
     ]],"spatialReference":{"wkid":102100,"latestWkid":3857}}
     """
     
-    private var isTracking: Bool = false {
+    private var isTracking = false {
         didSet {
             handleLocationStatusChange()
         }


### PR DESCRIPTION
Remove redundant type annotation for rule `redundant_type_annotation` of SwiftLint to get ready for a clean release.