### PR TITLE
[Update] Replace with a publicly accessible indoor map

### DIFF
--- a/arcgis-ios-sdk-samples/Maps/Show device location using indoor positioning/README.md
+++ b/arcgis-ios-sdk-samples/Maps/Show device location using indoor positioning/README.md
@@ -36,7 +36,7 @@ When there is no IPS beacons nearby, or other errors occur while initializing th
 
 ## About the data
 
-This sample uses an [IPS-enabled web map](https://viennardc.maps.arcgis.com/home/item.html?id=89f88764c29b48218366855d7717d266) that displays Building L on the Esri Redlands campus. Please note: you would only be able to use the indoor positioning functionalities when you are inside this building. Swap the web map to test with your own IPS setup.
+This sample uses an [IPS-enabled web map](https://www.arcgis.com/home/item.html?id=8fa941613b4b4b2b8a34ad4cdc3e4bba) that displays Building L on the Esri Redlands campus. Please note: you would only be able to use the indoor positioning functionalities when you are inside this building. Swap the web map to test with your own IPS setup.
 
 ## Additional information
 

--- a/arcgis-ios-sdk-samples/Maps/Show device location using indoor positioning/ShowDeviceLocationUsingIndoorPositioningViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Show device location using indoor positioning/ShowDeviceLocationUsingIndoorPositioningViewController.swift
@@ -249,7 +249,7 @@ extension ShowDeviceLocationUsingIndoorPositioningViewController: AGSLocationCha
                 let satelliteCount = location.additionalSourceProperties[.satelliteCount] as? Int ?? 0
                 return String(format: "%d satellite(s)", satelliteCount)
             default:
-                let transmitterCount = location.additionalSourceProperties[AGSLocationSourcePropertyKey("transmitterCount")] as? Int ?? 0
+                let transmitterCount = location.additionalSourceProperties[.transmitterCount] as? Int ?? 0
                 return String(format: "%d beacon(s)", transmitterCount)
             }
         }()

--- a/arcgis-ios-sdk-samples/Maps/Show device location using indoor positioning/ShowDeviceLocationUsingIndoorPositioningViewController.swift
+++ b/arcgis-ios-sdk-samples/Maps/Show device location using indoor positioning/ShowDeviceLocationUsingIndoorPositioningViewController.swift
@@ -58,17 +58,8 @@ class ShowDeviceLocationUsingIndoorPositioningViewController: UIViewController {
     
     /// Load an IPS-enabled web map from a portal.
     func makeMap() -> AGSMap {
-        // Temporarily unset the API key for this sample.
-        AGSArcGISRuntimeEnvironment.apiKey = ""
-        
-        // The portal that hosts the IPS-enabled map.
-        let portal = AGSPortal(url: URL(string: "https://viennardc.maps.arcgis.com")!, loginRequired: true)
-        // WARNING: Never hardcode login information in a production application.
-        // This is done solely for the sake of the sample.
-        let credential = AGSCredential(user: "tester_viennardc", password: "password.testing12345")
-        portal.credential = credential
         // A floor-aware, IPS-enabled web map for floors of Esri Building L in Redlands.
-        let map = AGSMap(item: AGSPortalItem(portal: portal, itemID: "89f88764c29b48218366855d7717d266"))
+        let map = AGSMap(item: AGSPortalItem(portal: .arcGISOnline(withLoginRequired: false), itemID: "8fa941613b4b4b2b8a34ad4cdc3e4bba"))
         map.load { [weak self] error in
             if let error = error {
                 self?.presentAlert(error: error)


### PR DESCRIPTION
## Description

This PR replaces the indoor map with a publicly accessible alternative.

## Linked Issue(s)

- `common-samples/pull/3676`

## How To Test

Ting will go into Building L to test. Other than that, open the sample and see if the map can load.

Please note:
- transmitter count shows 0
- positioning source shows AppleIPS instead of Bluetooth

I reported these issues in #indoor-positioning-questions channel and am waiting for response.