### PR TITLE
Update: Use basemap API key instead of global key for Create and save map

### DIFF
--- a/arcgis-ios-sdk-samples/Maps/Create and save a map/CreateSaveMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Create and save a map/CreateSaveMapViewController.swift
@@ -47,7 +47,8 @@ class CreateSaveMapViewController: UIViewController, CreateOptionsViewController
             "CreateOptionsViewController",
             "SaveAsViewController"
         ]
-        
+        // Temporarily remove the API key for this sample.
+        // Please see the additional information in the README.
         apiKey = AGSArcGISRuntimeEnvironment.apiKey
         AGSArcGISRuntimeEnvironment.apiKey = ""
         

--- a/arcgis-ios-sdk-samples/Maps/Create and save a map/CreateSaveMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Create and save a map/CreateSaveMapViewController.swift
@@ -36,7 +36,6 @@ class CreateSaveMapViewController: UIViewController, CreateOptionsViewController
     @IBOutlet private weak var mapView: AGSMapView!
     
     private var portal: AGSPortal?
-    private var apiKey: String!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -47,10 +46,6 @@ class CreateSaveMapViewController: UIViewController, CreateOptionsViewController
             "CreateOptionsViewController",
             "SaveAsViewController"
         ]
-        // Temporarily remove the API key for this sample.
-        // Please see the additional information in the README.
-        apiKey = AGSArcGISRuntimeEnvironment.apiKey
-        AGSArcGISRuntimeEnvironment.apiKey = ""
         
         // Auth Manager settings
         let config = AGSOAuthConfiguration(portalURL: nil, clientID: "xHx4Nj7q1g19Wh6P", redirectURL: "iOSSamples://auth")
@@ -59,10 +54,6 @@ class CreateSaveMapViewController: UIViewController, CreateOptionsViewController
         
         // Initially show the map creation UI.
         performSegue(withIdentifier: "CreateNewSegue", sender: self)
-    }
-    
-    deinit {
-        AGSArcGISRuntimeEnvironment.apiKey = apiKey
     }
     
     private func showSuccess() {
@@ -115,7 +106,6 @@ class CreateSaveMapViewController: UIViewController, CreateOptionsViewController
     
     func createOptionsViewController(_ createOptionsViewController: CreateOptionsViewController, didSelectBasemap basemap: AGSBasemap, layers: [AGSLayer]) {
         // Create a map with the selected basemap.
-        basemap.apiKey = apiKey
         let map = AGSMap(basemap: basemap)
         
         // Add the selected operational layers.
@@ -144,6 +134,11 @@ class CreateSaveMapViewController: UIViewController, CreateOptionsViewController
             // Also to cut on the size.
             let croppedImage: UIImage? = image?.croppedImage(CGSize(width: 200, height: 200))
             
+            // Temporarily unset the API key for this sample.
+            // Please see the additional information in the README.
+            let apiKey = AGSArcGISRuntimeEnvironment.apiKey
+            AGSArcGISRuntimeEnvironment.apiKey = ""
+            
             self.mapView.map?.save(as: title, portal: self.portal!, tags: tags, folder: nil, itemDescription: itemDescription, thumbnail: croppedImage, forceSaveToSupportedVersion: true) { [weak self] (error) in
                 // Dismiss progress hud.
                 UIApplication.shared.hideProgressHUD()
@@ -155,6 +150,8 @@ class CreateSaveMapViewController: UIViewController, CreateOptionsViewController
                     }
                 }
             }
+            
+            AGSArcGISRuntimeEnvironment.apiKey = apiKey
         }
     }
 }

--- a/arcgis-ios-sdk-samples/Maps/Create and save a map/CreateSaveMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Create and save a map/CreateSaveMapViewController.swift
@@ -36,6 +36,7 @@ class CreateSaveMapViewController: UIViewController, CreateOptionsViewController
     @IBOutlet private weak var mapView: AGSMapView!
     
     private var portal: AGSPortal?
