### PR TITLE
Fix: Explore sceneS in flyover AR

### DIFF
--- a/arcgis-ios-sdk-samples/Augmented reality/Explore scenes in flyover AR/ExploreScenesInFlyoverAR.swift
+++ b/arcgis-ios-sdk-samples/Augmented reality/Explore scenes in flyover AR/ExploreScenesInFlyoverAR.swift
@@ -61,7 +61,7 @@ class ExploreScenesInFlyoverAR: UIViewController {
             if let error = error {
                 self.presentAlert(error: error)
             } else {
-                let location = AGSPoint(x: 2.8259, y: 41.9906, z: 200.0, spatialReference: .wgs84())
+                let location = AGSPoint(x: 2.8262, y: 41.9857, z: 200.0, spatialReference: .wgs84())
                 let camera = AGSCamera(location: location, heading: 190, pitch: 90, roll: 0)
                 self.arView.originCamera = camera
             }

--- a/arcgis-ios-sdk-samples/Augmented reality/Explore scenes in flyover AR/ExploreScenesInFlyoverAR.swift
+++ b/arcgis-ios-sdk-samples/Augmented reality/Explore scenes in flyover AR/ExploreScenesInFlyoverAR.swift
@@ -62,7 +62,7 @@ class ExploreScenesInFlyoverAR: UIViewController {
                 self.presentAlert(error: error)
             } else {
                 let location = AGSPoint(x: 2.8259, y: 41.9906, z: 200.0, spatialReference: .wgs84())
-                let camera = AGSCamera(location: location, heading: 190, pitch: 65, roll: 0)
+                let camera = AGSCamera(location: location, heading: 190, pitch: 90, roll: 0)
                 self.arView.originCamera = camera
             }
         }


### PR DESCRIPTION
## Description

This PR fixes a bug in `Explore sceneS in flyover AR` in `Augmented reality` category.
Branch: [URL_TO_BRANCH](https://github.com/Esri/arcgis-runtime-samples-ios/tree/Viv/fixFlyoverAR)

## Linked Issue(s)

- `common-samples/issues/3492`

## How To Test

Launch sample, ensure that camera is not tilted.
