### PR TITLE
Fix: Explicitly specify the result types for Create load report

### DIFF
--- a/arcgis-ios-sdk-samples/Utility network/Create load report/CreateLoadReportViewController.swift
+++ b/arcgis-ios-sdk-samples/Utility network/Create load report/CreateLoadReportViewController.swift
@@ -97,9 +97,9 @@ class CreateLoadReportViewController: UIViewController {
         // Set the default expression.
         initialExpression = traceConfiguration.traversability?.barriers as? AGSUtilityTraceConditionalExpression
         
-        // Create downstream trace parameters with function outputs.
+        // Create downstream trace parameters with elements and function outputs.
         let traceParameters = AGSUtilityTraceParameters(traceType: .downstream, startingLocations: [startingLocation])
-        traceParameters.resultTypes.append(.ags_value(with: .functionOutputs))
+        traceParameters.resultTypes = [.ags_value(with: .elements), .ags_value(with: .functionOutputs)]
         
         // The service category for counting total customers.
         if let serviceCategory = utilityNetwork.definition.categories.first(where: { $0.name == "ServicePoint" }),


### PR DESCRIPTION
After the Friday review meeting, Tanner and I collaborated to find out the issue within the code. And later we realized that it would be better to explicitly specify the result types for the trace, instead of relying on the default populated elements type.

![image](https://user-images.githubusercontent.com/9660181/114226715-c8b55280-9928-11eb-9654-1c0d2356f53c.png)

Pros and cons for this change:

- Pros: the user can have a clearer expectation for the output result types
- Cons: it seems a bit redundant to override the default value, as it was described in the docstring

I find this change helpful because I didn't realize/took for granted that the element output type was implicitly included, without thinking about the reason.

Please let me know your thoughts!

---

This PR doesn't change the behavior of the sample.