+    private var apiKey: String!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -47,6 +48,9 @@ class CreateSaveMapViewController: UIViewController, CreateOptionsViewController
             "SaveAsViewController"
         ]
         
+        apiKey = AGSArcGISRuntimeEnvironment.apiKey
+        AGSArcGISRuntimeEnvironment.apiKey = ""
+        
         // Auth Manager settings
         let config = AGSOAuthConfiguration(portalURL: nil, clientID: "xHx4Nj7q1g19Wh6P", redirectURL: "iOSSamples://auth")
         AGSAuthenticationManager.shared().oAuthConfigurations.add(config)
@@ -54,6 +58,10 @@ class CreateSaveMapViewController: UIViewController, CreateOptionsViewController
         
         // Initially show the map creation UI.
         performSegue(withIdentifier: "CreateNewSegue", sender: self)
+    }
+    
+    deinit {
+        AGSArcGISRuntimeEnvironment.apiKey = apiKey
     }
     
     private func showSuccess() {
@@ -106,6 +114,7 @@ class CreateSaveMapViewController: UIViewController, CreateOptionsViewController
     
     func createOptionsViewController(_ createOptionsViewController: CreateOptionsViewController, didSelectBasemap basemap: AGSBasemap, layers: [AGSLayer]) {
         // Create a map with the selected basemap.
+        basemap.apiKey = apiKey
         let map = AGSMap(basemap: basemap)
         
         // Add the selected operational layers.

--- a/arcgis-ios-sdk-samples/Maps/Create and save a map/CreateSaveMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Create and save a map/CreateSaveMapViewController.swift
@@ -142,6 +142,7 @@ class CreateSaveMapViewController: UIViewController, CreateOptionsViewController
             self.mapView.map?.save(as: title, portal: self.portal!, tags: tags, folder: nil, itemDescription: itemDescription, thumbnail: croppedImage, forceSaveToSupportedVersion: true) { [weak self] (error) in
                 // Dismiss progress hud.
                 UIApplication.shared.hideProgressHUD()
+                AGSArcGISRuntimeEnvironment.apiKey = apiKey
                 if let error = error {
                     saveAsViewController.presentAlert(error: error)
                 } else {
@@ -150,8 +151,6 @@ class CreateSaveMapViewController: UIViewController, CreateOptionsViewController
                     }
                 }
             }
-            
-            AGSArcGISRuntimeEnvironment.apiKey = apiKey
         }
     }
 }

--- a/arcgis-ios-sdk-samples/Maps/Create and save a map/README.md
+++ b/arcgis-ios-sdk-samples/Maps/Create and save a map/README.md
@@ -29,7 +29,7 @@ Select the basemap and layers you'd like to add to your map. Tap the "Save" butt
 
 ## Additional information
 
-In this sample, an API key is set directly on `AGSBasemap` objects rather than on the whole app using the `AGSArcGISRuntimeEnvironment` class. This is useful in a scenario where an individual developer is part of an organization within ArcGIS Online that uses an API key to access a range of `AGSBasemapStyle`s. In the case that an individual member of the organization wants to save a map locally to their account, and not that of the organization, they can set the organization's API key on the basemap, and log in to their own account when challenged. The individual can then save the final map to their own ArcGIS Online account.
+In this sample, the API key is unset from `AGSArcGISRuntimeEnvironment` class when the user wants to save the map. This is useful in a scenario where an individual developer is part of an organization within ArcGIS Online that uses an API key to access a range of `AGSBasemapStyle`s. In the case that an individual member of the organization wants to save a map locally to their account, and not that of the organization, they can either set the organization's API key on the basemap, or set it as the environment key, unset before saving the map, and log in to their own account when challenged. The individual can then save the final map to their own ArcGIS Online account.
 
 ## Tags
 

--- a/arcgis-ios-sdk-samples/Maps/Create and save a map/README.md
+++ b/arcgis-ios-sdk-samples/Maps/Create and save a map/README.md
@@ -29,7 +29,7 @@ Select the basemap and layers you'd like to add to your map. Tap the "Save" butt
 
 ## Additional information
 
