### PR TITLE
Update: Change all basemap constructor to basemapStyle

### DIFF
--- a/arcgis-ios-sdk-samples/Analysis/Distance measurement analysis/DistanceMeasurementAnalysisViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Distance measurement analysis/DistanceMeasurementAnalysisViewController.swift
@@ -31,7 +31,7 @@ class DistanceMeasurementAnalysisViewController: UIViewController, AGSGeoViewTou
     
     required init?(coder: NSCoder) {
         // Create the scene.
-        scene = AGSScene(basemap: .topographic())
+        scene = AGSScene(basemapStyle: .arcGISTopographic)
         
         // The elevation image service URL.
         let elevationServiceURL = URL(string: "https://scene.arcgis.com/arcgis/rest/services/BREST_DTM_1M/ImageServer")!

--- a/arcgis-ios-sdk-samples/Analysis/Line of sight (geoelement)/LineOfSightGeoElementViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Line of sight (geoelement)/LineOfSightGeoElementViewController.swift
@@ -62,8 +62,8 @@ class LineOfSightGeoElementViewController: UIViewController {
         
         observerPoint = AGSPoint(x: -73.984988, y: 40.748131, z: observerZ, spatialReference: .wgs84())
 
-        // initialize the scene with an imagery basemap
-        scene = AGSScene(basemap: .imageryWithLabels())
+        // Initialize the scene with an imagery basemap style.
+        scene = AGSScene(basemapStyle: .arcGISImageryLabels)
 
         /// The url of the Terrain 3D ArcGIS REST Service.
         let worldElevationServiceURL = URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!

--- a/arcgis-ios-sdk-samples/Analysis/Line of sight (location)/LineOfSightLocationViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Line of sight (location)/LineOfSightLocationViewController.swift
@@ -45,8 +45,8 @@ class LineOfSightLocationViewController: UIViewController, AGSGeoViewTouchDelega
         // add the source code button item to the right of navigation bar
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["LineOfSightLocationViewController"]
         
-        // initialize the scene with an imagery basemap
-        let scene = AGSScene(basemap: .imagery())
+        // Initialize the scene with an imagery basemap style.
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
         
         // assign the scene to the scene view
         sceneView.scene = scene

--- a/arcgis-ios-sdk-samples/Analysis/Viewshed (GeoElement)/ViewshedGeoElementViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Viewshed (GeoElement)/ViewshedGeoElementViewController.swift
@@ -44,7 +44,7 @@ class ViewshedGeoElementViewController: UIViewController, AGSGeoViewTouchDelegat
     
     private func makeScene() -> AGSScene {
         // create the scene
-        let scene = AGSScene(basemap: .imagery())
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
         
         // add base surface for elevation data
         let surface = AGSSurface()

--- a/arcgis-ios-sdk-samples/Analysis/Viewshed (camera)/ViewshedCameraViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Viewshed (camera)/ViewshedCameraViewController.swift
@@ -26,8 +26,8 @@ class ViewshedCameraViewController: UIViewController {
         // Add the source code button item to the right of navigation bar.
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["ViewshedCameraViewController"]
         
-        // Initialize the scene with an imagery basemap.
-        let scene = AGSScene(basemap: .imagery())
+        // Initialize the scene with an imagery basemap style.
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
         
         // Assign the scene to the scene view.
         sceneView.scene = scene

--- a/arcgis-ios-sdk-samples/Analysis/Viewshed (location)/ViewshedLocationViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Viewshed (location)/ViewshedLocationViewController.swift
@@ -39,8 +39,8 @@ class ViewshedLocationViewController: UIViewController {
             "ColorPickerViewController"
         ]
         
-        // initialize the scene with an imagery basemap
-        let scene = AGSScene(basemap: .imagery())
+        // Initialize the scene with an imagery basemap style.
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
         
         // assign the scene to the scene view
         sceneView.scene = scene

--- a/arcgis-ios-sdk-samples/Features/List related features/ListRelatedFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/List related features/ListRelatedFeaturesViewController.swift
@@ -32,7 +32,7 @@ class ListRelatedFeaturesViewController: UIViewController, AGSGeoViewTouchDelega
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["ListRelatedFeaturesViewController", "RelatedFeaturesListViewController"]
         
         // initialize map with a basemap
-        let map = AGSMap(basemap: .nationalGeographic())
+        let map = AGSMap(basemapStyle: .arcGISTopographic)
         
         // add self as the touch delegate for map view
         // we will need to be notified when the user taps with the map

--- a/arcgis-ios-sdk-samples/Geometry/Project/ProjectViewController.swift
+++ b/arcgis-ios-sdk-samples/Geometry/Project/ProjectViewController.swift
@@ -19,7 +19,7 @@ class ProjectViewController: UIViewController {
     @IBOutlet private weak var mapView: AGSMapView! {
         didSet {
             // initialize the map
-            mapView.map = AGSMap(basemap: .nationalGeographic())
+            mapView.map = AGSMap(basemapStyle: .arcGISTopographic)
             mapView.touchDelegate = self
             mapView.setViewpointCenter(AGSPoint(x: -1.2e7, y: 5e6, spatialReference: .webMercator()), scale: 4e7)
             

--- a/arcgis-ios-sdk-samples/Layers/Edit KML ground overlay/EditKMLGroundOverlayViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Edit KML ground overlay/EditKMLGroundOverlayViewController.swift
@@ -63,7 +63,7 @@ class EditKMLGroundOverlayViewController: UIViewController {
     
     func makeScene(groundOverlay: AGSKMLGroundOverlay) -> AGSScene {
         // Create a scene for the scene view.
-        let scene = AGSScene(basemap: .imagery())
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
         // Create a KML dataset with the ground overlay as the root node.
         let dataset = AGSKMLDataset(rootNode: groundOverlay)
         // Create a KML layer for the scene view.

--- a/arcgis-ios-sdk-samples/Layers/Export vector tiles/ExportVectorTilesViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Export vector tiles/ExportVectorTilesViewController.swift
@@ -21,7 +21,7 @@ class ExportVectorTilesViewController: UIViewController {
     /// The map view managed by the view controller.
     @IBOutlet var mapView: AGSMapView! {
         didSet {
-            mapView.map = AGSMap(basemap: AGSBasemap(style: .arcGISStreetsNight))
+            mapView.map = AGSMap(basemapStyle: .arcGISStreetsNight)
             // Set the viewpoint.
             mapView.setViewpoint(AGSViewpoint(latitude: 34.049, longitude: -117.181, scale: 1e4))
         }

--- a/arcgis-ios-sdk-samples/Layers/Group layers/GroupLayersViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Group layers/GroupLayersViewController.swift
@@ -94,9 +94,9 @@ class GroupLayersViewController: UIViewController {
         return groupLayer
     }
     
-    /// Returns a scene with imagery basemap and elevation data.
+    /// Returns a scene with imagery basemap style and elevation data.
     func makeScene() -> AGSScene {
-        let scene = AGSScene(basemap: .imagery())
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
         
         // Add base surface to the scene for elevation data.
         let surface = AGSSurface()

--- a/arcgis-ios-sdk-samples/Layers/Play a KML Tour/PlayKMLTourViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Play a KML Tour/PlayKMLTourViewController.swift
@@ -62,7 +62,7 @@ class PlayKMLTourViewController: UIViewController {
     /// - Parameter kmlDataset: A KML dataset.
     /// - Returns: A new `AGSScene` object.
     func makeScene(kmlDataset: AGSKMLDataset) -> AGSScene {
-        let scene = AGSScene(basemap: .imagery())
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
         
         let elevationServiceURL = URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!
         let elevationSource = AGSArcGISTiledElevationSource(url: elevationServiceURL)

--- a/arcgis-ios-sdk-samples/Scenes/Animate 3D graphic/Animate3DGraphicViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Animate 3D graphic/Animate3DGraphicViewController.swift
@@ -59,8 +59,8 @@ class Animate3DGraphicViewController: UIViewController {
         // hide attribution text for map view
         mapView.isAttributionTextVisible = false
         
-        // initalize scene with imagery basemap
-        let scene = AGSScene(basemap: .imagery())
+        // Initalize scene with imagery basemap style.
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
         
         // assign scene to scene view
         sceneView.scene = scene

--- a/arcgis-ios-sdk-samples/Scenes/Animate images with image overlay/AnimateImagesWithImageOverlayViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Animate images with image overlay/AnimateImagesWithImageOverlayViewController.swift
@@ -97,7 +97,7 @@ class AnimateImagesWithImageOverlayViewController: UIViewController {
         let elevationSource = AGSArcGISTiledElevationSource(url: elevationServiceURL)
         let surface = AGSSurface()
         surface.elevationSources = [elevationSource]
-        let scene = AGSScene(basemap: AGSBasemap(baseLayer: worldDarkGrayBasemap))
+        let scene = AGSScene(basemapStyle: .arcGISDarkGray)
         scene.baseSurface = surface
         return scene
     }

--- a/arcgis-ios-sdk-samples/Scenes/Choose camera controller/ChooseCameraControllerViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Choose camera controller/ChooseCameraControllerViewController.swift
@@ -63,9 +63,9 @@ class ChooseCameraControllerViewController: UIViewController {
         }
     }
 
-    /// Returns a scene with imagery basemap and elevation data.
+    /// Returns a scene with imagery basemap style and elevation data.
     func makeScene() -> AGSScene {
-        let scene = AGSScene(basemap: .imagery())
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
 
         // Add base surface to the scene for elevation data.
         let surface = AGSSurface()

--- a/arcgis-ios-sdk-samples/Scenes/Display a scene/DisplaySceneViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Display a scene/DisplaySceneViewController.swift
@@ -26,8 +26,8 @@ class DisplaySceneViewController: UIViewController {
         // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["DisplaySceneViewController"]
         
-        // initialize scene with topographic basemap
-        let scene = AGSScene(basemap: .imagery())
+        // Initialize scene with imagery basemap style.
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
         // assign scene to the scene view
         self.sceneView.scene = scene
         

--- a/arcgis-ios-sdk-samples/Scenes/Distance composite symbol/DistanceCompositeSymbolViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Distance composite symbol/DistanceCompositeSymbolViewController.swift
@@ -26,8 +26,8 @@ class DistanceCompositeSymbolViewController: UIViewController {
         // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["DistanceCompositeSymbolViewController"]
         
-        // initialize scene with topographic basemap
-        let scene = AGSScene(basemap: .imagery())
+        // Initialize scene with imagery basemap style.
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
         // assign scene to the scene view
         self.sceneView.scene = scene
         

--- a/arcgis-ios-sdk-samples/Scenes/Extrude graphics/ExtrudeGraphicsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Extrude graphics/ExtrudeGraphicsViewController.swift
@@ -33,8 +33,8 @@ class ExtrudeGraphicsViewController: UIViewController {
         // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["ExtrudeGraphicsViewController"]
         
-        // initialize scene with topographic basemap
-        let scene = AGSScene(basemap: .topographic())
+        // Initialize scene with topographic basemap style.
+        let scene = AGSScene(basemapStyle: .arcGISTopographic)
         // assign scene to the scene view
         self.sceneView.scene = scene
         

--- a/arcgis-ios-sdk-samples/Scenes/Orbit camera around object/OrbitCameraAroundObjectViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Orbit camera around object/OrbitCameraAroundObjectViewController.swift
@@ -66,7 +66,7 @@ class OrbitCameraAroundObjectViewController: UIViewController {
     
     /// Create a scene.
     func makeScene() -> AGSScene {
-        let scene = AGSScene(basemap: .imagery())
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
         // Create an elevation source from Terrain3D REST service.
         let elevationServiceURL = URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!
         let elevationSource = AGSArcGISTiledElevationSource(url: elevationServiceURL)

--- a/arcgis-ios-sdk-samples/Scenes/Realistic lighting and shadows/RealisticLightingAndShadowsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Realistic lighting and shadows/RealisticLightingAndShadowsViewController.swift
@@ -56,7 +56,7 @@ class RealisticLightingAndShadowsViewController: UIViewController {
         let elevationSource = AGSArcGISTiledElevationSource(url: elevationServiceURL)
         let surface = AGSSurface()
         surface.elevationSources = [elevationSource]
-        let scene = AGSScene(basemap: .topographic())
+        let scene = AGSScene(basemapStyle: .arcGISTopographic)
         scene.baseSurface = surface
         scene.operationalLayers.add(buildingsLayer)
         return scene

--- a/arcgis-ios-sdk-samples/Scenes/Scene layer (URL)/SceneLayerURLViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Scene layer (URL)/SceneLayerURLViewController.swift
@@ -26,8 +26,8 @@ class SceneLayerURLViewController: UIViewController {
         // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["SceneLayerURLViewController"]
         
-        // initialize scene with topographic basemap
-        let scene = AGSScene(basemap: .topographic())
+        // Initialize scene with topographic basemap style.
+        let scene = AGSScene(basemapStyle: .arcGISTopographic)
         
         // assign scene to the scene view
         self.sceneView.scene = scene

--- a/arcgis-ios-sdk-samples/Scenes/Scene layer selection/SceneLayerSelectionViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Scene layer selection/SceneLayerSelectionViewController.swift
@@ -25,7 +25,7 @@ class SceneLayerSelectionViewController: UIViewController {
     let buildingsLayer: AGSArcGISSceneLayer
     
     required init?(coder: NSCoder) {
-        scene = AGSScene(basemap: .topographic())
+        scene = AGSScene(basemapStyle: .arcGISTopographic)
         
         // Create a surface set it as the base surface of the scene.
         let surface = AGSSurface()

--- a/arcgis-ios-sdk-samples/Scenes/Scene properties expressions/ScenePropertiesExpressionsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Scene properties expressions/ScenePropertiesExpressionsViewController.swift
@@ -29,8 +29,8 @@ class ScenePropertiesExpressionsViewController: UIViewController {
         // add the source code button item to the right of navigation bar
         (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["ScenePropertiesExpressionsViewController"]
         
-        // initialize scene with streets basemap
-        let scene = AGSScene(basemap: .streets())
+        // Initialize scene with streets basemap style.
+        let scene = AGSScene(basemapStyle: .arcGISStreets)
         // assign scene to the scene view
         self.sceneView.scene = scene
         

--- a/arcgis-ios-sdk-samples/Scenes/Scene symbols/SceneSymbolsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Scene symbols/SceneSymbolsViewController.swift
@@ -26,7 +26,7 @@ class SceneSymbolsViewController: UIViewController {
         // Add the source code button item to the right of navigation bar.
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["SceneSymbolsViewController"]
         
-        let scene = AGSScene(basemap: .topographic())
+        let scene = AGSScene(basemapStyle: .arcGISTopographic)
         
         // Add base surface for elevation data.
         let surface = AGSSurface()

--- a/arcgis-ios-sdk-samples/Scenes/Surface placements/SurfacePlacementsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Surface placements/SurfacePlacementsViewController.swift
@@ -90,7 +90,7 @@ class SurfacePlacementsViewController: UIViewController {
     ///
     /// - Returns: A new `AGSScene` object.
     func makeScene() -> AGSScene {
-        let scene = AGSScene(basemap: .imagery())
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
         // Add a base surface for elevation data.
         let surface = AGSSurface()
         // Create elevation source from the Terrain 3D ArcGIS REST Service.

--- a/arcgis-ios-sdk-samples/Scenes/Terrain exaggeration/TerrainExaggerationViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Terrain exaggeration/TerrainExaggerationViewController.swift
@@ -20,8 +20,8 @@ class TerrainExaggerationViewController: UIViewController {
     @IBOutlet weak var exaggerationSlider: UISlider!
     @IBOutlet weak var sceneView: AGSSceneView!
     
-    // initialize scene with streets basemap
-    let scene = AGSScene(basemap: .streets())
+    // Initialize scene with streets basemap style.
+    let scene = AGSScene(basemapStyle: .arcGISStreets)
     
     // initialize surface
     let surface = AGSSurface()


### PR DESCRIPTION
## Description

With 100.13 we have full support for vector tiled layers in scenes which means all samples should now be using the new `AGSBasemapStyle` wherever an Esri basemap is relevantly used.

## Linked Issue(s)

`common-samples/issues/3267`

## How To Test

Open each changed sample and see the basemap displays.

## To Discuss

- (Sarat) How would this affect image comparison tests?
- There are 2 samples with `nationalGeographic` basemap. I replaced them with topographic style, but wonder if it is a right choice?