### PR TITLE
[Update] App Store app link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-ArcGIS Runtime SDK for iOS Samples [![](https://user-images.githubusercontent.com/2257493/54144188-6fe0fc00-43e8-11e9-8cf5-229af80f604a.png)](https://itunes.apple.com/us/app/arcgis-runtime-sdk-for-ios/id1180714771)
+ArcGIS Runtime SDK for iOS Samples [![](https://user-images.githubusercontent.com/2257493/54144188-6fe0fc00-43e8-11e9-8cf5-229af80f604a.png)](https://apps.apple.com/us/app/arcgis-runtime-sdk-for-ios/id1180714771)
 ==========================
 
-This repository contains Swift sample code demonstrating the capabilities of [ArcGIS Runtime SDK for iOS](https://developers.arcgis.com/ios/) and how to use them in your own app. The project can be opened in Xcode and run on a simulator or a device. Or you can [download the app from the App Store](https://itunes.apple.com/us/app/arcgis-runtime-sdk-for-ios/id1180714771) on your iOS device.
+This repository contains Swift sample code demonstrating the capabilities of [ArcGIS Runtime SDK for iOS](https://developers.arcgis.com/ios/) and how to use them in your own app. The project can be opened in Xcode and run on a simulator or a device. Or you can [download the app from the App Store](https://apps.apple.com/us/app/arcgis-runtime-sdk-for-ios/id1180714771) on your iOS device.
 
 ![Samples app](SamplesApp.png)
 


### PR DESCRIPTION
## Description

This PR updates the app link on App Store. 

- When you click on https://itunes.apple.com/us/app/arcgis-runtime-sdk-for-ios/id1180714771 , it will auto redirect to https://apps.apple.com/us/app/arcgis-runtime-sdk-for-ios/id1180714771 , so I updates the former to the latter.