### PR TITLE
[Fix] Address Xcode 14 build warnings

### DIFF
--- a/arcgis-ios-sdk-samples.xcodeproj/project.pbxproj
+++ b/arcgis-ios-sdk-samples.xcodeproj/project.pbxproj
@@ -5293,6 +5293,7 @@
 		};
 		3ED029A21B8E5D4D00ACA70D /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -5306,6 +5307,7 @@
 		};
 		4CB506D1224C2C20006A3471 /* Download Portal Item Data */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -5326,6 +5328,7 @@
 		};
 		4CBDB3192190E88F006E5D39 /* Lint Code */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);


### PR DESCRIPTION
## Description

This PR fixes more build warnings provided by Xcode 14 beta 4. The nature of the warnings are similar to Swift SV pull 41.

```
Run script build phase 'Run Script' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase.
```

See similar issue here: https://github.com/realm/SwiftLint/issues/4015