### PR TITLE
Fix: Remove redundant property in `Map reference scale`

### DIFF
--- a/arcgis-ios-sdk-samples/Maps/Map reference scale/MapReferenceScaleSettingsViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Map reference scale/MapReferenceScaleSettingsViewController.swift
@@ -89,8 +89,6 @@ class MapReferenceScaleSettingsViewController: UITableViewController {
     
     /// The observer of the reference scale of the map.
     private var referenceScaleObserver: NSObjectProtocol?
-    /// The observer of the scale of the map.
-    private var scaleObserver: NSObjectProtocol?
     
     // MARK: UIViewController
     


### PR DESCRIPTION
Close #1108 Sample should work the same as before.