### PR TITLE
Fix: Identify KML features tolerance

### DIFF
--- a/arcgis-ios-sdk-samples/Layers/Identify KML features/IdentifyKMLFeaturesViewController.swift
+++ b/arcgis-ios-sdk-samples/Layers/Identify KML features/IdentifyKMLFeaturesViewController.swift
@@ -75,7 +75,7 @@ class IdentifyKMLFeaturesViewController: UIViewController {
 extension IdentifyKMLFeaturesViewController: AGSGeoViewTouchDelegate {
     func geoView(_ geoView: AGSGeoView, didTapAtScreenPoint screenPoint: CGPoint, mapPoint: AGSPoint) {
         geoView.callout.dismiss()
-        geoView.identifyLayer(forecastLayer, screenPoint: screenPoint, tolerance: 15, returnPopupsOnly: false) { [weak self] (result) in
+        geoView.identifyLayer(forecastLayer, screenPoint: screenPoint, tolerance: 2, returnPopupsOnly: false) { [weak self] (result) in
             if let placemark = result.geoElements.first as? AGSKMLPlacemark {
                 // Google Earth only displays the placemarks with description
                 // or extended data. To match its behavior, add a description


### PR DESCRIPTION
## Description

This PR implements `Identify KML features` in `Layers` category.
Branch: [URL_TO_BRANCH](https://github.com/Esri/arcgis-runtime-samples-ios/tree/Viv/fixIdentifyKML)

## Linked Issue(s)

- `common-samples/issues/946`

## How To Test

Tap on the features and ensure that the popup displays more accurately to the location of the tapped point.
