### PR TITLE
Update: 100.11.2 version number

### DIFF
--- a/arcgis-ios-sdk-samples.xcodeproj/project.pbxproj
+++ b/arcgis-ios-sdk-samples.xcodeproj/project.pbxproj
@@ -5634,7 +5634,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 100.11.1;
+				MARKETING_VERSION = 100.11.2;
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.esri.arcgis-ios-sdk-samples";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -5663,7 +5663,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 100.11.1;
+				MARKETING_VERSION = 100.11.2;
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.esri.arcgis-ios-sdk-samples";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Similar to #1069 

Note: 100.11.2 pre UC build of the sample viewer will be uploaded around July 2nd, next Friday. 
Before that, a TestFlight build will be rolled out. - done

I'll start to draft a release note/list of samples updated for 11.2 soon.