### PR TITLE
Fix file error

### DIFF
--- a/arcgis-ios-sdk-samples/Layers/Identify raster cell/IdentifyRasterCellViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Identify raster cell/IdentifyRasterCellViewController.swift
@@ -35,7 +35,11 @@ class IdentifyRasterCellViewController: UIViewController {
     // MARK: Properties
     
     /// The raster layer created using local raster file.
-    let rasterLayer = AGSRasterLayer(raster: AGSRaster(name: "SA_EVI_8Day_03May20", extension: "tif"))
+    let rasterLayer = AGSRasterLayer(raster: AGSRaster(fileURL: Bundle.main.url(
+        forResource: "SA_EVI_8Day_03May20",
+        withExtension: "tif",
+        subdirectory: "SA_EVI_8Day_03May20"
+    )!))
     
     /// A formatter for coordinates.
     let formatter: NumberFormatter = {


### PR DESCRIPTION
This PR resolves an issue brought to my attention by Divesh. After launching the "Identify raster cell" sample, the data did not load properly and an error message said "File error". See `common-samples/3016` for more info.