### PR TITLE
Prevent sample re-selection

### DIFF
--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ContentTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ContentTableViewController.swift
@@ -171,9 +171,6 @@ class ContentTableViewController: UITableViewController {
                     if self.bundleResourceRequest?.progress.isCancelled == false {
                         // show view controller
                         self.showSample(sample)
-                    } else {
-                        self.bundleResourceRequest = nil
-                        self.selectedSample = nil
                     }
                 }
             }
@@ -225,6 +222,8 @@ extension ContentTableViewController: DownloadProgressViewDelegate {
             return
         }
         bundleResourceRequest.progress.cancel()
+        self.bundleResourceRequest = nil
+        self.selectedSample = nil
     }
 }
 


### PR DESCRIPTION
Standard behavior is that if a row is selected, tapping it again doesn't reload the associated content. This PR changes the sample list view view controller to match that behavior. Now, when the selected sample is tapped, nothing happens.