### PR TITLE
Update: Add GIF extension to the metadata checker script

### DIFF
--- a/Scripts/CI/README_Metadata_StyleCheck/metadata_style_checker.py
+++ b/Scripts/CI/README_Metadata_StyleCheck/metadata_style_checker.py
@@ -138,7 +138,7 @@ class MetadataCreator:
         """
         results = []
         for file in os.listdir(self.folder_path):
-            if os.path.splitext(file)[1].lower() in ['.png']:
+            if os.path.splitext(file)[1].lower() in ['.png', '.gif']:
                 results.append(file)
         if not results:
             raise Exception('Unable to get images paths.')


### PR DESCRIPTION
This PR adds the GIF extension to the checker script so that it doesn't give an error for https://github.com/Esri/arcgis-runtime-samples-ios/pull/1080 .