### PR TITLE
Fix: location display overlapping issue in `Show location history`

### DIFF
--- a/arcgis-ios-sdk-samples/Maps/Show location history/LocationHistoryViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Show location history/LocationHistoryViewController.swift
@@ -105,6 +105,8 @@ class LocationHistoryViewController: UIViewController {
     private var trackBuilder: AGSPolylineBuilder?
     private var pointBuilder: AGSMultipointBuilder?
     
+    private var lastPosition: AGSPoint?
+    
     // MARK: UIViewController
     
     override func viewDidLoad() {
@@ -156,7 +158,7 @@ class LocationHistoryViewController: UIViewController {
     }
     
     private func processLocationUpdate() {
-        guard isTracking, let position = mapView.locationDisplay.mapLocation, position.x != 0, position.y != 0 else { return }
+        guard isTracking, let position = lastPosition, position.x != 0, position.y != 0 else { return }
         pointBuilder?.points.add(position)
         locationGraphic.geometry = pointBuilder?.toGeometry()
         trackBuilder?.add(position)
@@ -202,9 +204,10 @@ class LocationHistoryViewController: UIViewController {
     
     private func startProcessingLocationChanges() {
         mapView.locationDisplay.locationChangedHandler = { [weak self] (location) in
-            guard location.horizontalAccuracy >= 0 else { return }
+            guard let self = self, location.horizontalAccuracy >= 0 else { return }
             DispatchQueue.main.async {
-                self?.processLocationUpdate()
+                self.processLocationUpdate()
+                self.lastPosition = location.position
             }
         }
     }


### PR DESCRIPTION
Please refer to `common-samples/issues/2239` for more details.

Last year Simone from Java team noticed that

> I noticed that if you pan away from the location symbol, then pan back again, extra polylines are created on the tracking line.

It is due to that this sample reads the current location from the location display's `mapLocation`, i.e. the location of the blue indicator, and uses it to create the polyline. There was a pan momentum on the `mapView` which makes this position point not accurate enough, and causes overlapping polyline graphics.

![overlap](https://user-images.githubusercontent.com/9660181/120567401-8fe4a780-c3c6-11eb-9999-db7e9ad40adc.png)

A video before making the changes in this PR - see the polylines

https://user-images.githubusercontent.com/9660181/120567560-f5d12f00-c3c6-11eb-8a5d-bbd36e87bac6.mp4

One way to fix the issue is to pass the location update from `locationChangedHandler` to the polyline builder. But that will make the polyline display ahead of the location indicator. See the video below.

https://user-images.githubusercontent.com/9660181/120567653-1ef1bf80-c3c7-11eb-83af-d8999c06bcbc.mp4

Alternatively, we store the last location point as a property, and each time the location updates, we draw the last point. This is how Qt and Java dealt with the problem.

https://github.com/Esri/arcgis-runtime-samples-qt/blob/93705a8adf66497737d0919cc3f2dd78044fd18c/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowLocationHistory/ShowLocationHistory.cpp#L143

https://github.com/Esri/arcgis-runtime-samples-java/blob/624c1034d76e58c99f919dde95be39515adfb7a3/map_view/show-location-history/src/main/java/com/esri/samples/show_location_history/ShowLocationHistorySample.java#L151