### PR TITLE
Fix: Add alert for route tracker licensing error

### DIFF
--- a/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/NavigateARNavigatorViewController.swift
+++ b/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/NavigateARNavigatorViewController.swift
@@ -249,7 +249,15 @@ extension NavigateARNavigatorViewController: AGSLocationChangeHandlerDelegate {
     func locationDataSource(_ locationDataSource: AGSLocationDataSource, locationDidChange location: AGSLocation) {
         startButtonItem.isEnabled = true
         // Send location updates to route tracker if actively navigating.
-        routeTracker?.trackLocation(location)
+        routeTracker?.trackLocation(location)  { [weak self] error in
+            guard let self = self else { return }
+            if let error = error {
+                // Display error message and stop further route tracking if it
+                // fails due to formatting or licensing issue.
+                self.setStatus(message: error.localizedDescription)
+                locationDataSource.locationChangeHandlerDelegate = nil
+            }
+        }
     }
 }
 

--- a/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/NavigateARNavigatorViewController.swift
+++ b/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/NavigateARNavigatorViewController.swift
@@ -253,7 +253,7 @@ extension NavigateARNavigatorViewController: AGSLocationChangeHandlerDelegate {
             guard let self = self else { return }
             if let error = error {
                 // Display error message and stop further route tracking if it
-                // fails due to formatting or licensing issue.
+                // fails due to data format, licensing issue, etc.
                 self.setStatus(message: error.localizedDescription)
                 locationDataSource.locationChangeHandlerDelegate = nil
             }

--- a/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/NavigateARNavigatorViewController.swift
+++ b/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/NavigateARNavigatorViewController.swift
@@ -249,13 +249,13 @@ extension NavigateARNavigatorViewController: AGSLocationChangeHandlerDelegate {
     func locationDataSource(_ locationDataSource: AGSLocationDataSource, locationDidChange location: AGSLocation) {
         startButtonItem.isEnabled = true
         // Send location updates to route tracker if actively navigating.
-        routeTracker?.trackLocation(location)  { [weak self] error in
+        routeTracker?.trackLocation(location) { [weak self] error in
             guard let self = self else { return }
             if let error = error {
                 // Display error message and stop further route tracking if it
                 // fails due to data format, licensing issue, etc.
                 self.setStatus(message: error.localizedDescription)
-                locationDataSource.locationChangeHandlerDelegate = nil
+                self.routeTracker = nil
             }
         }
     }

--- a/arcgis-ios-sdk-samples/Route and directions/Navigate route with rerouting/NavigateRouteWithReroutingViewController.swift
+++ b/arcgis-ios-sdk-samples/Route and directions/Navigate route with rerouting/NavigateRouteWithReroutingViewController.swift
@@ -334,8 +334,10 @@ extension NavigateRouteWithReroutingViewController: AGSLocationChangeHandlerDele
         routeTracker?.trackLocation(location) { [weak self] error in
             guard let self = self else { return }
             if let error = error {
+                // Display error message and stop further route tracking if it
+                // fails due to formatting or licensing issue.
                 self.setStatus(message: error.localizedDescription)
-                self.routeTracker.delegate = nil
+                locationDataSource.locationChangeHandlerDelegate = nil
             }
         }
     }

--- a/arcgis-ios-sdk-samples/Route and directions/Navigate route with rerouting/NavigateRouteWithReroutingViewController.swift
+++ b/arcgis-ios-sdk-samples/Route and directions/Navigate route with rerouting/NavigateRouteWithReroutingViewController.swift
@@ -335,7 +335,7 @@ extension NavigateRouteWithReroutingViewController: AGSLocationChangeHandlerDele
             guard let self = self else { return }
             if let error = error {
                 // Display error message and stop further route tracking if it
-                // fails due to formatting or licensing issue.
+                // fails due to data format, licensing issue, etc.
                 self.setStatus(message: error.localizedDescription)
                 locationDataSource.locationChangeHandlerDelegate = nil
             }

--- a/arcgis-ios-sdk-samples/Route and directions/Navigate route with rerouting/NavigateRouteWithReroutingViewController.swift
+++ b/arcgis-ios-sdk-samples/Route and directions/Navigate route with rerouting/NavigateRouteWithReroutingViewController.swift
@@ -337,7 +337,7 @@ extension NavigateRouteWithReroutingViewController: AGSLocationChangeHandlerDele
                 // Display error message and stop further route tracking if it
                 // fails due to data format, licensing issue, etc.
                 self.setStatus(message: error.localizedDescription)
-                locationDataSource.locationChangeHandlerDelegate = nil
+                self.routeTracker = nil
             }
         }
     }

