### PR TITLE
Update: master to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,11 +2,11 @@
 name: README and metadata formatting
 
 # Controls when the action will run.
-# Below triggers the workflow on pull requests to `master` or `v.next` branch.
+# Below triggers the workflow on pull requests to `main` or `v.next` branch.
 on:
   pull_request:
     branches:
-      - master
+      - main
       - v.next
 
 # A workflow run is made up of one or more jobs that can run sequentially or

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains Swift sample code demonstrating the capabilities of [Ar
 
 ![Samples app](SamplesApp.png)
 
-The ```master``` branch of this repository contains samples configured for the latest available version of ArcGIS Runtime SDK for iOS. For samples configured for older versions of the SDK, look under the [```Releases```](https://github.com/Esri/arcgis-runtime-samples-ios/releases) tab for a specific version.
+The ```main``` branch of this repository contains samples configured for the latest available version of ArcGIS Runtime SDK for iOS. For samples configured for older versions of the SDK, look under the [```Releases```](https://github.com/Esri/arcgis-runtime-samples-ios/releases) tab for a specific version.
 
 ## Features
 
@@ -87,7 +87,7 @@ Note: Without licensing or licensing with invalid keys do not throw an exception
 
 Visit the developer's website to learn more about [Licensing your ArcGIS Runtime App](https://developers.arcgis.com/pricing/licensing/) and [Security and authentication](https://developers.arcgis.com/documentation/mapping-apis-and-location-services/security-and-authentication/).
 
-To learn more about `masquerade`, consult the [documentation](https://github.com/Esri/data-collection-ios/tree/master/docs#masquerade) of Esri's Data Collection app.
+To learn more about `masquerade`, consult the [documentation](https://github.com/Esri/data-collection-ios/tree/main/docs#masquerade) of Esri's Data Collection app.
 
 ## Additional Resources
 

--- a/README.md
+++ b/README.md
@@ -119,4 +119,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-A copy of the license is available in the repository's [LICENSE](https://github.com/Esri/arcgis-runtime-samples-ios/blob/master/LICENSE) file.
+A copy of the license is available in the repository's [LICENSE](https://github.com/Esri/arcgis-runtime-samples-ios/blob/main/LICENSE) file.


### PR DESCRIPTION
This PR updates the wording `master` to `main`, to reflect the change in the primary branch's name.

Please note: this change directly targets at the `main` branch. Later these same changes will be merged into `v.next`

Also, I'm cancelling the status check because it depends on the branch name being `master`. After it's been merged, everything should be back to normal. 🤞 

Refs:
- https://github.com/github/renaming#later-this-year
- common-samples/issues/2251