### PR TITLE
[Fix] San Diego network data on-demand resource access

### DIFF
--- a/arcgis-ios-sdk-samples/Route and directions/Navigate route with rerouting/NavigateRouteWithReroutingViewController.swift
+++ b/arcgis-ios-sdk-samples/Route and directions/Navigate route with rerouting/NavigateRouteWithReroutingViewController.swift
@@ -38,7 +38,7 @@ class NavigateRouteWithReroutingViewController: UIViewController {
     // MARK: Instance properties
     
     /// The route task to solve the route between stops, using the online routing service.
-    let routeTask = AGSRouteTask(databaseName: "sandiego", networkName: "Streets_ND")
+    let routeTask = AGSRouteTask(fileURLToDatabase: Bundle.main.url(forResource: "sandiego", withExtension: "geodatabase", subdirectory: "san-diego")!, networkName: "Streets_ND")
     /// The route result solved by the route task.
     var routeResult: AGSRouteResult!
     /// The route tracker for navigation. Use delegate methods to update tracking status.


### PR DESCRIPTION
## Description

This PR makes a further fix to #1191 . Since the rerouting sample requires the network data, it's unknown why it cannot be accessed by the other route task initializer. It is probably because the ODR isn't in that initializer's search paths.
 
## Linked Issue(s)

- `common-samples/issues/3734`

## How To Test

Upload another TestFlight build to test. Current build 20220804 still gives error.