### PR TITLE
Update: `OpenStreetMap layer`

### DIFF
--- a/arcgis-ios-sdk-samples/Layers/OpenStreetMap layer/OpenStreetMapLayerViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/OpenStreetMap layer/OpenStreetMapLayerViewController.swift
@@ -16,18 +16,27 @@ import UIKit
 import ArcGIS
 
 class OpenStreetMapLayerViewController: UIViewController {
-    @IBOutlet private weak var mapView: AGSMapView!
+    @IBOutlet var mapView: AGSMapView! {
+        didSet {
+            // assign the map to the map view
+            mapView.map = makeMap()
+            mapView.setViewpoint(AGSViewpoint(latitude: 34.056295, longitude: -117.195800, scale: 577790.554289))
+        }
+    }
+    
+    /// Create a map.
+    ///
+    /// - Returns: An `AGSMap` object.
+    func makeMap() -> AGSMap {
+        // Create an OpenStreetMap layer that requests tiles from its servers.
+        let openStreetMapLayer = AGSOpenStreetMapLayer()
+        // Initialize map and set the OpenStreetMap layer as its basemap.
+        let map = AGSMap(basemap: AGSBasemap(baseLayer: openStreetMapLayer))
+        return map
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        // initialize map with an OpenStreetMap standard basemap
-        let map = AGSMap(basemapStyle: .osmStandard)
-        
-        // assign the map to the map view
-        mapView.map = map
-        mapView.setViewpoint(AGSViewpoint(latitude: 34.056295, longitude: -117.195800, scale: 577790.554289))
-    
         // add the source code button item to the right of navigation bar
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["OpenStreetMapLayerViewController"]
     }

--- a/arcgis-ios-sdk-samples/Layers/OpenStreetMap layer/OpenStreetMapLayerViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/OpenStreetMap layer/OpenStreetMapLayerViewController.swift
@@ -25,7 +25,6 @@ class OpenStreetMapLayerViewController: UIViewController {
     }
     
     /// Create a map.
-    ///
     /// - Returns: An `AGSMap` object.
     func makeMap() -> AGSMap {
         // Create an OpenStreetMap layer that requests tiles from its servers.

--- a/arcgis-ios-sdk-samples/Layers/OpenStreetMap layer/OpenStreetMapLayerViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/OpenStreetMap layer/OpenStreetMapLayerViewController.swift
@@ -18,7 +18,7 @@ import ArcGIS
 class OpenStreetMapLayerViewController: UIViewController {
     @IBOutlet var mapView: AGSMapView! {
         didSet {
-            // assign the map to the map view
+            // Assign the map to the map view.
             mapView.map = makeMap()
             mapView.setViewpoint(AGSViewpoint(latitude: 34.056295, longitude: -117.195800, scale: 577790.554289))
         }
@@ -30,14 +30,14 @@ class OpenStreetMapLayerViewController: UIViewController {
     func makeMap() -> AGSMap {
         // Create an OpenStreetMap layer that requests tiles from its servers.
         let openStreetMapLayer = AGSOpenStreetMapLayer()
-        // Initialize map and set the OpenStreetMap layer as its basemap.
+        // Initialize a map and set the OpenStreetMap layer as its basemap.
         let map = AGSMap(basemap: AGSBasemap(baseLayer: openStreetMapLayer))
         return map
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        // add the source code button item to the right of navigation bar
-        (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["OpenStreetMapLayerViewController"]
+        // Add the source code button item to the right of navigation bar.
+        (navigationItem.rightBarButtonItem as? SourceCodeBarButtonItem)?.filenames = ["OpenStreetMapLayerViewController"]
     }
 }

--- a/arcgis-ios-sdk-samples/Layers/OpenStreetMap layer/README.md
+++ b/arcgis-ios-sdk-samples/Layers/OpenStreetMap layer/README.md
@@ -10,12 +10,12 @@ You may want to create a map with an [OpenStreetMap](https://www.openstreetmap.o
 
 ## How to use the sample
 
-When the sample opens, it will automatically display the map with the OpenStreetMap basemap. Pan and zoom to observe the basemap.
+When the sample opens, it will automatically display the OpenStreetMap basemap. Pan and zoom to explore the basemap.
 
 ## How it works
 
-1. Create an `AGSMap` with `osmStandard` as the `basemapStyle` and specify the other properties.
-2. Apply the `AGSMap` to the `AGSMapView`.
+1. Create an `AGSOpenStreetMapLayer`, and set it as the `AGSMap`'s basemap.
+2. Set the `AGSMap` to the `AGSMapView`.
 
 ## Relevant API
 

--- a/arcgis-ios-sdk-samples/Layers/OpenStreetMap layer/README.md
+++ b/arcgis-ios-sdk-samples/Layers/OpenStreetMap layer/README.md
@@ -10,12 +10,13 @@ You may want to create a map with an [OpenStreetMap](https://www.openstreetmap.o
 
 ## How to use the sample
 
-The OpenStreetMap basemap will display upon launch. Pan and zoom to explore the basemap.
+The OpenStreetMap basemap will display upon launch. Pan and zoom to explore the base layer.
 
 ## How it works
 
-1. Create an `AGSOpenStreetMapLayer`, and set it as the `AGSMap`'s basemap.
-2. Set the `AGSMap` to the `AGSMapView`.
+1. Create an instance of `AGSOpenStreetMapLayer`.
+2. Create an instance of `AGSMap` using the OpenStreetMap layer as the base layer.
+3. Set the map to the map view's `map` property.
 
 ## Relevant API
 

--- a/arcgis-ios-sdk-samples/Layers/OpenStreetMap layer/README.md
+++ b/arcgis-ios-sdk-samples/Layers/OpenStreetMap layer/README.md
@@ -10,7 +10,7 @@ You may want to create a map with an [OpenStreetMap](https://www.openstreetmap.o
 
 ## How to use the sample
 
-When the sample opens, it will automatically display the OpenStreetMap basemap. Pan and zoom to explore the basemap.
+The OpenStreetMap basemap will display upon launch. Pan and zoom to explore the basemap.
 
 ## How it works
 


### PR DESCRIPTION
Our "OpenStreetMap layer" sample uses an OSM basemap. The original intention of this sample was to actually demonstrate use of the `AGSOpenStreetMapLayer` class.

Please refer to...

- https://github.com/Esri/arcgis-runtime-samples-java/pull/663
- https://github.com/Esri/arcgis-runtime-samples-qt/pull/1301
- `common-samples/issues/2474`