### PR TITLE
Update: Replace route API and remove OAuth from Navigate in AR

### DIFF
--- a/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/NavigateARRoutePlannerViewController.swift
+++ b/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/NavigateARRoutePlannerViewController.swift
@@ -38,8 +38,8 @@ class NavigateARRoutePlannerViewController: UIViewController {
     
     // MARK: Instance properties
     
-    /// The route task that solves the route using the online routing service, with authentication required.
-    let routeTask = AGSRouteTask(url: URL(string: "https://route.arcgis.com/arcgis/rest/services/World/Route/NAServer/Route_World")!)
+    /// The route task that solves the route using the online routing service, using API key authentication.
+    let routeTask = AGSRouteTask(url: URL(string: "https://route-api.arcgis.com/arcgis/rest/services/World/Route/NAServer/Route_World")!)
     /// The parameters for route task to solve a route.
     var routeParameters: AGSRouteParameters!
     /// The data source to track device location and provide updates to location display.
@@ -55,13 +55,6 @@ class NavigateARRoutePlannerViewController: UIViewController {
         )
         return overlay
     }()
-    
-    /// An OAuth2 configuration to access online routing service.
-    let oAuthConfiguration = AGSOAuthConfiguration(
-        portalURL: URL(string: "https://www.arcgis.com")!,
-        clientID: "lgAdHkYZYlwwfAhC",
-        redirectURL: "my-ags-app://auth"
-    )
     
     /// An `AGSPoint` representing the start of navigation.
     var startPoint: AGSPoint? {
@@ -156,10 +149,6 @@ class NavigateARRoutePlannerViewController: UIViewController {
         // Avoid overlapping status label and map content.
         mapView.contentInset.top = 2 * statusLabel.font.lineHeight
         
-        // Configure the authentication manager to show the OAuth dialog.
-        AGSAuthenticationManager.shared().delegate = self
-        AGSAuthenticationManager.shared().oAuthConfigurations.add(oAuthConfiguration)
-        
         routeTask.load { [weak self] (error: Error?) in
             guard let self = self else { return }
             if let error = error {
@@ -199,11 +188,6 @@ class NavigateARRoutePlannerViewController: UIViewController {
             }
         }
     }
-    
-    deinit {
-        AGSAuthenticationManager.shared().oAuthConfigurations.remove(oAuthConfiguration)
-        AGSAuthenticationManager.shared().credentialCache.removeAllCredentials()
-    }
 }
 
 // MARK: - Set route start and end on touch
@@ -224,18 +208,5 @@ extension NavigateARRoutePlannerViewController: AGSGeoViewTouchDelegate {
                 }
             }
         }
-    }
-}
-
-// MARK: - Show OAuth dialog for route service
-
-extension NavigateARRoutePlannerViewController: AGSAuthenticationManagerDelegate {
-    func authenticationManager( _ authenticationManager: AGSAuthenticationManager, wantsToShow viewController: UIViewController) {
-        viewController.modalPresentationStyle = .overFullScreen
-        present(viewController, animated: true)
-    }
-    
-    func authenticationManager(_ authenticationManager: AGSAuthenticationManager, wantsToDismiss viewController: UIViewController) {
-        dismiss(animated: true)
     }
 }

--- a/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/README.md
+++ b/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/README.md
@@ -52,13 +52,17 @@ When you start, route instructions will be displayed and spoken. As you proceed 
 
 This sample uses Esri's [World Elevation](https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer) service to ensure that route lines are placed appropriately in 3D space. It uses Esri's [World Route](https://www.arcgis.com/home/item.html?id=1feb41652c5c4bd2ba5c60df2b4ea2c4) service to calculate routes. The world routing service requires authentication and does consume ArcGIS Online credits.
 
-**Note:** This item requires an ArcGIS Online organizational subscription or an ArcGIS Developer account and consumes credits.
+**Note:** This routing service requires one of the following authentication methods
 
-To access this sample, you'll need to do one of the following:
+* An ArcGIS Online organizational subscription and consumes credits
+* An ArcGIS Developer account and consumes credits
+* An API key
 
-* Sign in with an account that is a member of an organizational subscription.
-* Sign in with a developer account.
-* Register an application and use your application's credentials.
+To access this sample with ArcGIS identity/named user login using OAuth workflow, please read more at [ArcGIS Identity](https://developers.arcgis.com/documentation/mapping-apis-and-services/security/arcgis-identity/).
+
+The routing service can also be accessed with an API key, either specified in AppDelegate or in the sample. Please read more at [API keys](https://developers.arcgis.com/documentation/mapping-apis-and-services/security/api-keys/).
+
+Learn more about [security and authentication on ArcGIS Developers website](https://developers.arcgis.com/documentation/mapping-apis-and-services/security/).
 
 ## Additional information
 

--- a/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/README.md
+++ b/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/README.md
@@ -50,17 +50,17 @@ When you start, route instructions will be displayed and spoken. As you proceed 
 
 ## About the data
 
-This sample uses Esri's [World Elevation](https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer) service to ensure that route lines are placed appropriately in 3D space. It uses Esri's [World Route](https://www.arcgis.com/home/item.html?id=1feb41652c5c4bd2ba5c60df2b4ea2c4) service to calculate routes. The world routing service requires authentication and does consume ArcGIS Online credits.
+This sample uses Esri's [World Elevation](https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer) service to ensure that route lines are placed appropriately in 3D space. It uses Esri's [World Route](https://www.arcgis.com/home/item.html?id=1feb41652c5c4bd2ba5c60df2b4ea2c4) service to calculate routes.
 
-**Note:** This routing service requires one of the following authentication methods
+**Note:** This routing service requires one of the following authentication methods:
 
-* An ArcGIS Online organizational subscription and consumes credits
-* An ArcGIS Developer account and consumes credits
+* An ArcGIS Online organizational subscription and credits
+* An ArcGIS Developer account and credits
 * An API key
 
-To access this sample with ArcGIS identity/named user login using OAuth workflow, please read more at [ArcGIS Identity](https://developers.arcgis.com/documentation/mapping-apis-and-services/security/arcgis-identity/).
+To access the routing service with ArcGIS identity/named user login using OAuth workflow, please read more at [ArcGIS Identity](https://developers.arcgis.com/documentation/mapping-apis-and-services/security/arcgis-identity/).
 
-The routing service can also be accessed with an API key, either specified in AppDelegate or in the sample. Please read more at [API keys](https://developers.arcgis.com/documentation/mapping-apis-and-services/security/api-keys/).
+The routing service can also be accessed with an API key. Please read more at [API keys](https://developers.arcgis.com/documentation/mapping-apis-and-services/security/api-keys/).
 
 Learn more about [security and authentication on ArcGIS Developers website](https://developers.arcgis.com/documentation/mapping-apis-and-services/security/).
 


### PR DESCRIPTION
This PR resolves the issue in

- common-samples/issues/2678
- common-samples/issues/2677

that uses API key instead of OAuth to authenticate the user for the navigation task.