### PR TITLE
Fix: Authenticate with OAuth bug

### DIFF
--- a/arcgis-ios-sdk-samples/Cloud and portal/Authenticate with OAuth/AuthenticateWithOAuthViewController.swift
+++ b/arcgis-ios-sdk-samples/Cloud and portal/Authenticate with OAuth/AuthenticateWithOAuthViewController.swift
@@ -58,7 +58,8 @@ class AuthenticateWithOAuthViewController: UIViewController {
         AGSAuthenticationManager.shared().oAuthConfigurations.add(oAuthConfiguration)
     }
     
-    deinit {
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
         AGSAuthenticationManager.shared().oAuthConfigurations.remove(oAuthConfiguration)
         AGSAuthenticationManager.shared().credentialCache.removeAllCredentials()
     }

--- a/arcgis-ios-sdk-samples/Cloud and portal/Authenticate with OAuth/AuthenticateWithOAuthViewController.swift
+++ b/arcgis-ios-sdk-samples/Cloud and portal/Authenticate with OAuth/AuthenticateWithOAuthViewController.swift
@@ -58,12 +58,6 @@ class AuthenticateWithOAuthViewController: UIViewController {
         AGSAuthenticationManager.shared().oAuthConfigurations.add(oAuthConfiguration)
     }
     
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        AGSAuthenticationManager.shared().oAuthConfigurations.remove(oAuthConfiguration)
-        AGSAuthenticationManager.shared().credentialCache.removeAllCredentials()
-    }
-    
     // MARK: UIViewController
     
     override func viewDidLoad() {
@@ -72,6 +66,13 @@ class AuthenticateWithOAuthViewController: UIViewController {
         (navigationItem.rightBarButtonItem as? SourceCodeBarButtonItem)?.filenames = [
             "AuthenticateWithOAuthViewController"
         ]
+    }
+    
+    // Clear the credential cache upon exiting the sample.
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        AGSAuthenticationManager.shared().oAuthConfigurations.remove(oAuthConfiguration)
+        AGSAuthenticationManager.shared().credentialCache.removeAllCredentials()
     }
 }
 

--- a/arcgis-ios-sdk-samples/Cloud and portal/Authenticate with OAuth/AuthenticateWithOAuthViewController.swift
+++ b/arcgis-ios-sdk-samples/Cloud and portal/Authenticate with OAuth/AuthenticateWithOAuthViewController.swift
@@ -68,7 +68,7 @@ class AuthenticateWithOAuthViewController: UIViewController {
         ]
     }
     
-    // Clear the credential cache upon exiting the sample.
+    // Clearing the credential cache so sample go through authentication every time.
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         AGSAuthenticationManager.shared().oAuthConfigurations.remove(oAuthConfiguration)

--- a/arcgis-ios-sdk-samples/Cloud and portal/Token authentication/TokenAuthenticationViewController.swift
+++ b/arcgis-ios-sdk-samples/Cloud and portal/Token authentication/TokenAuthenticationViewController.swift
@@ -34,6 +34,12 @@ class TokenAuthenticationViewController: UIViewController {
         return AGSMap(item: portalItem)
     }
     
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        
+        AGSAuthenticationManager.shared().credentialCache.removeAllCredentials()
+    }
+    
     // MARK: UIViewController
     
     override func viewDidLoad() {

--- a/arcgis-ios-sdk-samples/Cloud and portal/Token authentication/TokenAuthenticationViewController.swift
+++ b/arcgis-ios-sdk-samples/Cloud and portal/Token authentication/TokenAuthenticationViewController.swift
@@ -44,6 +44,7 @@ class TokenAuthenticationViewController: UIViewController {
         ]
     }
     
+    // Clear the credential cache upon exiting the sample.
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         AGSAuthenticationManager.shared().credentialCache.removeAllCredentials()

--- a/arcgis-ios-sdk-samples/Cloud and portal/Token authentication/TokenAuthenticationViewController.swift
+++ b/arcgis-ios-sdk-samples/Cloud and portal/Token authentication/TokenAuthenticationViewController.swift
@@ -34,12 +34,6 @@ class TokenAuthenticationViewController: UIViewController {
         return AGSMap(item: portalItem)
     }
     
-    required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-        
-        AGSAuthenticationManager.shared().credentialCache.removeAllCredentials()
-    }
-    
     // MARK: UIViewController
     
     override func viewDidLoad() {
@@ -48,5 +42,10 @@ class TokenAuthenticationViewController: UIViewController {
         (navigationItem.rightBarButtonItem as? SourceCodeBarButtonItem)?.filenames = [
             "TokenAuthenticationViewController"
         ]
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        AGSAuthenticationManager.shared().credentialCache.removeAllCredentials()
     }
 }

--- a/arcgis-ios-sdk-samples/Cloud and portal/Token authentication/TokenAuthenticationViewController.swift
+++ b/arcgis-ios-sdk-samples/Cloud and portal/Token authentication/TokenAuthenticationViewController.swift
@@ -44,7 +44,7 @@ class TokenAuthenticationViewController: UIViewController {
         ]
     }
     
-    // Clear the credential cache upon exiting the sample.
+    // Clearing the credential cache so sample go through authentication every time.
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         AGSAuthenticationManager.shared().credentialCache.removeAllCredentials()


### PR DESCRIPTION
## Description

This PR fixes `Token Authentication` in `Cloud and Portal` category.
Branch: [URL_TO_BRANCH](https://github.com/Esri/arcgis-runtime-samples-ios/tree/Viv/fixAuthenticateOAuth)

## Linked Issue(s)

- `common-samples/issues/3491`

## How to Test

First open the `Authenticate with OAuth` sample, log in, then open the `Token Authentication` sample. Ensure that you're prompted to log in upon `Token Authentication` launching.

## To Discuss

Although this fixes the problem, it may not be the best solution because it deviates from the token authentication workflow and best practices. Additionally, it's redundant since the credential cache is cleared twice.
