### PR TITLE
[Fix] Remove wrong API name

### DIFF
--- a/arcgis-ios-sdk-samples/Features/Filter by definition expression or display filter/README.md
+++ b/arcgis-ios-sdk-samples/Features/Filter by definition expression or display filter/README.md
@@ -22,12 +22,11 @@ The feature count value shows the current number of features in the current map 
 
 1. Create an `AGSServiceFeatureTable` from a URL.
 2. Create an `AGSFeatureLayer` from the service feature table.
-3. Filter features on your feature layer using an `AGSDefinitionExpression` to view a subset of features and modify the attribute table.
+3. Filter features on your feature layer using an definition expression to view a subset of features and modify the attribute table.
 4. Filter features on your feature layer using an `AGSDisplayFilterDefinition` to view a subset of features without modifying the attribute table.
 
 ## Relevant API
 
-* AGSDefinitionExpression
 * AGSFeatureLayer
 * AGSServiceFeatureTable
 

--- a/arcgis-ios-sdk-samples/Features/Filter by definition expression or display filter/README.metadata.json
+++ b/arcgis-ios-sdk-samples/Features/Filter by definition expression or display filter/README.metadata.json
@@ -14,7 +14,6 @@
         "query",
         "restrict data",
         "where clause",
-        "AGSDefinitionExpression",
         "AGSFeatureLayer",
         "AGSServiceFeatureTable"
     ],
@@ -22,7 +21,6 @@
         "/ios/latest/swift/sample-code/feature-layer-definition-expression.htm"
     ],
     "relevant_apis": [
-        "AGSDefinitionExpression",
         "AGSFeatureLayer",
         "AGSServiceFeatureTable"
     ],


### PR DESCRIPTION
## Description

This PR removes "AGSDefinitionExpression" from metadata json as it is not a valid API name. Thanks @TADraeseke for spotting this.
