### PR TITLE
Fix: Generate offline map error handling

### DIFF
--- a/arcgis-ios-sdk-samples/Maps/Generate offline map/GenerateOfflineMapViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Generate offline map/GenerateOfflineMapViewController.swift
@@ -168,10 +168,10 @@ class GenerateOfflineMapViewController: UIViewController {
             UIApplication.shared.hideProgressHUD()
             guard let self = self else { return }
             if let parameters = parameters {
-                // will need the parameters for creating the job later
+                // The parameters for creating a job of offline maps generation.
                 self.parameters = parameters
                 
-                // take map offline
+                // Take map offline.
                 self.takeMapOffline()
             } else if let error = error {
                 self.presentAlert(error: error)


### PR DESCRIPTION
## Description

This PR updates `Generate offline map` in `Maps` category.
Branch: [URL_TO_BRANCH](https://github.com/Esri/arcgis-runtime-samples-ios/tree/Viv/fixGenerateOfflineMap)

## Linked Issue(s)

- `common-samples/issues/1312`

## How To Test

Read through the error handling and ensure that all checks could possibly hit. Also ensure that offline map is generated successfully.

