### PR TITLE
[Fix] Address compiler deprecation warning

### DIFF
--- a/arcgis-ios-sdk-samples/Augmented reality/View hidden infrastructure in AR/ViewHiddenInfrastructureARPipePlacingViewController.swift
+++ b/arcgis-ios-sdk-samples/Augmented reality/View hidden infrastructure in AR/ViewHiddenInfrastructureARPipePlacingViewController.swift
@@ -215,6 +215,6 @@ extension ViewHiddenInfrastructureARPipePlacingViewController: AGSLocationChange
         setStatus(message: "Tap add button to add pipes.")
         sketchBarButtonItem.isEnabled = true
         locationDataSource.locationChangeHandlerDelegate = nil
-        locationDataSource.stop()
+        locationDataSource.stop(completion: nil)
     }
 }


### PR DESCRIPTION
## Description

This PR fixes compiler warning on LocationDataSource `stopWithCompletion`.

It was introduced in a recent daily build, around 3456 .

## Linked Issue(s)

- `runtime/cocoa/pull/11040`