### PR TITLE
[Fix] Change data reference in `Feature layer selection`

### DIFF
--- a/arcgis-ios-sdk-samples/Features/Feature layer selection/FeatureLayerSelectionViewController.swift
+++ b/arcgis-ios-sdk-samples/Features/Feature layer selection/FeatureLayerSelectionViewController.swift
@@ -37,11 +37,13 @@ class FeatureLayerSelectionViewController: UIViewController {
     
     /// The feature layer created from a feature service.
     let featureLayer: AGSFeatureLayer = {
-        // Create feature table using a url.
-        let featureServiceURL = URL(string: "https://services1.arcgis.com/4yjifSiIG17X0gW4/arcgis/rest/services/GDP_per_capita_1960_2016/FeatureServer/0")!
-        let featureTable = AGSServiceFeatureTable(url: featureServiceURL)
-        // Create feature layer using this feature table.
-        let featureLayer = AGSFeatureLayer(featureTable: featureTable)
+        // A feature layer visualizing GDP per capita.
+        let featureLayer = AGSFeatureLayer(
+            item: AGSPortalItem(
+                portal: .arcGISOnline(withLoginRequired: false),
+                itemID: "10d76a5b015647279b165f3a64c2524f"
+            )
+        )
         return featureLayer
     }()
     

--- a/arcgis-ios-sdk-samples/Features/Feature layer selection/README.md
+++ b/arcgis-ios-sdk-samples/Features/Feature layer selection/README.md
@@ -28,7 +28,7 @@ Tap on a feature in the map. All features within a given tolerance (in pixels) o
 
 ## About the data
 
-This sample uses the [Gross Domestic Product, 1960-2016](https://www.arcgis.com/home/item.html?id=0c4b6b70a56b40b08c5b0420c570a6ac) feature service. Only the 2016 GDP values are shown.
+This sample uses the [Gross Domestic Product Per Capita, 1960-2016](https://www.arcgis.com/home/item.html?id=10d76a5b015647279b165f3a64c2524f) feature service. Only the 2016 GDP values are shown.
 
 ## Tags
 


### PR DESCRIPTION
## Description

This PR changes the data reference in `Feature layer selection` in `Features` category.

- It updates the README to use the GDP per capita data, rather than the GDP total data
- It also uses the portal item instead of the raw feature service to create the feature layer

## Linked Issue(s)

- `common-samples/issues/3598`

Related links

- https://www.arcgis.com/home/item.html?id=10d76a5b015647279b165f3a64c2524f
- https://www.arcgis.com/home/item.html?id=0c4b6b70a56b40b08c5b0420c570a6ac
- https://services1.arcgis.com/4yjifSiIG17X0gW4/arcgis/rest/services/GDP_per_capita_1960_2016/FeatureServer/0

## How To Test

No visual changes. Verify the sample is the same as before.
