### PR TITLE
Deselect sample on viewWillAppear

### DIFF
--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ContentTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/ContentTableViewController.swift
@@ -53,6 +53,11 @@ class ContentTableViewController: UITableViewController {
         self.downloadProgressView = downloadProgressView
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        selectedSample = nil
+    }
+    
     // MARK: Sample Selection
     
     /// The currently selected sample.


### PR DESCRIPTION
This fixes an issue in compact width environments where a sample could not be selected after a sample had already been opened and closed.