### PR TITLE
Fix: Various bugs in Edit and sync features

### DIFF
--- a/arcgis-ios-sdk-samples/Content Display Logic/ContentPList.plist
+++ b/arcgis-ios-sdk-samples/Content Display Logic/ContentPList.plist
@@ -1111,6 +1111,10 @@
 				<string>EditAndSyncFeatures</string>
 				<key>descriptionText</key>
 				<string>Synchronize offline edits with a feature service.</string>
+				<key>dependency</key>
+				<array>
+					<string>SanFranciscoTilePackage</string>
+				</array>
 			</dict>
 			<dict>
 				<key>displayName</key>

--- a/arcgis-ios-sdk-samples/Edit data/Edit and sync features/EditAndSyncFeatures.storyboard
+++ b/arcgis-ios-sdk-samples/Edit data/Edit and sync features/EditAndSyncFeatures.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="x5g-SP-gLy">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="x5g-SP-gLy">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -38,7 +38,7 @@
                                 <rect key="frame" x="0.0" y="813" width="414" height="49"/>
                                 <items>
                                     <barButtonItem style="plain" systemItem="flexibleSpace" id="RT5-mr-U1C"/>
-                                    <barButtonItem title="Generate Geodatabase" id="1os-c0-2Eg" userLabel="Bar Button Item">
+                                    <barButtonItem enabled="NO" title="Generate Geodatabase" id="1os-c0-2Eg" userLabel="Bar Button Item">
                                         <connections>
                                             <action selector="generateOrSync" destination="x5g-SP-gLy" id="5Ky-fq-dYu"/>
                                         </connections>
@@ -73,7 +73,6 @@
                         <outlet property="extentView" destination="r5p-5s-jhB" id="Jpf-uw-Cte"/>
                         <outlet property="instructionsLabel" destination="HcO-gi-Dd8" id="kRJ-PE-Pcc"/>
                         <outlet property="mapView" destination="0sH-Kk-wWr" id="39U-ww-1Lh"/>
-                        <outlet property="toolBar" destination="IcZ-Ht-3Pq" id="TuF-KQ-RXm"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="05V-VB-iTD" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/arcgis-ios-sdk-samples/Edit data/Edit and sync features/EditAndSyncFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit and sync features/EditAndSyncFeaturesViewController.swift
@@ -80,13 +80,14 @@ class EditAndSyncFeaturesViewController: UIViewController {
                 self.presentAlert(error: error)
             } else {
                 let featureServiceInfo = self.geodatabaseSyncTask.featureServiceInfo!
-                for index in featureServiceInfo.layerInfos.indices.reversed() {
-                    // For each layer in the serice, add a layer to the map.
-                    let layerURL = self.featureServiceURL.appendingPathComponent(String(index))
+                let featureLayers = featureServiceInfo.layerInfos.compactMap { (layerInfo) -> AGSFeatureLayer? in
+                    let layerID = layerInfo.id
+                    guard layerID >= 0 else { return nil }
+                    let layerURL = self.featureServiceURL.appendingPathComponent(String(layerID))
                     let featureTable = AGSServiceFeatureTable(url: layerURL)
-                    let featureLayer = AGSFeatureLayer(featureTable: featureTable)
-                    self.mapView.map?.operationalLayers.add(featureLayer)
+                    return AGSFeatureLayer(featureTable: featureTable)
                 }
+                self.mapView.map?.operationalLayers.addObjects(from: featureLayers)
                 self.barButtonItem.isEnabled = true
             }
         }

--- a/arcgis-ios-sdk-samples/Edit data/Edit and sync features/EditAndSyncFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Edit and sync features/EditAndSyncFeaturesViewController.swift
@@ -26,10 +26,6 @@ class EditAndSyncFeaturesViewController: UIViewController {
             let map = AGSMap(basemap: AGSBasemap(baseLayer: tiledLayer))
             // Assign the map to the map view.
             mapView.map = map
-            
-            // Create a geodatabase sync task using the feature service URL.
-            geodatabaseSyncTask = AGSGeodatabaseSyncTask(url: featureServiceURL)
-            self.addFeatureLayers()
         }
     }
     
@@ -41,7 +37,6 @@ class EditAndSyncFeaturesViewController: UIViewController {
         }
     }
     
