### PR TITLE
[Update] AGSBasemapType enum have been deprecated at 100.14

### DIFF
--- a/arcgis-ios-sdk-samples/Analysis/Line of sight (geoelement)/LineOfSightGeoElementViewController.swift
+++ b/arcgis-ios-sdk-samples/Analysis/Line of sight (geoelement)/LineOfSightGeoElementViewController.swift
@@ -63,7 +63,7 @@ class LineOfSightGeoElementViewController: UIViewController {
         observerPoint = AGSPoint(x: -73.984988, y: 40.748131, z: observerZ, spatialReference: .wgs84())
 
         // Initialize the scene with an imagery basemap style.
-        scene = AGSScene(basemapStyle: .arcGISImageryLabels)
+        scene = AGSScene(basemapStyle: .arcGISImagery)
 
         /// The url of the Terrain 3D ArcGIS REST Service.
         let worldElevationServiceURL = URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!

--- a/arcgis-ios-sdk-samples/Augmented reality/Collect data in AR/CollectDataAR.swift
+++ b/arcgis-ios-sdk-samples/Augmented reality/Collect data in AR/CollectDataAR.swift
@@ -105,7 +105,7 @@ class CollectDataAR: UIViewController {
 
     private func configureSceneForAR() {
         // Create scene with imagery basemap
-        let scene = AGSScene(basemapType: .imageryWithLabels)
+        let scene = AGSScene(basemapStyle: .arcGISImageryLabels)
 
         // Create an elevation source and add it to the scene
         let elevationSource = AGSArcGISTiledElevationSource(url:

--- a/arcgis-ios-sdk-samples/Augmented reality/Collect data in AR/CollectDataAR.swift
+++ b/arcgis-ios-sdk-samples/Augmented reality/Collect data in AR/CollectDataAR.swift
@@ -105,7 +105,7 @@ class CollectDataAR: UIViewController {
 
     private func configureSceneForAR() {
         // Create scene with imagery basemap
-        let scene = AGSScene(basemapStyle: .arcGISImageryLabels)
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
 
         // Create an elevation source and add it to the scene
         let elevationSource = AGSArcGISTiledElevationSource(url:

--- a/arcgis-ios-sdk-samples/Augmented reality/Explore scenes in flyover AR/ExploreScenesInFlyoverAR.swift
+++ b/arcgis-ios-sdk-samples/Augmented reality/Explore scenes in flyover AR/ExploreScenesInFlyoverAR.swift
@@ -44,7 +44,7 @@ class ExploreScenesInFlyoverAR: UIViewController {
 
     private func configureSceneForAR() {
         // Create scene with imagery basemap
-        let scene = AGSScene(basemapType: .imagery)
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
 
         // Create an integrated mesh layer
         let meshLayer = AGSIntegratedMeshLayer(url: URL(string: "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/Girona_Spain/SceneServer")!)

--- a/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/NavigateARNavigatorViewController.swift
+++ b/arcgis-ios-sdk-samples/Augmented reality/Navigate in AR/NavigateARNavigatorViewController.swift
@@ -70,7 +70,7 @@ class NavigateARNavigatorViewController: UIViewController {
     ///
     /// - Returns: A new `AGSScene` object.
     func makeScene() -> AGSScene {
-        let scene = AGSScene(basemapType: .imagery)
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
         elevationSurface.navigationConstraint = .none
         elevationSurface.opacity = 0
         elevationSurface.elevationSources = [elevationSource]

--- a/arcgis-ios-sdk-samples/Augmented reality/View hidden infrastructure in AR/ViewHiddenInfrastructureARExplorerViewController.swift
+++ b/arcgis-ios-sdk-samples/Augmented reality/View hidden infrastructure in AR/ViewHiddenInfrastructureARExplorerViewController.swift
@@ -63,7 +63,7 @@ class ViewHiddenInfrastructureARExplorerViewController: UIViewController {
     ///
     /// - Returns: A new `AGSScene` object.
     func makeScene() -> AGSScene {
-        let scene = AGSScene(basemapType: .imagery)
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
         elevationSurface.navigationConstraint = .none
         elevationSurface.opacity = 0
         elevationSurface.elevationSources = [elevationSource]

--- a/arcgis-ios-sdk-samples/Layers/Display KML network links/DisplayKMLNetworkLinksViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Display KML network links/DisplayKMLNetworkLinksViewController.swift
@@ -33,7 +33,7 @@ class DisplayKMLNetworkLinksViewController: UIViewController {
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["DisplayKMLNetworkLinksViewController"]
         
         // instantiate a scene using labeled imagery basemap
-        let scene = AGSScene(basemapType: .imageryWithLabels)
+        let scene = AGSScene(basemapStyle: .arcGISImageryLabels)
         // set the view's scene
         sceneView.scene = scene
         

--- a/arcgis-ios-sdk-samples/Layers/Display KML network links/DisplayKMLNetworkLinksViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Display KML network links/DisplayKMLNetworkLinksViewController.swift
@@ -33,7 +33,7 @@ class DisplayKMLNetworkLinksViewController: UIViewController {
         (navigationItem.rightBarButtonItem as! SourceCodeBarButtonItem).filenames = ["DisplayKMLNetworkLinksViewController"]
         
         // instantiate a scene using labeled imagery basemap
-        let scene = AGSScene(basemapStyle: .arcGISImageryLabels)
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
         // set the view's scene
         sceneView.scene = scene
         

--- a/arcgis-ios-sdk-samples/Layers/List KML contents/ListKMLContentsSceneViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/List KML contents/ListKMLContentsSceneViewController.swift
@@ -24,7 +24,7 @@ class ListKMLContentsSceneViewController: UIViewController {
     
     private let scene: AGSScene = {
         // initialize scene with labeled imagery
-        let scene = AGSScene(basemapType: .imageryWithLabels)
+        let scene = AGSScene(basemapStyle: .arcGISImageryLabels)
         
         // create an elevation source and add it to the scene's surface
         let elevationSourceURL = URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!

--- a/arcgis-ios-sdk-samples/Scenes/Add a point scene layer/AddPointSceneLayerViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Add a point scene layer/AddPointSceneLayerViewController.swift
@@ -28,7 +28,7 @@ class AddPointSceneLayerViewController: UIViewController {
     ///
     /// - Returns: A new `AGSScene` object.
     func makeScene() -> AGSScene {
-        let scene = AGSScene(basemapType: .imagery)
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
         
         // Create the elevation source.
         let elevationServiceURL = URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!

--- a/arcgis-ios-sdk-samples/Scenes/Add an integrated mesh layer/AddIntegratedMeshLayerViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Add an integrated mesh layer/AddIntegratedMeshLayerViewController.swift
@@ -35,7 +35,7 @@ class AddIntegratedMeshLayerViewController: UIViewController {
     ///
     /// - Returns: A new `AGSScene` object.
     func makeScene() -> AGSScene {
-        let scene = AGSScene(basemapType: .imagery)
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
         
         // Create the elevation source.
         let elevationServiceURL = URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!

--- a/arcgis-ios-sdk-samples/Scenes/Change atmosphere effect/ChangeAtmosphereEffectViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Change atmosphere effect/ChangeAtmosphereEffectViewController.swift
@@ -27,7 +27,7 @@ class ChangeAtmosphereEffectViewController: UIViewController {
         super.viewDidLoad()
         
         /// The scene for the scene view.
-        let scene = AGSScene(basemapType: .imagery)
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
         // add the scene to the scene view
         sceneView.scene = scene
         

--- a/arcgis-ios-sdk-samples/Scenes/Create terrain surface from a local raster/CreateTerrainSurfaceFromLocalRasterViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Create terrain surface from a local raster/CreateTerrainSurfaceFromLocalRasterViewController.swift
@@ -28,7 +28,7 @@ class CreateTerrainSurfaceFromLocalRasterViewController: UIViewController {
     }
     
     func makeScene() -> AGSScene {
-        let scene = AGSScene(basemapType: .imageryWithLabels)
+        let scene = AGSScene(basemapStyle: .arcGISImageryLabels)
         
         let surface = AGSSurface()
         // Create raster elevation source.

--- a/arcgis-ios-sdk-samples/Scenes/Create terrain surface from a local raster/CreateTerrainSurfaceFromLocalRasterViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Create terrain surface from a local raster/CreateTerrainSurfaceFromLocalRasterViewController.swift
@@ -28,7 +28,7 @@ class CreateTerrainSurfaceFromLocalRasterViewController: UIViewController {
     }
     
     func makeScene() -> AGSScene {
-        let scene = AGSScene(basemapStyle: .arcGISImageryLabels)
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
         
         let surface = AGSSurface()
         // Create raster elevation source.

--- a/arcgis-ios-sdk-samples/Scenes/Create terrain surface from a local tile package/CreateTerrainSurfaceFromLocalTilePackageViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Create terrain surface from a local tile package/CreateTerrainSurfaceFromLocalTilePackageViewController.swift
@@ -28,7 +28,7 @@ class CreateTerrainSurfaceFromLocalTilePackageViewController: UIViewController {
     }
     
     func makeScene() -> AGSScene {
-        let scene = AGSScene(basemapType: .imageryWithLabels)
+        let scene = AGSScene(basemapStyle: .arcGISImageryLabels)
         
         // Create an elevation source using the path to the tile package.
         let surface = AGSSurface()

--- a/arcgis-ios-sdk-samples/Scenes/Create terrain surface from a local tile package/CreateTerrainSurfaceFromLocalTilePackageViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Create terrain surface from a local tile package/CreateTerrainSurfaceFromLocalTilePackageViewController.swift
@@ -28,7 +28,7 @@ class CreateTerrainSurfaceFromLocalTilePackageViewController: UIViewController {
     }
     
     func makeScene() -> AGSScene {
-        let scene = AGSScene(basemapStyle: .arcGISImageryLabels)
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
         
         // Create an elevation source using the path to the tile package.
         let surface = AGSSurface()

--- a/arcgis-ios-sdk-samples/Scenes/Feature layer extrusion/FeatureLayerExtrusionViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Feature layer extrusion/FeatureLayerExtrusionViewController.swift
@@ -24,7 +24,7 @@ class FeatureLayerExtrusionViewController: UIViewController {
     let renderer: AGSRenderer
     
     required init?(coder: NSCoder) {
-        scene = AGSScene(basemapType: .topographic)
+        scene = AGSScene(basemapStyle: .arcGISTopographic)
         
         /// The url of the States layer of the Census Map Service.
         let censusMapServiceStatesLayerURL = URL(string: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3")!

--- a/arcgis-ios-sdk-samples/Scenes/Get elevation at a point/GetElevationPointViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Get elevation at a point/GetElevationPointViewController.swift
@@ -46,7 +46,7 @@ class GetElevationPointViewController: UIViewController {
     /// - Returns: A new `AGSScene` object with a base surface configured with
     /// an elevation source.
     private func makeScene() -> AGSScene {
-        let scene = AGSScene(basemapStyle: .arcGISImageryLabels)
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
         
         let surface = AGSSurface()
         // Create an elevation source.

--- a/arcgis-ios-sdk-samples/Scenes/Get elevation at a point/GetElevationPointViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Get elevation at a point/GetElevationPointViewController.swift
@@ -46,7 +46,7 @@ class GetElevationPointViewController: UIViewController {
     /// - Returns: A new `AGSScene` object with a base surface configured with
     /// an elevation source.
     private func makeScene() -> AGSScene {
-        let scene = AGSScene(basemapType: .imageryWithLabels)
+        let scene = AGSScene(basemapStyle: .arcGISImageryLabels)
         
         let surface = AGSSurface()
         // Create an elevation source.

--- a/arcgis-ios-sdk-samples/Scenes/Sync map and scene views/SyncMapAndSceneViewsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Sync map and scene views/SyncMapAndSceneViewsViewController.swift
@@ -32,7 +32,7 @@ class SyncMapAndSceneViewsViewController: UIViewController {
         // add a map with labeled imagery to the map view
         mapView.map = AGSMap(basemapStyle: .arcGISImagery)
         // add a scene with labeled imagery to the scene view
-        sceneView.scene = AGSScene(basemapType: .imageryWithLabels)
+        sceneView.scene = AGSScene(basemapStyle: .arcGISImageryLabels)
         
         // add handlers to each view to receive viewpoint change events
         mapView.viewpointChangedHandler = { [weak self] in

--- a/arcgis-ios-sdk-samples/Scenes/Sync map and scene views/SyncMapAndSceneViewsViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Sync map and scene views/SyncMapAndSceneViewsViewController.swift
@@ -32,7 +32,7 @@ class SyncMapAndSceneViewsViewController: UIViewController {
         // add a map with labeled imagery to the map view
         mapView.map = AGSMap(basemapStyle: .arcGISImagery)
         // add a scene with labeled imagery to the scene view
-        sceneView.scene = AGSScene(basemapStyle: .arcGISImageryLabels)
+        sceneView.scene = AGSScene(basemapStyle: .arcGISImagery)
         
         // add handlers to each view to receive viewpoint change events
         mapView.viewpointChangedHandler = { [weak self] in

--- a/arcgis-ios-sdk-samples/Scenes/View point cloud data offline/ViewPointCloudDataOfflineViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/View point cloud data offline/ViewPointCloudDataOfflineViewController.swift
@@ -31,7 +31,7 @@ class ViewPointCloudDataOfflineViewController: UIViewController {
     ///
     /// - Returns: A new `AGSScene` object.
     func makeScene() -> AGSScene {
-        let scene = AGSScene(basemapType: .imagery)
+        let scene = AGSScene(basemapStyle: .arcGISImagery)
         
         // Create the elevation source.
         let elevationServiceURL = URL(string: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")!


### PR DESCRIPTION
## Description

This PR updates all `AGSScene` with the `AGSScene.init(basemapType:)` constructor to the latest `AGSScene.init(basemapStyle:)` due to

> BasemapType enum and associated constructor, as well as the factory Basemap methods have been deprecated at 100.14.

## Linked Issue(s)

- `common-samples/issues/3436`
- `common-samples/issues/3267`

## How To Test

Run a few changed samples and see they should still work.

## To Discuss

Sarat might need to run the basemap auto update script to use the latest basemapStyles that might contain subtle differences to the older basemaps.