### PR TITLE
Fix: Info button bug

### DIFF
--- a/arcgis-ios-sdk-samples/Content Display Logic/Controllers/CategoryTableViewController.swift
+++ b/arcgis-ios-sdk-samples/Content Display Logic/Controllers/CategoryTableViewController.swift
@@ -232,7 +232,11 @@ class CategoryTableViewController: UITableViewController {
             // Get the two cells and update.
             expandedRowIndexPaths.update(with: indexPath)
         }
-        tableView.reloadRows(at: [indexPath], with: .automatic)
+        // Reload the corresponding row.
+        let identifier = dataSource.itemIdentifier(for: indexPath)!
+        var snapshot = dataSource.snapshot()
+        snapshot.reloadItems([identifier])
+        dataSource.apply(snapshot)
     }
 }
 


### PR DESCRIPTION
## Description

This PR resolves the issue Ting found [here](https://github.com/Esri/arcgis-runtime-samples-ios/pull/1175#discussion_r896158415).

## Linked Issue(s)

- `common-samples/issues/3603`

## How To Test

Tap on the accessory buttons next to the sample titles to confirm that the app doesn't crash.
