### PR TITLE
Update: Add "Arcade" to checker

### DIFF
--- a/Scripts/CI/README_Metadata_StyleCheck/README_style_checker.py
+++ b/Scripts/CI/README_Metadata_StyleCheck/README_style_checker.py
@@ -35,6 +35,7 @@ exception_proper_nouns = {
     'OpenStreetMap',
     'Play a KML Tour',
     'SwiftUI'
+    'Arcade'
 }
 
 # A set of category folder names in current sample viewer.


### PR DESCRIPTION
## Description

This PR adds "Arcade" as a proper noun to the Github style checker.
Branch: [URL_TO_BRANCH](https://github.com/Esri/arcgis-runtime-samples-ios/tree/Viv/addArcadeChecker)

