### PR TITLE
Logistics: Add gitattributes to exclude paths from linguist detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+Scripts linguist-detectable=false
+"arcgis-ios-sdk-samples/Content Display Logic/Js" linguist-vendored


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9660181/115080932-5ad4d200-9eb8-11eb-8053-3e89c30083ae.png)

[Linguist](https://github.com/github/linguist) is the GitHub tool for summarizing repo language stats.

By adding a `.gitattributes` configuration file and merge it onto `main` branch in U11, we'll have a fully Swift repo, 100% orange bar.
IMO it would make our repo look more professional and up-to-date.

Doc here for excluded items: https://github.com/github/linguist/blob/master/docs/overrides.md#summary

Do you think this is necessary/acceptable?