-The sample allows users to view the basemaps with the pre-baked API key. To save the map to ArcGIS Online, please login with an ArcGIS identity/named user account.
+In this sample, an API key is set directly on `AGSBasemap` objects rather than on the whole app using the `AGSArcGISRuntimeEnvironment` class. This is useful in a scenario where an individual developer is part of an organization within ArcGIS Online that uses an API key to access a range of `AGSBasemapStyle`s. In the case that an individual member of the organization wants to save a map locally to their account, and not that of the organization, they can set the organization's API key on the basemap, and log in to their own account when challenged.  The individual can then save the final map to their own ArcGIS Online account.
 
 ## Tags
 

--- a/arcgis-ios-sdk-samples/Maps/Create and save a map/README.md
+++ b/arcgis-ios-sdk-samples/Maps/Create and save a map/README.md
@@ -27,6 +27,10 @@ Select the basemap and layers you'd like to add to your map. Tap the "Save" butt
 * AGSMap.save
 * AGSPortal
 
+## Additional information
+
+The sample allows users to view the basemaps with the pre-baked API keys. To save the map to ArcGIS Online, please login with an ArcGIS identity/named user account.
+
 ## Tags
 
 ArcGIS Online, ArcGIS Pro, portal, publish, share, web map

--- a/arcgis-ios-sdk-samples/Maps/Create and save a map/README.md
+++ b/arcgis-ios-sdk-samples/Maps/Create and save a map/README.md
@@ -29,7 +29,7 @@ Select the basemap and layers you'd like to add to your map. Tap the "Save" butt
 
 ## Additional information
 
-In this sample, an API key is set directly on `AGSBasemap` objects rather than on the whole app using the `AGSArcGISRuntimeEnvironment` class. This is useful in a scenario where an individual developer is part of an organization within ArcGIS Online that uses an API key to access a range of `AGSBasemapStyle`s. In the case that an individual member of the organization wants to save a map locally to their account, and not that of the organization, they can set the organization's API key on the basemap, and log in to their own account when challenged.  The individual can then save the final map to their own ArcGIS Online account.
+In this sample, an API key is set directly on `AGSBasemap` objects rather than on the whole app using the `AGSArcGISRuntimeEnvironment` class. This is useful in a scenario where an individual developer is part of an organization within ArcGIS Online that uses an API key to access a range of `AGSBasemapStyle`s. In the case that an individual member of the organization wants to save a map locally to their account, and not that of the organization, they can set the organization's API key on the basemap, and log in to their own account when challenged. The individual can then save the final map to their own ArcGIS Online account.
 
 ## Tags
 

--- a/arcgis-ios-sdk-samples/Maps/Create and save a map/README.md
+++ b/arcgis-ios-sdk-samples/Maps/Create and save a map/README.md
@@ -29,7 +29,7 @@ Select the basemap and layers you'd like to add to your map. Tap the "Save" butt
 
 ## Additional information
 
-The sample allows users to view the basemaps with the pre-baked API keys. To save the map to ArcGIS Online, please login with an ArcGIS identity/named user account.
+The sample allows users to view the basemaps with the pre-baked API key. To save the map to ArcGIS Online, please login with an ArcGIS identity/named user account.
 
 ## Tags
 


### PR DESCRIPTION
## Description

This PR address the issue in `common-samples/issues/2613`, to resolve the potential API key and Named User conflict on creating a portal item, by

- First unassign the environment API key, and keep it in a property (or should I do that in `init()` instead of `viewDidLoad`?)
- Whenever a basemap needs to be accessed, use the API key on the basemap
- When it requires to login to save the map to a user's account, don't use the API key and instead use Named User
- When the sample exits, restore the API key on the environment

## Known Issue

The current `Create and save map` sample works on iOS even if the same sample doesn't work on other platforms. Trevor's comment: `2613#issuecomment-2836473` sums up the the behavior and situation very well. To be more defensive, we tend to make this change on all platforms.