-    @IBOutlet private var toolBar: UIToolbar!
     @IBOutlet private var barButtonItem: UIBarButtonItem!
     @IBOutlet private var instructionsLabel: UILabel!
     
@@ -52,19 +47,18 @@ class EditAndSyncFeaturesViewController: UIViewController {
     private var geodatabaseSyncTask: AGSGeodatabaseSyncTask!
     private var geodatabase: AGSGeodatabase!
     private var areaOfInterest: AGSEnvelope!
-
+    
     private var selectedFeature: AGSFeature? {
         didSet {
-            if let feature = selectedFeature {
-                if let featureLayer = feature.featureTable?.layer as? AGSFeatureLayer {
-                    featureLayer.select(feature)
-                }
+            if let feature = selectedFeature,
+               let featureLayer = feature.featureTable?.layer as? AGSFeatureLayer {
+                featureLayer.select(feature)
             } else {
                 clearSelection()
             }
         }
     }
-
+    
     private func extentViewFrameToEnvelope() -> AGSEnvelope {
         let frame = mapView.convert(extentView.frame, from: view)
         
@@ -86,21 +80,14 @@ class EditAndSyncFeaturesViewController: UIViewController {
                 self.presentAlert(error: error)
             } else {
                 let featureServiceInfo = self.geodatabaseSyncTask.featureServiceInfo!
-                let map = self.mapView.map!
-                for index in featureServiceInfo.layerInfos.indices {
+                for index in featureServiceInfo.layerInfos.indices.reversed() {
                     // For each layer in the serice, add a layer to the map.
                     let layerURL = self.featureServiceURL.appendingPathComponent(String(index))
                     let featureTable = AGSServiceFeatureTable(url: layerURL)
-                    featureTable.load { [weak self, unowned featureTable] error in
-                        guard let self = self else { return }
-                        if let error = error {
-                            self.presentAlert(error: error)
-                        } else if featureTable.geometryType == .point {
-                            let featureLayer = AGSFeatureLayer(featureTable: featureTable)
-                            map.operationalLayers.add(featureLayer)
-                        }
-                    }
+                    let featureLayer = AGSFeatureLayer(featureTable: featureTable)
+                    self.mapView.map?.operationalLayers.add(featureLayer)
                 }
+                self.barButtonItem.isEnabled = true
             }
         }
     }
@@ -166,7 +153,10 @@ class EditAndSyncFeaturesViewController: UIViewController {
         geodatabaseSyncTask.defaultGenerateGeodatabaseParameters(withExtent: areaOfInterest) { [weak self] (params: AGSGenerateGeodatabaseParameters?, error: Error?) in
             guard let self = self else { return }
             
-            guard let params = params else { return self.presentAlert(title: "Could not generate default parameters: \(error!)") }
+            guard let params = params else {
+                self.presentAlert(title: "Could not generate default parameters: \(error!)")
+                return
+            }
             // Don't include attachments to minimize the geodatabase size.
             params.returnAttachments = false
             
@@ -177,7 +167,7 @@ class EditAndSyncFeaturesViewController: UIViewController {
             let downloadFileURL = documentDirectoryURL
                 .appendingPathComponent(dateFormatter.string(from: Date()))
                 .appendingPathExtension("geodatabase")
-           
+            
             // Request a job to generate the geodatabase.
             let generateGeodatabaseJob = self.geodatabaseSyncTask.generateJob(with: params, downloadFileURL: downloadFileURL)
             self.generateJob = generateGeodatabaseJob
@@ -245,6 +235,10 @@ class EditAndSyncFeaturesViewController: UIViewController {
         
         // Add the source code button item to the right of navigation bar.
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["EditAndSyncFeaturesViewController"]
+        
+        // Create a geodatabase sync task using the feature service URL.
+        geodatabaseSyncTask = AGSGeodatabaseSyncTask(url: featureServiceURL)
+        addFeatureLayers()
     }
 }
 


### PR DESCRIPTION
This PR is a quick fix to address the AppStore feedback on the crash in `Edit and sync features` sample

- Add `SanFrancisco.tpk` on-demand resource into plist dependency
- Fix the features not showing issue when the feature layers are loaded
- Clear away some smelling code

The sample would need further refactor, but as we are catching up with a release, let's punt it into the future...

Astonishingly, the On-Demand Resource bug has been there since 2019, but we never caught it as we've never run ad-hoc test on the AppStore released version. 😨 Really hard to catch.