### PR TITLE
Fix: `Route around barriers` misc issues

### DIFF
--- a/arcgis-ios-sdk-samples/Route and directions/Route around barriers/RouteAroundBarriersViewController.swift
+++ b/arcgis-ios-sdk-samples/Route and directions/Route around barriers/RouteAroundBarriersViewController.swift
@@ -73,7 +73,7 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
         // hide directions list
         self.setRouteDetailsVisibility(visible: generatedRoute != nil, animated: false)
     }
-
+    
     // MARK: - Route logic
     
     func getDefaultParameters() {
@@ -133,10 +133,12 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
             if let error = error {
                 self.presentAlert(error: error)
             } else if let routeResult = routeResult,
-                let route = routeResult.routes.first {
-                let routeGraphic = AGSGraphic(geometry: route.routeGeometry, symbol: self.routeSymbol(), attributes: nil)
+                      let route = routeResult.routes.first,
+                      let geometry = route.routeGeometry {
+                let routeGraphic = AGSGraphic(geometry: geometry, symbol: self.routeSymbol(), attributes: nil)
                 self.routeGraphicsOverlay.graphics.add(routeGraphic)
                 self.generatedRoute = route
+                self.mapView.setViewpointGeometry(geometry, padding: 30)
             }
         }
     }

--- a/arcgis-ios-sdk-samples/Route and directions/Route around barriers/RouteAroundBarriersViewController.swift
+++ b/arcgis-ios-sdk-samples/Route and directions/Route around barriers/RouteAroundBarriersViewController.swift
@@ -67,8 +67,8 @@ class RouteAroundBarriersViewController: UIViewController, AGSGeoViewTouchDelega
         self.getDefaultParameters()
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         
         // hide directions list
         self.setRouteDetailsVisibility(visible: generatedRoute != nil, animated: false)


### PR DESCRIPTION
## Description

This PR fixes `Route around barriers` in `Route and directions` category. The sample was first added in #150

## Linked Issue(s)

`common-samples/issues/814`

## How To Test

Run the sample, and solve a route.

- The solved route graphic should be padded with a margin to the screen
- No warning message in the console

@philium when you have a chance, can you elaborate on the first 2 issues you mentioned in the original post?

I cannot figure out which part of sample code should be improved, or maybe they are already fixed in the SDK or core.

## To Discuss

- Respond appropriately if the service is down. Just got this in the console.

I cannot repro this issue, so didn't add error handling.

- Runtime Error for some portions of the route

I'm not sure where does this come from either. 😳 

- Pad the portion of the route more as you display it

I padded the viewpoint around the solved route geometry.