### PR TITLE
Fix: Animate 3D graphic

### DIFF
--- a/arcgis-ios-sdk-samples/Scenes/Animate 3D graphic/Animate3DGraphicViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Animate 3D graphic/Animate3DGraphicViewController.swift
@@ -291,9 +291,6 @@ class Animate3DGraphicViewController: UIViewController {
     @IBAction func playAction(sender: UIBarButtonItem) {
         if isAnimating {
             animationTimer?.invalidate()
-            let frame = frames[currentFrameIndex]
-            // update stats
-            planeStatsViewController?.frame = frame
         } else {
             startAnimation()
         }
@@ -322,7 +319,10 @@ class Animate3DGraphicViewController: UIViewController {
             }
         } else if let planeStatsViewController = segue.destination as? PlaneStatsViewController {
             self.planeStatsViewController = planeStatsViewController
-            
+            let frame = frames[currentFrameIndex]
+            // Update stats.
+            planeStatsViewController.frame = frame
+            print("Overwrite frame")
             // pop over settings
             planeStatsViewController.presentationController?.delegate = self
         } else if let navController = segue.destination as? UINavigationController,

--- a/arcgis-ios-sdk-samples/Scenes/Animate 3D graphic/Animate3DGraphicViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Animate 3D graphic/Animate3DGraphicViewController.swift
@@ -291,6 +291,9 @@ class Animate3DGraphicViewController: UIViewController {
     @IBAction func playAction(sender: UIBarButtonItem) {
         if isAnimating {
             animationTimer?.invalidate()
+            let frame = frames[currentFrameIndex]
+            // update stats
+            planeStatsViewController?.frame = frame
         } else {
             startAnimation()
         }

--- a/arcgis-ios-sdk-samples/Scenes/Animate 3D graphic/Animate3DGraphicViewController.swift
+++ b/arcgis-ios-sdk-samples/Scenes/Animate 3D graphic/Animate3DGraphicViewController.swift
@@ -322,7 +322,6 @@ class Animate3DGraphicViewController: UIViewController {
             let frame = frames[currentFrameIndex]
             // Update stats.
             planeStatsViewController.frame = frame
-            print("Overwrite frame")
             // pop over settings
             planeStatsViewController.presentationController?.delegate = self
         } else if let navController = segue.destination as? UINavigationController,


### PR DESCRIPTION
## Description

This PR fixes a bug in `Animate 3D graphic` in `Scenes` category.
Branch: [URL_TO_BRANCH](https://github.com/Esri/arcgis-runtime-samples-ios/tree/Viv/fixAnimate3DGraphic)

## Linked Issue(s)

- `common-samples/issues/3426`

## How To Test

Open the "stats" popup while the animation is playing and while it is paused. Ensure the correct stats are displayed while animation is playing and paused.
