### PR TITLE
[Update] Replace instances of `AGSServiceFeatureTable.applyEdits` , 1st PR

### DIFF
--- a/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
@@ -90,7 +90,7 @@ class AddFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate {
     /// Apply local edits to the geodatabase.
     func applyEdits() {
         if serviceGeodatabase.hasLocalEdits() {
-            serviceGeodatabase.applyEdits { [weak self] (featureTableEditResults: [AGSFeatureTableEditResult]?, error: Error?) in
+            serviceGeodatabase.applyEdits { [weak self] featureTableEditResults, error in
                 if let featureTableEditResults = featureTableEditResults,
                    featureTableEditResults.first?.editResults.first?.completedWithErrors == false {
                     self?.presentAlert(message: "Edits applied successfully")

--- a/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
@@ -73,10 +73,8 @@ class AddFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate {
         // Create a new feature.
         let feature = featureTable.createFeature(attributes: featureAttributes, geometry: normalizedGeometry)
         
-        UIApplication.shared.showProgressHUD(message: "Adding…")
         // Add the feature to the feature table.
         featureTable.add(feature) { [weak self] (error: Error?) in
-            UIApplication.shared.hideProgressHUD()
             // Enable interaction with map view.
             self?.mapView.isUserInteractionEnabled = true
             

--- a/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
@@ -91,18 +91,16 @@ class AddFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate {
     func applyEdits() {
         if serviceGeodatabase.hasLocalEdits() {
             serviceGeodatabase.applyEdits { [weak self] (featureTableEditResults: [AGSFeatureTableEditResult]?, error: Error?) in
-                if let error = error {
+                if let featureTableEditResults = featureTableEditResults,
+                   featureTableEditResults.first?.editResults.first?.completedWithErrors == false {
+                    self?.presentAlert(message: "Edits applied successfully")
+                } else if let error = error {
                     self?.presentAlert(message: "Error while applying edits: \(error.localizedDescription)")
-                } else {
-                    if let featureTableEditResults = featureTableEditResults,
-                       featureTableEditResults.first?.editResults.first?.completedWithErrors == false {
-                        self?.presentAlert(message: "Edits applied successfully")
-                    }
                 }
             }
         }
     }
-  
+    
     // MARK: - AGSGeoViewTouchDelegate
     
     func geoView(_ geoView: AGSGeoView, didTapAtScreenPoint screenPoint: CGPoint, mapPoint: AGSPoint) {

--- a/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
@@ -73,7 +73,7 @@ class AddFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate {
         // Create a new feature.
         let feature = featureTable.createFeature(attributes: featureAttributes, geometry: normalizedGeometry)
         
-        UIApplication.shared.showProgressHUD(message: "Adding..")
+        UIApplication.shared.showProgressHUD(message: "Adding…")
         // Add the feature to the feature table.
         featureTable.add(feature) { [weak self] (error: Error?) in
             UIApplication.shared.hideProgressHUD()
@@ -94,7 +94,7 @@ class AddFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate {
         if serviceGeodatabase.hasLocalEdits() {
             serviceGeodatabase.applyEdits { [weak self] (featureTableEditResults: [AGSFeatureTableEditResult]?, error: Error?) in
                 if let error = error {
-                    self?.presentAlert(message: "Error while applying edits:\(error.localizedDescription)")
+                    self?.presentAlert(message: "Error while applying edits: \(error.localizedDescription)")
                 } else {
                     if let featureTableEditResults = featureTableEditResults,
                        featureTableEditResults.first?.editResults.first?.completedWithErrors == false {

--- a/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
@@ -90,14 +90,13 @@ class AddFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate {
     
     /// Apply local edits to the geodatabase.
     func applyEdits() {
-        if serviceGeodatabase.hasLocalEdits() {
-            serviceGeodatabase.applyEdits { [weak self] featureTableEditResults, error in
-                if let featureTableEditResults = featureTableEditResults,
-                   featureTableEditResults.first?.editResults.first?.completedWithErrors == false {
-                    self?.presentAlert(message: "Edits applied successfully")
-                } else if let error = error {
-                    self?.presentAlert(message: "Error while applying edits: \(error.localizedDescription)")
-                }
+        guard serviceGeodatabase.hasLocalEdits() else { return }
+        serviceGeodatabase.applyEdits { [weak self] featureTableEditResults, error in
+            if let featureTableEditResults = featureTableEditResults,
+               featureTableEditResults.first?.editResults.first?.completedWithErrors == false {
+                self?.presentAlert(message: "Edits applied successfully")
+            } else if let error = error {
+                self?.presentAlert(message: "Error while applying edits: \(error.localizedDescription)")
             }
         }
     }

--- a/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
@@ -94,7 +94,6 @@ class AddFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate {
         serviceGeodatabase.applyEdits { [weak self] featureTableEditResults, error in
             if let featureTableEditResults = featureTableEditResults,
                featureTableEditResults.first?.editResults.first?.completedWithErrors == false {
-                self?.presentAlert(message: "Edits applied successfully")
             } else if let error = error {
                 self?.presentAlert(message: "Error while applying edits: \(error.localizedDescription)")
             }

--- a/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
@@ -91,10 +91,8 @@ class AddFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate {
     /// Apply local edits to the geodatabase.
     func applyEdits() {
         guard serviceGeodatabase.hasLocalEdits() else { return }
-        serviceGeodatabase.applyEdits { [weak self] featureTableEditResults, error in
-            if let featureTableEditResults = featureTableEditResults,
-               featureTableEditResults.first?.editResults.first?.completedWithErrors == false {
-            } else if let error = error {
+        serviceGeodatabase.applyEdits { [weak self] _, error in
+            if let error = error {
                 self?.presentAlert(message: "Error while applying edits: \(error.localizedDescription)")
             }
         }

--- a/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
@@ -16,73 +16,91 @@ import UIKit
 import ArcGIS
 
 class AddFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate {
-    @IBOutlet private var mapView: AGSMapView!
+    @IBOutlet var mapView: AGSMapView! {
+        didSet {
+            mapView.map = AGSMap(basemapStyle: .arcGISStreets)
+            // Set touch delegate on map view as self.
+            mapView.touchDelegate = self
+        }
+    }
     
-    private var featureTable: AGSServiceFeatureTable!
-    private var lastQuery: AGSCancelable!
+    /// The service geodatabase that contains damaged property features.
+    var serviceGeodatabase: AGSServiceGeodatabase!
+    /// The feature table to add features to.
+    var featureTable: AGSServiceFeatureTable!
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        // Add the source code button item to the right of navigation bar.
+        (navigationItem.rightBarButtonItem as? SourceCodeBarButtonItem)?.filenames = ["AddFeaturesViewController"]
         
-        // add the source code button item to the right of navigation bar
-        (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["AddFeaturesViewController"]
-        
-        // assign the map to the map view
-        let map = AGSMap(basemapStyle: .arcGISStreets)
-        self.mapView.map = map
-        self.mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: 544871.19, y: 6806138.66, spatialReference: .webMercator()), scale: 2e6))
-        // set touch delegate on map view as self
-        self.mapView.touchDelegate = self
-        
-        // instantiate service feature table using the url to the service
-        self.featureTable = AGSServiceFeatureTable(url: URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0")!)
-        // create a feature layer using the service feature table
-        let featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
-        
-        // add the feature layer to the operational layers on map
-        map.operationalLayers.add(featureLayer)
+        // Load the service geodatabase.
+        let damageFeatureService = URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer")!
+        loadServiceGeodatabase(from: damageFeatureService)
     }
     
-    func addFeature(at mappoint: AGSPoint) {
-        // disable interaction with map view
+    /// Load and set a service geodatabase from a feature service URL.
+    /// - Parameter serviceURL: The URL to the feature service.
+    func loadServiceGeodatabase(from serviceURL: URL) {
+        let serviceGeodatabase = AGSServiceGeodatabase(url: serviceURL)
+        serviceGeodatabase.load { [weak self] error in
+            guard let self = self else { return }
+            if let error = error {
+                self.presentAlert(error: error)
+            } else {
+                let featureTable = serviceGeodatabase.table(withLayerID: 0)!
+                self.featureTable = featureTable
+                self.serviceGeodatabase = serviceGeodatabase
+                // Add the feature layer to the operational layers on map.
+                let featureLayer = AGSFeatureLayer(featureTable: featureTable)
+                self.mapView.map?.operationalLayers.add(featureLayer)
+                self.mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: 544871.19, y: 6806138.66, spatialReference: .webMercator()), scale: 2e6))
+            }
+        }
+    }
+    
+    /// Add a feature at the tapped point.
+    /// - Parameter mapPoint: The point where user tapped.
+    func addFeature(at mapPoint: AGSPoint) {
+        // Disable interaction with map view.
         mapView.isUserInteractionEnabled = false
         
-        // normalize geometry
-        let normalizedGeometry = AGSGeometryEngine.normalizeCentralMeridian(of: mappoint)!
+        // Normalize geometry.
+        let normalizedGeometry = AGSGeometryEngine.normalizeCentralMeridian(of: mapPoint)!
         
-        // attributes for the new feature
+        // Attributes for the new feature.
         let featureAttributes = ["typdamage": "Minor", "primcause": "Earthquake"]
-        // create a new feature
+        // Create a new feature.
         let feature = featureTable.createFeature(attributes: featureAttributes, geometry: normalizedGeometry)
         
-        // show the progress hud
         UIApplication.shared.showProgressHUD(message: "Adding..")
-        
-        // add the feature to the feature table
+        // Add the feature to the feature table.
         featureTable.add(feature) { [weak self] (error: Error?) in
             UIApplication.shared.hideProgressHUD()
+            // Enable interaction with map view.
+            self?.mapView.isUserInteractionEnabled = true
             
             if let error = error {
                 self?.presentAlert(message: "Error while adding feature: \(error.localizedDescription)")
             } else {
-                // applied edits on success
+                // Applied edits on success.
                 self?.applyEdits()
             }
-            // enable interaction with map view
-            self?.mapView.isUserInteractionEnabled = true
         }
     }
     
+    /// Apply local edits to the geodatabase.
     func applyEdits() {
-        self.featureTable.applyEdits { [weak self] (featureEditResults: [AGSFeatureEditResult]?, error: Error?) in
-            if let error = error {
-                self?.presentAlert(message: "Error while applying edits :: \(error.localizedDescription)")
-            } else {
-                if let featureEditResults = featureEditResults,
-                    featureEditResults.first?.completedWithErrors == false {
-                    self?.presentAlert(message: "Edits applied successfully")
+        if serviceGeodatabase.hasLocalEdits() {
+            serviceGeodatabase.applyEdits { [weak self] (featureTableEditResults: [AGSFeatureTableEditResult]?, error: Error?) in
+                if let error = error {
+                    self?.presentAlert(message: "Error while applying edits:\(error.localizedDescription)")
+                } else {
+                    if let featureTableEditResults = featureTableEditResults,
+                       featureTableEditResults.first?.editResults.first?.completedWithErrors == false {
+                        self?.presentAlert(message: "Edits applied successfully")
+                    }
                 }
-                UIApplication.shared.hideProgressHUD()
             }
         }
     }
@@ -90,7 +108,7 @@ class AddFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate {
     // MARK: - AGSGeoViewTouchDelegate
     
     func geoView(_ geoView: AGSGeoView, didTapAtScreenPoint screenPoint: CGPoint, mapPoint: AGSPoint) {
-        // add a feature at the tapped location
-        self.addFeature(at: mapPoint)
+        // Add a feature at the tapped location.
+        addFeature(at: mapPoint)
     }
 }

--- a/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Add features (feature service)/AddFeaturesViewController.swift
@@ -75,14 +75,15 @@ class AddFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate {
         
         // Add the feature to the feature table.
         featureTable.add(feature) { [weak self] (error: Error?) in
+            guard let self = self else { return }
             // Enable interaction with map view.
-            self?.mapView.isUserInteractionEnabled = true
+            self.mapView.isUserInteractionEnabled = true
             
             if let error = error {
-                self?.presentAlert(message: "Error while adding feature: \(error.localizedDescription)")
+                self.presentAlert(message: "Error while adding feature: \(error.localizedDescription)")
             } else {
                 // Applied edits on success.
-                self?.applyEdits()
+                self.applyEdits()
             }
         }
     }

--- a/arcgis-ios-sdk-samples/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
@@ -78,7 +78,7 @@ class DeleteFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate, A
     func deleteFeature(_ feature: AGSFeature) {
         featureTable.delete(feature) { [weak self] (error: Error?) in
             if let error = error {
-                print("Error while deleting feature: \(error.localizedDescription)")
+                self?.presentAlert(message: "Error while deleting feature: \(error.localizedDescription)")
             } else {
                 self?.applyEdits()
             }

--- a/arcgis-ios-sdk-samples/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
@@ -88,11 +88,8 @@ class DeleteFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate, A
     /// Apply local edits to the geodatabase.
     func applyEdits() {
         guard serviceGeodatabase.hasLocalEdits() else { return }
-        serviceGeodatabase.applyEdits { [weak self] featureTableEditResults, error in
-            if let featureTableEditResults = featureTableEditResults,
-               featureTableEditResults.first?.editResults.first?.completedWithErrors == false {
-                self?.presentAlert(message: "Edits applied successfully")
-            } else if let error = error {
+        serviceGeodatabase.applyEdits { [weak self] _, error in
+            if let error = error {
                 self?.presentAlert(message: "Error while applying edits: \(error.localizedDescription)")
             }
         }

--- a/arcgis-ios-sdk-samples/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
@@ -87,14 +87,13 @@ class DeleteFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate, A
     
     /// Apply local edits to the geodatabase.
     func applyEdits() {
-        if serviceGeodatabase.hasLocalEdits() {
-            serviceGeodatabase.applyEdits { [weak self] featureTableEditResults, error in
-                if let featureTableEditResults = featureTableEditResults,
-                   featureTableEditResults.first?.editResults.first?.completedWithErrors == false {
-                    self?.presentAlert(message: "Edits applied successfully")
-                } else if let error = error {
-                    self?.presentAlert(message: "Error while applying edits: \(error.localizedDescription)")
-                }
+        guard serviceGeodatabase.hasLocalEdits() else { return }
+        serviceGeodatabase.applyEdits { [weak self] featureTableEditResults, error in
+            if let featureTableEditResults = featureTableEditResults,
+               featureTableEditResults.first?.editResults.first?.completedWithErrors == false {
+                self?.presentAlert(message: "Edits applied successfully")
+            } else if let error = error {
+                self?.presentAlert(message: "Error while applying edits: \(error.localizedDescription)")
             }
         }
     }

--- a/arcgis-ios-sdk-samples/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Delete features (feature service)/DeleteFeaturesViewController.swift
@@ -76,7 +76,7 @@ class DeleteFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate, A
     
     /// Delete a feature from the feature table.
     func deleteFeature(_ feature: AGSFeature) {
-        featureTable.delete(feature) { [weak self] (error: Error?) in
+        featureTable.delete(feature) { [weak self] error in
             if let error = error {
                 self?.presentAlert(message: "Error while deleting feature: \(error.localizedDescription)")
             } else {
@@ -88,7 +88,7 @@ class DeleteFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate, A
     /// Apply local edits to the geodatabase.
     func applyEdits() {
         if serviceGeodatabase.hasLocalEdits() {
-            serviceGeodatabase.applyEdits { [weak self] (featureTableEditResults: [AGSFeatureTableEditResult]?, error: Error?) in
+            serviceGeodatabase.applyEdits { [weak self] featureTableEditResults, error in
                 if let featureTableEditResults = featureTableEditResults,
                    featureTableEditResults.first?.editResults.first?.completedWithErrors == false {
                     self?.presentAlert(message: "Edits applied successfully")
@@ -106,7 +106,7 @@ class DeleteFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate, A
         // Hide the callout.
         mapView.callout.dismiss()
         
-        lastQuery = mapView.identifyLayer(featureLayer, screenPoint: screenPoint, tolerance: 12, returnPopupsOnly: false) { [weak self] (identifyLayerResult: AGSIdentifyLayerResult) in
+        lastQuery = mapView.identifyLayer(featureLayer, screenPoint: screenPoint, tolerance: 12, returnPopupsOnly: false) { [weak self] identifyLayerResult in
             guard let self = self else { return }
             self.lastQuery = nil
             if let feature = identifyLayerResult.geoElements.first as? AGSFeature {
@@ -125,11 +125,11 @@ class DeleteFeaturesViewController: UIViewController, AGSGeoViewTouchDelegate, A
     func didTapAccessoryButton(for callout: AGSCallout) {
         mapView.callout.dismiss()
         let alertController = UIAlertController(title: "Are you sure you want to delete the feature?", message: nil, preferredStyle: .alert)
-        let alertAction = UIAlertAction(title: "Yes", style: .default) { [unowned self] _ in
+        let alertAction = UIAlertAction(title: "Delete", style: .destructive) { [unowned self] _ in
             deleteFeature(selectedFeature)
         }
         alertController.addAction(alertAction)
-        let cancelAlertAction = UIAlertAction(title: "No", style: .cancel)
+        let cancelAlertAction = UIAlertAction(title: "Cancel", style: .cancel)
         alertController.addAction(cancelAlertAction)
         alertController.preferredAction = cancelAlertAction
         present(alertController, animated: true)

--- a/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/UpdateAttributesOptionsViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/UpdateAttributesOptionsViewController.swift
@@ -16,7 +16,7 @@ import UIKit
 
 protocol UpdateAttributesOptionsViewControllerDelegate: AnyObject {
     func optionsViewController(_ optionsViewController: UpdateAttributesOptionsViewController, didSelectOptionAtIndex index: Int)
-    func optionsViewControllerDidCancell(_ optionsViewController: UpdateAttributesOptionsViewController)
+    func optionsViewControllerDidCancel(_ optionsViewController: UpdateAttributesOptionsViewController)
 }
 
 class UpdateAttributesOptionsViewController: UITableViewController {
@@ -50,6 +50,6 @@ class UpdateAttributesOptionsViewController: UITableViewController {
     // MARK: - Actions
     
     @IBAction func cancel() {
-        delegate?.optionsViewControllerDidCancell(self)
+        delegate?.optionsViewControllerDidCancel(self)
     }
 }

--- a/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/UpdateAttributesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/UpdateAttributesViewController.swift
@@ -83,7 +83,7 @@ class UpdateAttributesViewController: UIViewController, AGSGeoViewTouchDelegate,
     /// Apply local edits to the geodatabase.
     func applyEdits() {
         if serviceGeodatabase.hasLocalEdits() {
-            serviceGeodatabase.applyEdits { [weak self] (featureTableEditResults: [AGSFeatureTableEditResult]?, error: Error?) in
+            serviceGeodatabase.applyEdits { [weak self] featureTableEditResults, error in
                 guard let self = self else { return }
                 if let featureTableEditResults = featureTableEditResults,
                    featureTableEditResults.first?.editResults.first?.completedWithErrors == false {

--- a/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/UpdateAttributesViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update attributes (feature service)/UpdateAttributesViewController.swift
@@ -82,16 +82,14 @@ class UpdateAttributesViewController: UIViewController, AGSGeoViewTouchDelegate,
     
     /// Apply local edits to the geodatabase.
     func applyEdits() {
-        if serviceGeodatabase.hasLocalEdits() {
-            serviceGeodatabase.applyEdits { [weak self] featureTableEditResults, error in
-                guard let self = self else { return }
-                if let featureTableEditResults = featureTableEditResults,
-                   featureTableEditResults.first?.editResults.first?.completedWithErrors == false {
-                    self.presentAlert(message: "Edits applied successfully")
-                    self.showCallout(for: self.selectedFeature, at: nil)
-                } else if let error = error {
-                    self.presentAlert(message: "Error while applying edits: \(error.localizedDescription)")
-                }
+        guard serviceGeodatabase.hasLocalEdits() else { return }
+        serviceGeodatabase.applyEdits { [weak self] featureTableEditResults, error in
+            guard let self = self else { return }
+            if let featureTableEditResults = featureTableEditResults,
+               featureTableEditResults.first?.editResults.first?.completedWithErrors == false {
+                self.showCallout(for: self.selectedFeature, at: nil)
+            } else if let error = error {
+                self.presentAlert(message: "Error while applying edits: \(error.localizedDescription)")
             }
         }
     }

--- a/arcgis-ios-sdk-samples/Edit data/Update geometries (feature service)/EditGeometryViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update geometries (feature service)/EditGeometryViewController.swift
@@ -16,44 +16,75 @@ import UIKit
 import ArcGIS
 
 class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGSCalloutDelegate {
-    @IBOutlet private weak var mapView: AGSMapView!
-    @IBOutlet private weak var toolbar: UIToolbar!
-    @IBOutlet private var toolbarBottomConstraint: NSLayoutConstraint!
+    @IBOutlet var mapView: AGSMapView! {
+        didSet {
+            mapView.map = AGSMap(basemapStyle: .arcGISOceans)
+            // Set touch delegate on map view as self.
+            mapView.touchDelegate = self
+            mapView.callout.delegate = self
+        }
+    }
     
-    private var map: AGSMap!
-    private var featureTable: AGSServiceFeatureTable!
-    private var featureLayer: AGSFeatureLayer!
-    private var lastQuery: AGSCancelable!
+    @IBOutlet var toolbar: UIToolbar!
+    @IBOutlet var toolbarBottomConstraint: NSLayoutConstraint!
     
-    private var selectedFeature: AGSArcGISFeature!
-    private let featureServiceURL = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"
+    /// The feature table to update features geometries.
+    var featureTable: AGSServiceFeatureTable!
+    /// The service geodatabase that contains damaged property features.
+    var serviceGeodatabase: AGSServiceGeodatabase!
+    /// The feature layer created from the feature table.
+    var featureLayer: AGSFeatureLayer!
+    /// Last identify operation.
+    var lastQuery: AGSCancelable!
+    /// The currently selected feature.
+    var selectedFeature: AGSFeature!
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        // Add the source code button item to the right of navigation bar.
+        (navigationItem.rightBarButtonItem as? SourceCodeBarButtonItem)?.filenames = ["EditGeometryViewController"]
         
-        // add the source code button item to the right of navigation bar
-        (self.navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["EditGeometryViewController"]
-        
-        self.map = AGSMap(basemapStyle: .arcGISOceans)
-        
-        self.featureTable = AGSServiceFeatureTable(url: URL(string: featureServiceURL)!)
-        let featureLayer = AGSFeatureLayer(featureTable: self.featureTable)
-        
-        self.map.operationalLayers.add(featureLayer)
-
-        self.mapView.map = self.map
-        self.mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: -9030446.96, y: 943791.32, spatialReference: .webMercator()), scale: 2e6))
-        self.mapView.touchDelegate = self
-        
-        // store the feature layer for later use
-        self.featureLayer = featureLayer
+        // Load the service geodatabase.
+        let damageFeatureService = URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer")!
+        loadServiceGeodatabase(from: damageFeatureService)
     }
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
-        // default state for toolbar is off
-        self.setToolbarVisibility(visible: false)
+        // Default state for toolbar is hidden.
+        setToolbarVisibility(visible: false)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if let sketchEditor = mapView.sketchEditor, sketchEditor.isStarted, let feature = selectedFeature {
+            // Make the feature visible when sketch editor is started.
+            featureLayer.setFeature(feature, visible: true)
+            // Stop sketch editor.
+            mapView.sketchEditor?.stop()
+        }
+        setToolbarVisibility(visible: false)
+    }
+    
+    /// Load and set a service geodatabase from a feature service URL.
+    /// - Parameter serviceURL: The URL to the feature service.
+    func loadServiceGeodatabase(from serviceURL: URL) {
+        let serviceGeodatabase = AGSServiceGeodatabase(url: serviceURL)
+        serviceGeodatabase.load { [weak self] error in
+            guard let self = self else { return }
+            if let error = error {
+                self.presentAlert(error: error)
+            } else {
+                let featureTable = serviceGeodatabase.table(withLayerID: 0)!
+                self.featureTable = featureTable
+                self.serviceGeodatabase = serviceGeodatabase
+                // Add the feature layer to the operational layers on map.
+                let featureLayer = AGSFeatureLayer(featureTable: featureTable)
+                self.featureLayer = featureLayer
+                self.mapView.map?.operationalLayers.add(featureLayer)
+                self.mapView.setViewpoint(AGSViewpoint(center: AGSPoint(x: -9030446.96, y: 943791.32, spatialReference: .webMercator()), scale: 2e6))
+            }
+        }
     }
     
     func setToolbarVisibility(visible: Bool) {
@@ -64,40 +95,45 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
         }
     }
     
+    /// Apply local edits to the geodatabase.
     func applyEdits() {
-        self.featureTable.applyEdits { [weak self] (_, error) in
-            if let error = error {
-                self?.presentAlert(error: error)
-            } else {
-                self?.presentAlert(message: "Saved successfully!")
+        if serviceGeodatabase.hasLocalEdits() {
+            serviceGeodatabase.applyEdits { [weak self] (featureTableEditResults: [AGSFeatureTableEditResult]?, error: Error?) in
+                guard let self = self else { return }
+                if let featureTableEditResults = featureTableEditResults,
+                   featureTableEditResults.first?.editResults.first?.completedWithErrors == false {
+                    self.featureLayer.setFeature(self.selectedFeature, visible: true)
+                    self.presentAlert(message: "Saved successfully!")
+                } else if let error = error {
+                    self.presentAlert(message: "Error while applying edits: \(error.localizedDescription)")
+                }
             }
-            // un hide the feature
-            self?.featureLayer.setFeature(self!.selectedFeature, visible: true)
         }
+    }
+    
+    func showCallout(for feature: AGSFeature, at tapLocation: AGSPoint?) {
+        let title = feature.attributes["typdamage"] as! String
+        mapView.callout.title = title
+        mapView.callout.show(for: feature, tapLocation: tapLocation, animated: true)
     }
     
     // MARK: - AGSGeoViewTouchDelegate
     
     func geoView(_ geoView: AGSGeoView, didTapAtScreenPoint screenPoint: CGPoint, mapPoint: AGSPoint) {
-        if let lastQuery = self.lastQuery {
-            lastQuery.cancel()
-        }
+        if let query = lastQuery { query.cancel() }
+        // Hide the callout.
+        mapView.callout.dismiss()
         
-        // hide the callout
-        self.mapView.callout.dismiss()
-        
-        self.lastQuery = self.mapView.identifyLayer(self.featureLayer, screenPoint: screenPoint, tolerance: 12, returnPopupsOnly: false, maximumResults: 1) { [weak self] (identifyLayerResult: AGSIdentifyLayerResult) in
-            if let error = identifyLayerResult.error {
-                print(error)
-            } else if let features = identifyLayerResult.geoElements as? [AGSArcGISFeature],
-                let feature = features.first {
-                // show callout for the first feature
-                let title = feature.attributes["typdamage"] as! String
-                self?.mapView.callout.title = title
-                self?.mapView.callout.delegate = self
-                self?.mapView.callout.show(for: feature, tapLocation: mapPoint, animated: true)
-                // update selected feature
-                self?.selectedFeature = feature
+        lastQuery = mapView.identifyLayer(featureLayer, screenPoint: screenPoint, tolerance: 12, returnPopupsOnly: false) { [weak self] (identifyLayerResult: AGSIdentifyLayerResult) in
+            guard let self = self else { return }
+            self.lastQuery = nil
+            if let feature = identifyLayerResult.geoElements.first as? AGSFeature {
+                // Show callout for the feature.
+                self.showCallout(for: feature, at: mapPoint)
+                // Update selected feature.
+                self.selectedFeature = feature
+            } else if let error = identifyLayerResult.error {
+                self.presentAlert(error: error)
             }
         }
     }
@@ -105,50 +141,43 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
     // MARK: - AGSCalloutDelegate
     
     func didTapAccessoryButton(for callout: AGSCallout) {
-        // hide the callout
-        self.mapView.callout.dismiss()
+        guard let point = selectedFeature.geometry as? AGSPoint else { return }
+        // Hide the callout.
+        mapView.callout.dismiss()
         
-        // add the default geometry
-        let point = self.selectedFeature.geometry as! AGSPoint
+        // Instantiate sketch editor with selected feature's geometry, and
+        // enable the sketch editor to start tracking user gesture.
+        let sketchEditor = AGSSketchEditor()
+        mapView.sketchEditor = sketchEditor
+        sketchEditor.start(with: point)
         
-        // instantiate sketch editor with selected feature's geometry
-        self.mapView.sketchEditor = AGSSketchEditor()
-        
-        // enable the sketch editor to start tracking user gesture
-        self.mapView.sketchEditor?.start(with: point)
-        
-        // show the toolbar
-        self.setToolbarVisibility(visible: true)
-        
-        // hide the feature for time being
-        self.featureLayer.setFeature(self.selectedFeature, visible: false)
+        // Show the toolbar.
+        setToolbarVisibility(visible: true)
+        // Hide the feature for time being.
+        featureLayer.setFeature(selectedFeature, visible: false)
     }
     
     // MARK: - Actions
     
     @IBAction func doneAction() {
-        if let newGeometry = self.mapView.sketchEditor?.geometry {
-            self.selectedFeature.geometry = newGeometry
-            self.featureTable.update(self.selectedFeature) { [weak self] (error) in
+        if let newGeometry = mapView.sketchEditor?.geometry {
+            selectedFeature.geometry = newGeometry
+            featureTable.update(selectedFeature) { [weak self] (error: Error?) in
+                guard let self = self else { return }
                 if let error = error {
-                    self?.presentAlert(error: error)
-                    
-                    // un hide the feature
-                    self?.featureLayer.setFeature(self!.selectedFeature, visible: true)
+                    self.presentAlert(error: error)
+                    // Make the feature visible due to unsuccessful update.
+                    self.featureLayer.setFeature(self.selectedFeature, visible: true)
                 } else {
-                    // apply edits
-                    self?.applyEdits()
+                    // Apply edits.
+                    self.applyEdits()
                 }
             }
         }
-        
-        // hide toolbar
-        self.setToolbarVisibility(visible: false)
-        
-        // disable sketch editor
-        self.mapView.sketchEditor?.stop()
-        
-        // clear sketch editor
-        self.mapView.sketchEditor?.clearGeometry()
+        // Hide toolbar.
+        setToolbarVisibility(visible: false)
+        // Stop and clear sketch editor.
+        mapView.sketchEditor?.stop()
+        mapView.sketchEditor = nil
     }
 }

--- a/arcgis-ios-sdk-samples/Edit data/Update geometries (feature service)/EditGeometryViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update geometries (feature service)/EditGeometryViewController.swift
@@ -97,16 +97,14 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
     
     /// Apply local edits to the geodatabase.
     func applyEdits() {
-        if serviceGeodatabase.hasLocalEdits() {
-            serviceGeodatabase.applyEdits { [weak self] (featureTableEditResults: [AGSFeatureTableEditResult]?, error: Error?) in
-                guard let self = self else { return }
-                if let featureTableEditResults = featureTableEditResults,
-                   featureTableEditResults.first?.editResults.first?.completedWithErrors == false {
-                    self.featureLayer.setFeature(self.selectedFeature, visible: true)
-                    self.presentAlert(message: "Saved successfully!")
-                } else if let error = error {
-                    self.presentAlert(message: "Error while applying edits: \(error.localizedDescription)")
-                }
+        guard serviceGeodatabase.hasLocalEdits() else { return }
+        serviceGeodatabase.applyEdits { [weak self] (featureTableEditResults: [AGSFeatureTableEditResult]?, error: Error?) in
+            guard let self = self else { return }
+            if let featureTableEditResults = featureTableEditResults,
+               featureTableEditResults.first?.editResults.first?.completedWithErrors == false {
+                self.featureLayer.setFeature(self.selectedFeature, visible: true)
+            } else if let error = error {
+                self.presentAlert(message: "Error while applying edits: \(error.localizedDescription)")
             }
         }
     }

--- a/arcgis-ios-sdk-samples/Edit data/Update geometries (feature service)/EditGeometryViewController.swift
+++ b/arcgis-ios-sdk-samples/Edit data/Update geometries (feature service)/EditGeometryViewController.swift
@@ -124,7 +124,7 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
         // Hide the callout.
         mapView.callout.dismiss()
         
-        lastQuery = mapView.identifyLayer(featureLayer, screenPoint: screenPoint, tolerance: 12, returnPopupsOnly: false) { [weak self] (identifyLayerResult: AGSIdentifyLayerResult) in
+        lastQuery = mapView.identifyLayer(featureLayer, screenPoint: screenPoint, tolerance: 12, returnPopupsOnly: false) { [weak self] identifyLayerResult in
             guard let self = self else { return }
             self.lastQuery = nil
             if let feature = identifyLayerResult.geoElements.first as? AGSFeature {
@@ -162,7 +162,7 @@ class EditGeometryViewController: UIViewController, AGSGeoViewTouchDelegate, AGS
     @IBAction func doneAction() {
         if let newGeometry = mapView.sketchEditor?.geometry {
             selectedFeature.geometry = newGeometry
-            featureTable.update(selectedFeature) { [weak self] (error: Error?) in
+            featureTable.update(selectedFeature) { [weak self] error in
                 guard let self = self else { return }
                 if let error = error {
                     self.presentAlert(error: error)


### PR DESCRIPTION
## Description

This PR replaces various usage of `applyEdits` method on `AGSServiceFeatureTable` to `AGSServiceGeodatabase`, to prevent data inconsistency issue.

I'll break down the Epic into 2 PRs to make it easier to review. This is the 1st PR.

All the behaviors should remain the same. Coding style has been updated/refactored to follow our latest style guide. Also, a few UI related bugs are fixed. But we'll still request Sarat's review to ensure nothing is breaking the tests.

Also, all comment strings are formatted.

Finally, READMEs will be updated in yet another separate PR, after we finish updating the common designs.

## Linked Issue(s)

`common-samples/issues/3371`

## How To Test

Go though all changed samples and see if they work as expected.

<details><summary>Example change</summary>

```swift
/// Load and set a service geodatabase from a feature service URL.
/// - Parameter serviceURL: The URL to the feature service.
func loadServiceGeodatabase(from serviceURL: URL) {
    let serviceGeodatabase = AGSServiceGeodatabase(url: serviceURL)
    serviceGeodatabase.load { [weak self] error in
        guard let self = self else { return }
        if let error = error {
            self.presentAlert(error: error)
        } else {
            let featureTable = serviceGeodatabase.table(withLayerID: 0)!
            self.featureTable = featureTable
            self.serviceGeodatabase = serviceGeodatabase
            // Add the feature layer to the operational layers on map.
            let featureLayer = AGSFeatureLayer(featureTable: featureTable)
            self.mapView.map?.operationalLayers.add(featureLayer)
        }
    }
}

// then...
serviceGeodatabase.applyEdits { [weak self] (featureTableEditResults: [AGSFeatureTableEditResult]?, error: Error?) in
    if let error = error {
        self?.presentAlert(message: "Error while applying edits:\(error.localizedDescription)")
    } else {
        if let featureTableEditResults = featureTableEditResults,
           featureTableEditResults.first?.editResults.first?.completedWithErrors == false {
            self?.presentAlert(message: "Edits applied successfully")
        }
    }
}
```

</details>
