### PR TITLE
Update: Change licensing method to facilitate development

### DIFF
--- a/Documentation/ConfigureAppSecrets.md
+++ b/Documentation/ConfigureAppSecrets.md
@@ -1,0 +1,27 @@
+# Configure App Secrets
+
+As a best-practices principle, the project conceals app secrets from source code by generating and compiling an `AppSecrets.swift` source code file at build time using a custom build rule.
+
+This build rule looks for a secrets file stored in the project's root directory, `$(SRCROOT)/.secrets`.
+
+Note: License keys are not required for development. Without licensing or licensing with invalid keys do not throw an exception, but simply fail to license the app, falling back to Developer Mode (which will display a watermark on the map and scene views). Apply the license keys when the app is ready for deployment.
+
+1. Create a hidden secrets file in the project's root directory.
+
+  ```bash
+  touch .secrets
+  ```
+
+2. Add your **License Key** to the secrets file. Licensing the app will remove the 'Licensed for Developer Use Only' watermark. Licensing the app is optional in development but required for production. Add your **Extension License Key** and **API Key** to the secrets file if needed. Acquire license keys from your [dashboard](https://developers.arcgis.com/dashboard).
+
+  ```bash
+  echo ARCGIS_LICENSE_KEY=your-license-key >> .secrets
+  echo ARCGIS_EXTENSION_LICENSE_KEY=your-extension-license-key >> .secrets
+  echo ARCGIS_API_KEY=your-api-key >> .secrets
+  ```
+
+  > Replace 'your-license-key', 'your-extension-license-key' and 'your-api-key' with your keys.
+
+Visit the developer's website to learn more about [Deployment](https://developers.arcgis.com/documentation/mapping-apis-and-services/deployment/) and [Security and authentication](https://developers.arcgis.com/documentation/mapping-apis-and-services/security/).
+
+To learn more about `masquerade`, consult the [documentation](https://github.com/Esri/data-collection-ios/tree/main/docs#masquerade) of Esri's Data Collection app.

--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ Note: Without licensing or licensing with invalid keys do not throw an exception
 
   > Replace 'your-license-key', 'your-extension-license-key' and 'your-api-key' with your keys.
 
-3. Uncomment the line `application.license()` in `AppDelegate.application(_:didFinishLaunchingWithOptions:)`, and choose the appropriate licensing method for your keys.
-
 Visit the developer's website to learn more about [Licensing your ArcGIS Runtime App](https://developers.arcgis.com/pricing/licensing/) and [Security and authentication](https://developers.arcgis.com/documentation/mapping-apis-and-location-services/security-and-authentication/).
 
 To learn more about `masquerade`, consult the [documentation](https://github.com/Esri/data-collection-ios/tree/main/docs#masquerade) of Esri's Data Collection app.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The *ArcGIS Runtime SDK Samples app* has a *Target SDK* version of *13.0*, meani
     > The project has been configured to use the `arcgis-runtime-toolkit-ios` package, which provides the `ArcGISToolkit` framework as well as the `ArcGIS` framework.
 1. **Run** the `arcgis-ios-sdk-samples` app target
 
-> To add the Swift packages to your own projects, consult the documentation for the [ArcGIS Runtime iOS Toolkit](https://github.com/Esri/arcgis-runtime-toolkit-ios/#swift-package-manager) and [ArcGIS Runtime iOS SDK](https://github.com/Esri/arcgis-runtime-ios#instructions).
+> To add the Swift packages to your own projects, consult the documentation for the [ArcGIS Runtime iOS Toolkit](https://github.com/Esri/arcgis-runtime-toolkit-ios/#swift-package-manager) and [ArcGIS Runtime iOS SDK](https://github.com/Esri/arcgis-runtime-ios/#instructions).
 
 ## Building Samples Using CocoaPods
 
@@ -52,13 +52,9 @@ The *ArcGIS Runtime SDK Samples app* has a *Target SDK* version of *13.0*, meani
 
 Some sample data is too large to store in the repository, so it is automatically downloaded at build time. The first time the app is built, a build script downloads the necessary data to `Portal Data`. The script only downloads data files that do not already exist, so subsequent builds will take significantly less time.
 
-## Configure App Secrets
+## Configure API key
 
-As a best-practices principle, the project conceals app secrets from source code by generating and compiling an `AppSecrets.swift` source code file at build time using a custom build rule.
-
-This build rule looks for a secrets file stored in the project's root directory, `$(SRCROOT)/.secrets`.
-
-Note: Without licensing or licensing with invalid keys do not throw an exception, but simply fail to license the app, falling back to Developer Mode (which will display a watermark on the map and scene views).
+To build this app locally, follow the steps to add an API key to a secrets file stored in the project's root directory, `$(SRCROOT)/.secrets`.
 
 1. Create a hidden secrets file in the project's root directory.
 
@@ -66,19 +62,15 @@ Note: Without licensing or licensing with invalid keys do not throw an exception
   touch .secrets
   ```
 
-2. Add your **License Key** to the secrets file. Licensing the app will remove the 'Licensed for Developer Use Only' watermark. Licensing the app is optional in development but required for production. _Optionally_ add your **Extension License Key** and **API Key** to the secrets file if needed. Acquire license keys from your [dashboard](https://developers.arcgis.com/dashboard).
+2. Add your **API Key** to the secrets file aforementioned. Adding an API key allows you to access a set of ready-to-use services, including basemaps. Acquire the keys from your [dashboard](https://developers.arcgis.com/dashboard). Visit the developer's website to learn more about [API keys](https://developers.arcgis.com/documentation/mapping-apis-and-services/security/api-keys/).
 
   ```bash
-  echo ARCGIS_LICENSE_KEY=your-license-key >> .secrets
-  echo ARCGIS_EXTENSION_LICENSE_KEY=your-extension-license-key >> .secrets
   echo ARCGIS_API_KEY=your-api-key >> .secrets
   ```
 
-  > Replace 'your-license-key', 'your-extension-license-key' and 'your-api-key' with your keys.
+  > Replace 'your-api-key' with your keys.
 
-Visit the developer's website to learn more about [Licensing your ArcGIS Runtime App](https://developers.arcgis.com/pricing/licensing/) and [Security and authentication](https://developers.arcgis.com/documentation/mapping-apis-and-location-services/security-and-authentication/).
-
-To learn more about `masquerade`, consult the [documentation](https://github.com/Esri/data-collection-ios/tree/main/docs#masquerade) of Esri's Data Collection app.
+Please see [Configure App Secrets](Documentation/ConfigureAppSecrets.md) for adding license key and other details.
 
 ## Additional Resources
 

--- a/arcgis-ios-sdk-samples/AppDelegate.swift
+++ b/arcgis-ios-sdk-samples/AppDelegate.swift
@@ -48,8 +48,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
         // Enable/disable touches based on settings.
         self.setTouchPref()
         
-        // Uncomment the following line to set license key.
-        // application.license()
+        // Set license key and/or API key.
+        application.license()
         
         return true
     }
@@ -180,13 +180,16 @@ extension UIApplication {
         do {
             // Don't set extension key if you don't use utility network samples.
             // try AGSArcGISRuntimeEnvironment.setLicenseKey(.licenseKey)
+            if String.licenseKey != nil && String.extensionLicenseKey != nil {
+                // Set both keys for accessing all samples.
+                try AGSArcGISRuntimeEnvironment.setLicenseKey(.licenseKey!, extensions: [.extensionLicenseKey!])
+            }
             
-            // Set both keys for accessing all samples.
-            try AGSArcGISRuntimeEnvironment.setLicenseKey(.licenseKey, extensions: [.extensionLicenseKey])
-            
-            // Authentication with an API key or named user is required to
-            // access basemaps and other location services.
-            AGSArcGISRuntimeEnvironment.apiKey = .apiKey
+            if String.apiKey != nil {
+                // Authentication with an API key or named user is required to
+                // access basemaps and other location services.
+                AGSArcGISRuntimeEnvironment.apiKey = .apiKey!
+            }
         } catch {
             print("Error licensing app: \(error.localizedDescription)")
         }

--- a/arcgis-ios-sdk-samples/AppDelegate.swift
+++ b/arcgis-ios-sdk-samples/AppDelegate.swift
@@ -178,20 +178,19 @@ extension UIApplication {
     ///         license the app, falling back to Developer Mode (which will
     ///         display a watermark on the map view).
     func license() {
-        do {
-            if let licenseKey = String.licenseKey,
-               let extensionLicenseKey = String.extensionLicenseKey {
+        if let licenseKey = String.licenseKey,
+           let extensionLicenseKey = String.extensionLicenseKey {
+            do {
                 // Set both keys to access all samples, including utility network capability.
                 try AGSArcGISRuntimeEnvironment.setLicenseKey(licenseKey, extensions: [extensionLicenseKey])
+            } catch {
+                print("Error licensing app: \(error.localizedDescription)")
             }
-            
-            if let apiKey = String.apiKey {
-                // Authentication with an API key or named user is required to
-                // access basemaps and other location services.
-                AGSArcGISRuntimeEnvironment.apiKey = apiKey
-            }
-        } catch {
-            print("Error licensing app: \(error.localizedDescription)")
+        }
+        if let apiKey = String.apiKey {
+            // Authentication with an API key or named user is required to
+            // access basemaps and other location services.
+            AGSArcGISRuntimeEnvironment.apiKey = apiKey
         }
     }
 }

--- a/arcgis-ios-sdk-samples/AppDelegate.swift
+++ b/arcgis-ios-sdk-samples/AppDelegate.swift
@@ -174,21 +174,21 @@ extension UIColor {
 extension UIApplication {
     /// License the app with ArcGIS Runtime deployment license keys.
     ///
-    /// - Note: An invalid key does not throw an exception, but simply fails to license the app,
-    ///         falling back to Developer Mode (which will display a watermark on the map view).
+    /// - Note: An invalid key does not throw an exception, but simply fails to
+    ///         license the app, falling back to Developer Mode (which will
+    ///         display a watermark on the map view).
     func license() {
         do {
-            // Don't set extension key if you don't use utility network samples.
-            // try AGSArcGISRuntimeEnvironment.setLicenseKey(.licenseKey)
-            if String.licenseKey != nil && String.extensionLicenseKey != nil {
-                // Set both keys for accessing all samples.
-                try AGSArcGISRuntimeEnvironment.setLicenseKey(.licenseKey!, extensions: [.extensionLicenseKey!])
+            if let licenseKey = String.licenseKey,
+               let extensionLicenseKey = String.extensionLicenseKey {
+                // Set both keys to access all samples, including utility network capability.
+                try AGSArcGISRuntimeEnvironment.setLicenseKey(licenseKey, extensions: [extensionLicenseKey])
             }
             
-            if String.apiKey != nil {
+            if let apiKey = String.apiKey {
                 // Authentication with an API key or named user is required to
                 // access basemaps and other location services.
-                AGSArcGISRuntimeEnvironment.apiKey = .apiKey!
+                AGSArcGISRuntimeEnvironment.apiKey = apiKey
             }
         } catch {
             print("Error licensing app: \(error.localizedDescription)")

--- a/arcgis-ios-sdk-samples/AppSecrets.swift.masque
+++ b/arcgis-ios-sdk-samples/AppSecrets.swift.masque
@@ -13,50 +13,33 @@
 // limitations under the License.
 
 extension String {
-    /// The App's public client ID. The client ID is used by OAuth to authenticate a user.
-    ///
-    /// - Note: Change this to reflect your organization's client ID.
-    ///         The client ID can be found in the **Credentials** section of
-    ///         the **Authentication** tab within the [Dashboard of the ArcGIS for Developers](https://developers.arcgis.com/applications) site.
-    static let clientID: String = {
-        let clientID = "{{ ARCGIS_CLIENT_ID }}"
-        guard !clientID.isEmpty else {
-            fatalError(".secrets must contain ARCGIS_CLIENT_ID variable.")
-        }
-        return clientID
-    }()
-
     /// Your organization's ArcGIS Runtime [license](https://developers.arcgis.com/arcgis-runtime/licensing/) key.
     ///
     /// - Note: this step is optional during development but required for deployment.
     ///         Licensing the app will remove the "Licensed for Developer Use Only"
     ///         watermark on the map view.
-    static let licenseKey: String = {
+    static let licenseKey: String? = {
         let licenseKey = "{{ ARCGIS_LICENSE_KEY }}"
         guard !licenseKey.isEmpty else {
-            fatalError(".secrets must contain ARCGIS_LICENSE_KEY variable.")
+            return nil
         }
         return licenseKey
     }()
     
     /// The extension license key for sample viewer. Required for utility network samples.
-    static let extensionLicenseKey: String = {
+    static let extensionLicenseKey: String? = {
         let licenseKey = "{{ ARCGIS_EXTENSION_LICENSE_KEY }}"
         guard !licenseKey.isEmpty else {
-            #if DEBUG
-            return "fake_inconsequential_license_key"
-            #else
-            fatalError(".secrets must contain ARCGIS_EXTENSION_LICENSE_KEY variable.")
-            #endif
+            return nil
         }
         return licenseKey
     }()
     
     /// The API key for sample viewer.
-    static let apiKey: String = {
+    static let apiKey: String? = {
         let apiKey = "{{ ARCGIS_API_KEY }}"
         guard !apiKey.isEmpty else {
-            fatalError(".secrets must contain ARCGIS_API_KEY variable.")
+            return nil
         }
         return apiKey
     }()


### PR DESCRIPTION
## Description

Please see `common-samples/issues/2910` for the details. This PR aims to

- Get rid of the "uncomment a line in `AppDelegate`" step for daily development or archive
- Don't give `fatalError` if no API key or license key provided; instead make these keys optional

## Test

After these changes, the new behaviors...

- No key provided: login required, license watermark exists after successful ArcGIS Identity login
- API key provided: basemap can show, license watermark appear on the basemap
- License key provided: login required, license watermark disappear
- Both provided: normal as before, no watermark or login required

To Sarat: Please notice this change might slightly simplify your testing workflow. 🙂 

## Questions

- Should I put the `Configure App Secrets` details in the wiki, or should I put it in `/Documentation` with a separate md file?
