### PR TITLE
Update: Remove 2 unused exception HTTP URLs for `Display KML network links`

### DIFF
--- a/arcgis-ios-sdk-samples/Info.plist
+++ b/arcgis-ios-sdk-samples/Info.plist
@@ -53,13 +53,6 @@
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>
-			<key>buienradar.nl</key>
-			<dict>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-				<key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
 			<key>noaa.gov</key>
 			<dict>
 				<key>NSIncludesSubdomains</key>
@@ -68,13 +61,6 @@
 				<true/>
 			</dict>
 			<key>resources.esri.com</key>
-			<dict>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-				<key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-			<key>vlieghinder.nl</key>
 			<dict>
 				<key>NSIncludesSubdomains</key>
 				<true/>


### PR DESCRIPTION
This PR removes the unused HTTP exception URLs for `Display KML network links` sample, which was added in #500 . Now that the dataset has been updated all URLs to HTTPS, these 2 can be removed.

Please see `common-samples/issues/3160` for details. I reviewed their `git blame` history and they seem to be solely used by this sample.

To double check this doesn't affect other samples, we can go through every KML sample to see if they are working fine. (but I really don't think that is necessary 😏 )