--- a/arcgis-ios-sdk-samples/Route and directions/Navigate route/NavigateRouteViewController.swift
+++ b/arcgis-ios-sdk-samples/Route and directions/Navigate route/NavigateRouteViewController.swift
@@ -327,7 +327,7 @@ extension NavigateRouteViewController: AGSLocationChangeHandlerDelegate {
             guard let self = self else { return }
             if let error = error {
                 // Display error message and stop further route tracking if it
-                // fails due to formatting or licensing issue.
+                // fails due to data format, licensing issue, etc.
                 self.setStatus(message: error.localizedDescription)
                 locationDataSource.locationChangeHandlerDelegate = nil
             }

--- a/arcgis-ios-sdk-samples/Route and directions/Navigate route/NavigateRouteViewController.swift
+++ b/arcgis-ios-sdk-samples/Route and directions/Navigate route/NavigateRouteViewController.swift
@@ -323,6 +323,14 @@ extension NavigateRouteViewController: AGSRouteTrackerDelegate {
 extension NavigateRouteViewController: AGSLocationChangeHandlerDelegate {
     func locationDataSource(_ locationDataSource: AGSLocationDataSource, locationDidChange location: AGSLocation) {
         // Update the tracker location with the new location from the simulated data source.
-        routeTracker?.trackLocation(location)
+        routeTracker?.trackLocation(location) { [weak self] error in
+            guard let self = self else { return }
+            if let error = error {
+                // Display error message and stop further route tracking if it
+                // fails due to formatting or licensing issue.
+                self.setStatus(message: error.localizedDescription)
+                locationDataSource.locationChangeHandlerDelegate = nil
+            }
+        }
     }
 }

--- a/arcgis-ios-sdk-samples/Route and directions/Navigate route/NavigateRouteViewController.swift
+++ b/arcgis-ios-sdk-samples/Route and directions/Navigate route/NavigateRouteViewController.swift
@@ -329,7 +329,7 @@ extension NavigateRouteViewController: AGSLocationChangeHandlerDelegate {
                 // Display error message and stop further route tracking if it
                 // fails due to data format, licensing issue, etc.
                 self.setStatus(message: error.localizedDescription)
-                locationDataSource.locationChangeHandlerDelegate = nil
+                self.routeTracker = nil
             }
         }
     }


### PR DESCRIPTION
## Background

`common-samples/issues/2288`

User may use the route tracker sample code in the sample viewer. There are a few scenarios

- User is in developer mode without a license: the basemap will show the watermark, but all functionalities would work
- User uses a Advanced license string for deployment: all good
- User uses a Lite license string: in this case, since the route tracking is not supported by Lite license, the `AGSRouteTracker.trackLocation(_:completion:)` call would fail and give error. 
    However in our (my 🤕 ) previous implementations, we didn't handle that error and let the sample fail silently. That is due to my negligence of others using Lite license to build the app. See more in #980 

Better depict with a table

||`v.next`|this branch|
|-|-|-|
|Dev mode|✅ no error|✅ no error|
|Lite|❌ error not shown, silently fail|✅ Error handled with prompt|
|Advanced|✅ no error|✅ no error|

## Fix

Add error handling and comment in the code: By nilifying the route tracker, we can stop the route tracking.

This is not an elegant way to stop route tracker from giving a series of errors while location updates keep firing, but it works. Possible ways include:
    
- ✅  Nilify the route tracker object
- Nililfy the `locationChangeHandlerDelegate` on the data source, hence stop location updates.
- When error encountered, call the `reset` method in the VC, so that no more location updates are given. All 3 samples can be reset.

Also, we can show an alert instead of updating the status label to show this error. What do you think? (like this 👇 )

![error](https://user-images.githubusercontent.com/9660181/118199367-cc486780-b407-11eb-83fc-f8cc865fe434.png)

## How to test

- Swap the Advanced license key in the dev `.secrets` file with a Lite one (which can be acquired [here](https://developers.arcgis.com/ios/license-and-deployment/)), and compare `v.next` with this branch. The former will fail silently while the latter show the error in status label.
