### PR TITLE
Update: Create load report, Utility network URL for sample server 7

### DIFF
--- a/arcgis-ios-sdk-samples/Utility network/Create load report/CreateLoadReportViewController.swift
+++ b/arcgis-ios-sdk-samples/Utility network/Create load report/CreateLoadReportViewController.swift
@@ -28,7 +28,7 @@ class CreateLoadReportViewController: UIViewController {
     // MARK: Properties
     
     /// A feature service of an electric utility network in Naperville, Illinois.
-    let utilityNetwork = AGSUtilityNetwork(url: URL(string: "https://sampleserver7.arcgisonline.com/arcgis/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer")!)
+    let utilityNetwork = AGSUtilityNetwork(url: URL(string: "https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer")!)
     /// The initial conditional expression.
     var initialExpression: AGSUtilityTraceConditionalExpression!
     /// The trace parameters for creating load reports.

--- a/arcgis-ios-sdk-samples/Utility network/Create load report/CreateLoadReportViewController.swift
+++ b/arcgis-ios-sdk-samples/Utility network/Create load report/CreateLoadReportViewController.swift
@@ -64,6 +64,9 @@ class CreateLoadReportViewController: UIViewController {
     /// Load the utility network.
     func loadUtilityNetwork() {
         SVProgressHUD.show(withStatus: "Loading utility network…")
+        // NOTE: Never hardcode login information in a production application.
+        // This is done solely for the sake of the sample.
+        utilityNetwork.credential = AGSCredential(user: "viewer01", password: "I68VGU^nMurF")
         utilityNetwork.load { [weak self] error in
             SVProgressHUD.dismiss()
             guard let self = self else { return }

--- a/arcgis-ios-sdk-samples/Utility network/Create load report/README.md
+++ b/arcgis-ios-sdk-samples/Utility network/Create load report/README.md
@@ -49,7 +49,7 @@ Choose phases to be included in the report. Tap "Run" to initiate a downstream t
 
 ## About the data
 
-The [Naperville electrical](https://sampleserver7.arcgisonline.com/arcgis/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) network feature service, hosted on ArcGIS Online, contains a utility network used to run the subnetwork-based trace shown in this sample.
+The [Naperville electrical](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) network feature service, hosted on ArcGIS Online, contains a utility network used to run the subnetwork-based trace shown in this sample.
 
 ## Additional information
 


### PR DESCRIPTION
There has been 1 additional UN sample `Create load report` added since we created #1026 . With the rolled out SS7, the `Create load report` sample doesn't work with the invalid URL anymore.

This PR fixes the issue with the new URL and credentials.