### PR TITLE
Update: Replace/Remove OAuth with API key

### DIFF
--- a/arcgis-ios-sdk-samples/Maps/Generate offline map (overrides)/GenerateOfflineMapOverridesViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map (overrides)/GenerateOfflineMapOverridesViewController.swift
@@ -17,7 +17,7 @@
 import UIKit
 import ArcGIS
 
-class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthenticationManagerDelegate {
+class GenerateOfflineMapOverridesViewController: UIViewController {
     @IBOutlet weak var mapView: AGSMapView!
     @IBOutlet weak var extentView: UIView!
     @IBOutlet weak var generateButtonItem: UIBarButtonItem!
@@ -31,7 +31,6 @@ class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthentica
     private var parameterOverrides: AGSGenerateOfflineMapParameterOverrides?
     private var offlineMapTask: AGSOfflineMapTask?
     private var generateOfflineMapJob: AGSGenerateOfflineMapJob?
-    private var shouldShowAlert = true
     
     private var progressObservation: NSKeyValueObservation?
     
@@ -40,20 +39,8 @@ class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthentica
         
         // add the source code button item to the right of navigation bar
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["GenerateOfflineMapOverridesViewController", "OfflineMapParameterOverridesViewController"]
-
-        // prepare the authentication manager for user login (required for taking the sample's basemap offline)
-        let config = AGSOAuthConfiguration(portalURL: nil, clientID: "xHx4Nj7q1g19Wh6P", redirectURL: "iOSSamples://auth")
-        AGSAuthenticationManager.shared().oAuthConfigurations.add(config)
-        AGSAuthenticationManager.shared().credentialCache.removeAllCredentials()
-    }
-    
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
         
-        if shouldShowAlert {
-            shouldShowAlert = false
-            showLoginQueryAlert()
-        }
+        addMap()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -64,7 +51,7 @@ class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthentica
     
     private func addMap() {
         // portal for the web map
-        let portal = AGSPortal.arcGISOnline(withLoginRequired: true)
+        let portal = AGSPortal.arcGISOnline(withLoginRequired: false)
         
         // portal item for web map
         let portalItem = AGSPortalItem(portal: portal, itemID: "acc027394bc84c2fb04d1ed317aac674")
@@ -279,20 +266,6 @@ class GenerateOfflineMapOverridesViewController: UIViewController, AGSAuthentica
     }
     
     // MARK: - Helper methods
-    
-    private func showLoginQueryAlert() {
-        let alertController = UIAlertController(title: nil, message: "This sample requires you to login in order to take the map's basemap offline. Would you like to continue?", preferredStyle: .alert)
-        let loginAction = UIAlertAction(title: "Login", style: .default) { [weak self] (_) in
-            self?.addMap()
-        }
-        
-        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
-        
-        alertController.addAction(cancelAction)
-        alertController.addAction(loginAction)
-        alertController.preferredAction = loginAction
-        present(alertController, animated: true)
-    }
     
     private func extentViewFrameToEnvelope() -> AGSEnvelope {
         let frame = mapView.convert(extentView.frame, from: view)

--- a/arcgis-ios-sdk-samples/Maps/Generate offline map (overrides)/README.md
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map (overrides)/README.md
@@ -10,7 +10,7 @@ When taking a web map offline, you may adjust the data (such as layers or tiles)
 
 ## How to use the sample
 
-Sign in with an organizational ArcGIS Online account when prompted for credentials (taking web maps offline requires an account) and modify the overrides parameters:
+Modify the overrides parameters:
 
 * Use the sliders to adjust the the minimum and maximum scale levels and buffer radius to be taken offline for the streets basemap.
 * Toggle the switches for the feature operational layers you want to include in the offline map.

--- a/arcgis-ios-sdk-samples/Maps/Generate offline map/GenerateOfflineMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map/GenerateOfflineMapViewController.swift
@@ -17,7 +17,7 @@
 import UIKit
 import ArcGIS
 
-class GenerateOfflineMapViewController: UIViewController, AGSAuthenticationManagerDelegate {
+class GenerateOfflineMapViewController: UIViewController {
     @IBOutlet var mapView: AGSMapView!
     @IBOutlet var extentView: UIView!
     @IBOutlet var barButtonItem: UIBarButtonItem!
@@ -30,7 +30,6 @@ class GenerateOfflineMapViewController: UIViewController, AGSAuthenticationManag
     private var parameters: AGSGenerateOfflineMapParameters?
     private var offlineMapTask: AGSOfflineMapTask?
     private var generateOfflineMapJob: AGSGenerateOfflineMapJob?
-    private var shouldShowAlert = true
     
     private var jobProgressObservation: NSKeyValueObservation?
     
@@ -39,25 +38,13 @@ class GenerateOfflineMapViewController: UIViewController, AGSAuthenticationManag
         
         // add the source code button item to the right of navigation bar
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["GenerateOfflineMapViewController"]
-
-        // prepare the authentication manager for user login (required for taking the sample's basemap offline)
-        let config = AGSOAuthConfiguration(portalURL: nil, clientID: "xHx4Nj7q1g19Wh6P", redirectURL: "iOSSamples://auth")
-        AGSAuthenticationManager.shared().oAuthConfigurations.add(config)
-        AGSAuthenticationManager.shared().credentialCache.removeAllCredentials()
-    }
-    
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
         
-        if shouldShowAlert {
-            shouldShowAlert = false
-            showLoginQueryAlert()
-        }
+        addMap()
     }
     
     private func addMap() {
         // portal for the web map
-        let portal = AGSPortal.arcGISOnline(withLoginRequired: true)
+        let portal = AGSPortal.arcGISOnline(withLoginRequired: false)
         
         // portal item for web map
         let portalItem = AGSPortalItem(portal: portal, itemID: "acc027394bc84c2fb04d1ed317aac674")

--- a/arcgis-ios-sdk-samples/Maps/Generate offline map/README.md
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map/README.md
@@ -10,7 +10,7 @@ Taking a web map offline allows users continued productivity when their network 
 
 ## How to use the sample
 
-When the app starts, you will be prompted to sign in using an organizational ArcGIS Online account. Once the map loads, zoom to the extent you want to take offline. The red border shows the extent that will be downloaded. Tap the "Generate offline map" button to start the offline map job. The progress view will show the job's progress. When complete, the offline map will replace the online map in the map view.
+When the map loads, zoom to the extent you want to take offline. The red border shows the extent that will be downloaded. Tap the "Generate offline map" button to start the offline map job. The progress view will show the job's progress. When complete, the offline map will replace the online map in the map view.
 
 ## How it works
 


### PR DESCRIPTION
Please refer to the Epic issue `common-samples/issues/2823`.

Per Trevor

> Several samples use a named user authentication pattern for simplicity, but it is now simpler to use an API key - especially with the API being set ubiquitously across most samples with the sample viewer.

Samples we should update:

- [x] Generate offline map
- [x] Generate offline map overrides
- [ ] Generate offline map with local basemap - No need to update, not using OAuth currently
- [x] Navigate in AR - Already been done in #1055 
